### PR TITLE
feat(rivetkit): add runner override option to getOrCreate and create

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/client/actor-query.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/client/actor-query.ts
@@ -43,6 +43,7 @@ export async function queryActor(
 			key: query.getOrCreateForKey.key,
 			input: query.getOrCreateForKey.input,
 			region: query.getOrCreateForKey.region,
+			runner: query.getOrCreateForKey.runner,
 		});
 		actorOutput = {
 			actorId: getOrCreateOutput.actorId,
@@ -54,6 +55,7 @@ export async function queryActor(
 			key: query.create.key,
 			input: query.create.input,
 			region: query.create.region,
+			runner: query.create.runner,
 		});
 		actorOutput = {
 			actorId: createOutput.actorId,

--- a/rivetkit-typescript/packages/rivetkit/src/client/client.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/client/client.ts
@@ -112,6 +112,8 @@ export interface GetOrCreateOptions extends QueryOptions {
 	createInRegion?: string;
 	/** Input data to pass to the actor. */
 	createWithInput?: unknown;
+	/** Runner name to create the actor on. Overrides the client's default runner. */
+	createOnRunner?: string;
 }
 
 /**
@@ -124,6 +126,8 @@ export interface CreateOptions extends QueryOptions {
 	region?: string;
 	/** Input data to pass to the actor. */
 	input?: unknown;
+	/** Runner name to create the actor on. Overrides the client's default runner. */
+	runner?: string;
 }
 
 /**
@@ -270,6 +274,7 @@ export class ClientRaw {
 				key: keyArray,
 				input: opts?.createWithInput,
 				region: opts?.createInRegion,
+				runner: opts?.createOnRunner,
 			},
 		};
 

--- a/rivetkit-typescript/packages/rivetkit/src/manager/driver.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/manager/driver.ts
@@ -76,6 +76,7 @@ export interface GetOrCreateWithKeyInput<E extends Env = any> {
 	key: ActorKey;
 	input?: unknown;
 	region?: string;
+	runner?: string;
 }
 
 export interface CreateInput<E extends Env = any> {
@@ -84,6 +85,7 @@ export interface CreateInput<E extends Env = any> {
 	key: ActorKey;
 	input?: unknown;
 	region?: string;
+	runner?: string;
 }
 
 export interface ListActorsInput<E extends Env = any> {

--- a/rivetkit-typescript/packages/rivetkit/src/manager/protocol/query.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/manager/protocol/query.ts
@@ -21,6 +21,7 @@ export const CreateRequestSchema = z.object({
 	key: ActorKeySchema,
 	input: z.unknown().optional(),
 	region: z.string().optional(),
+	runner: z.string().optional(),
 });
 
 export const GetForKeyRequestSchema = z.object({
@@ -33,6 +34,7 @@ export const GetOrCreateRequestSchema = z.object({
 	key: ActorKeySchema,
 	input: z.unknown().optional(),
 	region: z.string().optional(),
+	runner: z.string().optional(),
 });
 
 export const ActorQuerySchema = z.union([


### PR DESCRIPTION
## Summary
Allows specifying a runner per-call instead of only at client config level.

## Usage
```ts
// getOrCreate with runner override
client.actor.getOrCreate(['key'], {
  createOnRunner: 'my-specific-runner'
});

// create with runner override
await client.actor.create(['key'], {
  runner: 'my-specific-runner'
});
```

## Changes
- `client.ts`: Add `createOnRunner` to `GetOrCreateOptions`, `runner` to `CreateOptions`
- `protocol/query.ts`: Add `runner` field to `CreateRequestSchema` and `GetOrCreateRequestSchema`
- `driver.ts`: Add `runner` to `GetOrCreateWithKeyInput` and `CreateInput` interfaces
- `actor-query.ts`: Pass runner through to manager driver calls

## Note
This adds the client-side support. The manager/engine implementation to actually route to the specified runner may need additional work depending on how runner selection is handled server-side.