### PR TITLE
fix(website): align Typesense env var to PUBLIC_TYPESENSE_API_KEY

### DIFF
--- a/website/src/components/v2/TypesenseSearch.tsx
+++ b/website/src/components/v2/TypesenseSearch.tsx
@@ -12,7 +12,7 @@ const searchClient = new Typesense.Client({
 			protocol: import.meta.env.PUBLIC_TYPESENSE_PROTOCOL || "https",
 		},
 	],
-	apiKey: import.meta.env.PUBLIC_TYPESENSE_SEARCH_API_KEY || "xyz",
+	apiKey: import.meta.env.PUBLIC_TYPESENSE_API_KEY || "xyz",
 	connectionTimeoutSeconds: 2,
 });
 
@@ -38,7 +38,7 @@ export function TypesenseSearch() {
 
 	const hasRequiredKeys = !!(
 		import.meta.env.PUBLIC_TYPESENSE_HOST &&
-		import.meta.env.PUBLIC_TYPESENSE_SEARCH_API_KEY
+		import.meta.env.PUBLIC_TYPESENSE_API_KEY
 	);
 
 	if (!hasRequiredKeys) {


### PR DESCRIPTION
### Motivation
- Align the Typesense search component to use Astro's `PUBLIC_TYPESENSE_API_KEY` environment variable so the site search can initialize after the Astro migration.

### Description
- Update `website/src/components/v2/TypesenseSearch.tsx` to use `import.meta.env.PUBLIC_TYPESENSE_API_KEY` for the `apiKey` and in the required-key check.

### Testing
- The pre-commit hook ran `cargo-fmt` via `lefthook` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ad7a06fd883218cf3e093130d5594)