### PR TITLE
fix(ci): copy skills to skills/ directory instead of repo root

### DIFF
--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -61,13 +61,15 @@ jobs:
 
       - name: Copy generated skills
         run: |
+          # Ensure skills directory exists
+          mkdir -p "skills-repo/skills"
+          
           # Only delete and replace the specific skill directories being updated
-          rm -rf "skills-repo/rivetkit-typescript"
           for skill_dir in website/dist/metadata/skills/*/; do
             skill_name=$(basename "$skill_dir")
             echo "Updating skill: $skill_name"
-            rm -rf "skills-repo/$skill_name"
-            cp -r "$skill_dir" "skills-repo/$skill_name"
+            rm -rf "skills-repo/skills/$skill_name"
+            cp -r "$skill_dir" "skills-repo/skills/$skill_name"
           done
 
       - name: Commit and push


### PR DESCRIPTION
The skills workflow was copying generated skills to the root of rivet-dev/skills repo instead of the skills/ subdirectory.

## Changes
- Copy skills to `skills-repo/skills/$skill_name` instead of `skills-repo/$skill_name`
- Ensure `skills/` directory exists before copying
- Remove the hardcoded `rivetkit-typescript` cleanup (not needed)