### PR TITLE
Add import conditions to prevent node dependencies in client bundle

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/package.json
+++ b/rivetkit-typescript/packages/rivetkit/package.json
@@ -24,13 +24,35 @@
 	"type": "module",
 	"exports": {
 		".": {
-			"import": {
-				"types": "./dist/tsup/mod.d.ts",
-				"default": "./dist/tsup/mod.js"
+			"node": {
+				"import": {
+					"types": "./dist/tsup/mod.d.ts",
+					"default": "./dist/tsup/mod.js"
+				},
+				"require": {
+					"types": "./dist/tsup/mod.d.cts",
+					"default": "./dist/tsup/mod.cjs"
+				}
 			},
-			"require": {
-				"types": "./dist/tsup/mod.d.cts",
-				"default": "./dist/tsup/mod.cjs"
+			"browser": {
+				"import": {
+					"types": "./dist/tsup/client/mod.d.ts",
+					"default": "./dist/tsup/client/mod.js"
+				},
+				"require": {
+					"types": "./dist/tsup/client/mod.d.cts",
+					"default": "./dist/tsup/client/mod.cjs"
+				}
+			},
+			"default": {
+				"import": {
+					"types": "./dist/tsup/mod.d.ts",
+					"default": "./dist/tsup/mod.js"
+				},
+				"require": {
+					"types": "./dist/tsup/mod.d.cts",
+					"default": "./dist/tsup/mod.cjs"
+				}
 			}
 		},
 		"./client": {
@@ -172,7 +194,6 @@
 		"@rivetkit/engine-runner": "workspace:*",
 		"@rivetkit/fast-json-patch": "^3.1.2",
 		"cbor-x": "^1.6.0",
-		"get-port": "^7.1.0",
 		"hono": "^4.7.0",
 		"invariant": "^2.2.4",
 		"nanoevents": "^9.1.0",
@@ -182,6 +203,9 @@
 		"uuid": "^12.0.0",
 		"zod": "^4.1.0",
 		"vbare": "^0.0.4"
+	},
+	"optionalDependencies": {
+		"get-port": "^7.1.0"
 	},
 	"devDependencies": {
 		"@bare-ts/tools": "^0.13.0",

--- a/rivetkit-typescript/packages/rivetkit/src/registry/serve.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/serve.ts
@@ -12,16 +12,24 @@ const DEFAULT_PORT = 6420;
  */
 export async function findFreePort(startPort: number = DEFAULT_PORT): Promise<number> {
 	const getPortModule = "get-port";
-	const { default: getPort } = await import(/* webpackIgnore: true */ getPortModule);
+	try {
+		const { default: getPort } = await import(/* webpackIgnore: true */ getPortModule);
 
-	// Create an iterable of ports starting from startPort
-	function* portRange(start: number, count: number = 100): Iterable<number> {
-		for (let i = 0; i < count; i++) {
-			yield start + i;
+		// Create an iterable of ports starting from startPort
+		function* portRange(start: number, count: number = 100): Iterable<number> {
+			for (let i = 0; i < count; i++) {
+				yield start + i;
+			}
 		}
-	}
 
-	return getPort({ port: portRange(startPort) });
+		return getPort({ port: portRange(startPort) });
+	} catch (err) {
+		logger().error({
+			msg: "failed to import get-port. please run 'npm install get-port'",
+			error: stringifyError(err),
+		});
+		throw new Error("get-port is required for finding free ports. Please install it with 'npm install get-port'");
+	}
 }
 
 export async function crossPlatformServe(


### PR DESCRIPTION
- Add import conditions to package.json exports to prevent node-only dependencies from being bundled in browser environments
- Move get-port to optionalDependencies since it's only needed for Node.js server environments
- Add error handling in serve.ts for missing get-port dependency
- Browser environments will automatically get the client-only build when importing from 'rivetkit'
- Node.js environments get the full server build with Registry and server utilities