### PR TITLE
fix(website): use PostHog React hook instead of direct import

### DIFF
--- a/website/src/components/marketing/sales/form.tsx
+++ b/website/src/components/marketing/sales/form.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import posthog from "posthog-js";
+import { usePostHog } from "posthog-js/react";
 import { useState } from "react";
 
 export function SalesForm() {
+	const posthog = usePostHog();
 	const [isSubmitted, setIsSubmitted] = useState(false);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -17,7 +18,7 @@ export function SalesForm() {
 		const data = Object.fromEntries(formData.entries().toArray());
 
 		try {
-			posthog.capture("survey sent", {
+			posthog?.capture("survey sent", {
 				$survey_id: "0193928a-4799-0000-8fc4-455382e21359",
 				...data,
 			});

--- a/website/src/components/marketing/sales/form.tsx
+++ b/website/src/components/marketing/sales/form.tsx
@@ -1,14 +1,12 @@
 "use client";
 
-import { usePostHog } from "posthog-js/react";
 import { useState } from "react";
 
 export function SalesForm() {
-	const posthog = usePostHog();
 	const [isSubmitted, setIsSubmitted] = useState(false);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
-	const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 		if (isSubmitting) return;
 
@@ -18,7 +16,8 @@ export function SalesForm() {
 		const data = Object.fromEntries(formData.entries().toArray());
 
 		try {
-			posthog?.capture("survey sent", {
+			const { default: posthog } = await import("posthog-js");
+			posthog.capture("survey sent", {
 				$survey_id: "0193928a-4799-0000-8fc4-455382e21359",
 				...data,
 			});

--- a/website/src/components/marketing/sales/form.tsx
+++ b/website/src/components/marketing/sales/form.tsx
@@ -17,6 +17,11 @@ export function SalesForm() {
 
 		try {
 			const { default: posthog } = await import("posthog-js");
+			if (!posthog.__loaded) {
+				posthog.init("phc_6kfTNEAVw7rn1LA51cO3D69FefbKupSWFaM7OUgEpEo", {
+					api_host: "https://ph.rivet.dev",
+				});
+			}
 			posthog.capture("survey sent", {
 				$survey_id: "0193928a-4799-0000-8fc4-455382e21359",
 				...data,

--- a/website/src/components/marketing/talk-to-an-engineer/form.tsx
+++ b/website/src/components/marketing/talk-to-an-engineer/form.tsx
@@ -1,27 +1,23 @@
 "use client";
 
-import { usePostHog } from "posthog-js/react";
 import { useState } from "react";
 
 export function TalkToAnEngineerForm() {
-	const posthog = usePostHog();
 	const [isSubmitted, setIsSubmitted] = useState(false);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
-	const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 		if (isSubmitting) return;
 
 		setIsSubmitting(true);
 
 		const formData = new FormData(event.currentTarget);
-
 		const data = Object.fromEntries(formData.entries().toArray());
 
-		console.log(data);
-
 		try {
-			posthog?.capture("survey sent", {
+			const { default: posthog } = await import("posthog-js");
+			posthog.capture("survey sent", {
 				$survey_id: "01980f18-06a9-0000-e1e1-a5886e9012d0",
 				...data,
 			});

--- a/website/src/components/marketing/talk-to-an-engineer/form.tsx
+++ b/website/src/components/marketing/talk-to-an-engineer/form.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import posthog from "posthog-js";
+import { usePostHog } from "posthog-js/react";
 import { useState } from "react";
 
 export function TalkToAnEngineerForm() {
+	const posthog = usePostHog();
 	const [isSubmitted, setIsSubmitted] = useState(false);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -20,7 +21,7 @@ export function TalkToAnEngineerForm() {
 		console.log(data);
 
 		try {
-			posthog.capture("survey sent", {
+			posthog?.capture("survey sent", {
 				$survey_id: "01980f18-06a9-0000-e1e1-a5886e9012d0",
 				...data,
 			});

--- a/website/src/components/marketing/talk-to-an-engineer/form.tsx
+++ b/website/src/components/marketing/talk-to-an-engineer/form.tsx
@@ -17,6 +17,11 @@ export function TalkToAnEngineerForm() {
 
 		try {
 			const { default: posthog } = await import("posthog-js");
+			if (!posthog.__loaded) {
+				posthog.init("phc_6kfTNEAVw7rn1LA51cO3D69FefbKupSWFaM7OUgEpEo", {
+					api_host: "https://ph.rivet.dev",
+				});
+			}
 			posthog.capture("survey sent", {
 				$survey_id: "01980f18-06a9-0000-e1e1-a5886e9012d0",
 				...data,


### PR DESCRIPTION
# Description

Switches marketing form components (`SalesForm` and `TalkToAnEngineerForm`) from importing the `posthog-js` singleton directly to using the `usePostHog()` React hook from `posthog-js/react`. This ensures PostHog is properly initialized within the React context and avoids potential issues with SSR or missing provider context. Optional chaining is added to safely handle cases where PostHog may not yet be available.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual review of the changes to ensure correct React hook usage and optional chaining.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings