### PR TITLE
fix: prevent white background flash on docs redirect pages

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -10,6 +10,7 @@ import { rehypePlugins } from './src/mdx/rehype';
 import { generateRoutes } from './src/integrations/generate-routes';
 import { typecheckCodeBlocks } from './src/integrations/typecheck-code-blocks';
 import { skillVersion } from './src/integrations/skill-version';
+import { styleRedirects } from './src/integrations/style-redirects';
 
 
 export default defineConfig({
@@ -79,6 +80,7 @@ export default defineConfig({
       		org: "rivet-gaming",
 			authToken: process.env.SENTRY_AUTH_TOKEN,
 		}),
+		styleRedirects(),
 	],
 	vite: {
 		ssr: {

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -20,7 +20,6 @@ export default defineConfig({
 	// SEO Redirects - Astro generates HTML redirect files for static builds
 	// These work in dev server and all deployment platforms (Vercel, Netlify, Cloudflare, etc.)
 	redirects: {
-		'/docs': '/docs/actors/',
 		// Documentation restructure
 		'/docs/setup': '/docs/actors/quickstart/',
 		'/docs/actors/queue': '/docs/actors/queues/',

--- a/website/src/components/Header.jsx
+++ b/website/src/components/Header.jsx
@@ -228,7 +228,7 @@ export const Header = forwardRef(function Header(
 									</Popover.Panel>
 								</Transition>
 							</Popover>
-							<TopLevelNavItem href="/docs">Documentation</TopLevelNavItem>
+							<TopLevelNavItem href="/docs/actors">Documentation</TopLevelNavItem>
 							<TopLevelNavItem href="/changelog">
 								Changelog
 							</TopLevelNavItem>

--- a/website/src/components/HeaderPopupProductMenu.tsx
+++ b/website/src/components/HeaderPopupProductMenu.tsx
@@ -9,7 +9,7 @@ import type { ComponentProps, ReactNode } from "react";
 export const HeaderPopupProductMenu = () => {
 	return (
 		<div className="grid h-full grid-cols-3 grid-rows-3 gap-4 overflow-hidden pb-2">
-			<a href="/docs" className="col-span-2 row-span-3 ">
+			<a href="/docs/actors" className="col-span-2 row-span-3 ">
 				<Item
 					onMouseEnter={(e) =>
 						e.currentTarget.querySelector("video")?.play()

--- a/website/src/components/Navigation.jsx
+++ b/website/src/components/Navigation.jsx
@@ -104,7 +104,7 @@ export function Navigation({ navigation, ...props }) {
 		<nav {...props}>
 			<ul role="list">
 				{/* Header */}
-				<TopLevelNavItem href="/docs" icon={faBooks}>
+				<TopLevelNavItem href="/docs/actors" icon={faBooks}>
 					Documentation
 				</TopLevelNavItem>
 				<TopLevelNavItem href="/changelog" icon={faNewspaper}>

--- a/website/src/components/marketing/comparison/RivetVsCloudflareWorkersPage.tsx
+++ b/website/src/components/marketing/comparison/RivetVsCloudflareWorkersPage.tsx
@@ -1005,7 +1005,7 @@ const CTASection = () => {
 					className="flex flex-col items-center justify-center gap-3 sm:flex-row"
 				>
 					<a
-						href="/docs"
+						href="/docs/actors"
 						className="selection-dark inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200"
 					>
 						Start Building

--- a/website/src/components/marketing/sales/form.tsx
+++ b/website/src/components/marketing/sales/form.tsx
@@ -53,7 +53,7 @@ export function SalesForm() {
 				<p className="text-zinc-400">
 					We will get back to you within the next few days. In the meantime, feel
 					free to explore our{" "}
-					<a href="/docs" className="text-white hover:text-zinc-300 underline underline-offset-2">
+					<a href="/docs/actors" className="text-white hover:text-zinc-300 underline underline-offset-2">
 						documentation
 					</a>{" "}
 					or{" "}

--- a/website/src/components/marketing/sections/RedesignedCTA.tsx
+++ b/website/src/components/marketing/sections/RedesignedCTA.tsx
@@ -26,7 +26,7 @@ export const RedesignedCTA = () => (
         className='flex flex-col items-center justify-center gap-3 sm:flex-row'
       >
         <a
-          href='/docs'
+          href='/docs/actors'
           className='inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200'
         >
           Start Building

--- a/website/src/components/marketing/sections/RedesignedHero.tsx
+++ b/website/src/components/marketing/sections/RedesignedHero.tsx
@@ -257,7 +257,7 @@ export const RedesignedHero = ({ latestChangelogTitle, thinkingImages }: Redesig
               transition={{ duration: 0.5, delay: 0.1 }}
               className='flex flex-col gap-3 sm:flex-row'
             >
-              <a href='/docs'
+              <a href='/docs/actors'
                 className='selection-dark inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200'
               >
                 Start Building

--- a/website/src/components/marketing/sections/TechSection.tsx
+++ b/website/src/components/marketing/sections/TechSection.tsx
@@ -253,13 +253,13 @@ export function TechSection() {
             <TechSubSection title='Tools'>
               <TechLink href='/docs/integrations/vitest' name='Vitest' icon={vitestLogo} alt='Vitest' />
               <TechLink
-                href='/docs'
+                href='/docs/actors'
                 name='OpenAPI'
                 icon={javascriptLogo}
                 alt='OpenAPI'
               />
               <TechLink
-                href='/docs'
+                href='/docs/actors'
                 name='AsyncAPI'
                 icon={javascriptLogo}
                 alt='AsyncAPI'

--- a/website/src/components/marketing/solutions/AgentsPage.tsx
+++ b/website/src/components/marketing/solutions/AgentsPage.tsx
@@ -139,7 +139,7 @@ const Hero = () => (
 						transition={{ duration: 0.5, delay: 0.3 }}
 						className="flex flex-col sm:flex-row items-center gap-3"
 					>
-						<a href="/docs" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
+						<a href="/docs/actors" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
 							Start Building
 							<ArrowRight className="h-4 w-4" />
 						</a>
@@ -490,7 +490,7 @@ export default function AgentsPage() {
 							transition={{ duration: 0.5, delay: 0.2 }}
 							className="flex flex-col items-center justify-center gap-3 sm:flex-row"
 						>
-							<a href="/docs" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
+							<a href="/docs/actors" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
 								Start Building
 								<ArrowRight className="h-4 w-4" />
 							</a>

--- a/website/src/components/marketing/solutions/AppGeneratorsPage.tsx
+++ b/website/src/components/marketing/solutions/AppGeneratorsPage.tsx
@@ -135,7 +135,7 @@ const Hero = () => (
 						transition={{ duration: 0.5, delay: 0.2 }}
 						className="flex flex-col sm:flex-row items-center gap-4"
 					>
-						<a href="/docs" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200 gap-2">
+						<a href="/docs/actors" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200 gap-2">
 							Start Building
 							<ArrowRight className="w-4 h-4" />
 						</a>
@@ -450,7 +450,7 @@ export default function AppGeneratorsPage() {
 							transition={{ duration: 0.5, delay: 0.2 }}
 							className="flex flex-col sm:flex-row items-center justify-center gap-4"
 						>
-							<a href="/docs" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
+							<a href="/docs/actors" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
 								Start Building Now
 							</a>
 							<a href="/docs/actors" className="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-white/10 px-4 py-2 text-sm text-zinc-300 transition-colors hover:border-white/20 hover:text-white">

--- a/website/src/components/marketing/solutions/CollaborativeStatePage.tsx
+++ b/website/src/components/marketing/solutions/CollaborativeStatePage.tsx
@@ -138,7 +138,7 @@ const Hero = () => (
 						transition={{ duration: 0.5, delay: 0.2 }}
 						className="flex flex-col sm:flex-row items-center gap-4"
 					>
-						<a href="/docs" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200 gap-2">
+						<a href="/docs/actors" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200 gap-2">
 							Get Started
 							<ArrowRight className="w-4 h-4" />
 						</a>
@@ -520,7 +520,7 @@ export default function CollaborativeStatePage() {
 							transition={{ duration: 0.5, delay: 0.2 }}
 							className="flex flex-col sm:flex-row items-center justify-center gap-4"
 						>
-							<a href="/docs" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
+							<a href="/docs/actors" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
 								Start for Free
 							</a>
 							<a href="/docs/actors" className="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-white/10 px-4 py-2 text-sm text-zinc-300 transition-colors hover:border-white/20 hover:text-white">

--- a/website/src/components/marketing/solutions/GameServersPage.tsx
+++ b/website/src/components/marketing/solutions/GameServersPage.tsx
@@ -163,7 +163,7 @@ const Hero = () => (
 						transition={{ duration: 0.5, delay: 0.2 }}
 						className="flex flex-col sm:flex-row items-center gap-3"
 					>
-						<a href="/docs" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
+						<a href="/docs/actors" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
 							Start Building
 							<ArrowRight className="h-4 w-4" />
 						</a>
@@ -515,7 +515,7 @@ export default function GameServersPage() {
 							Focus on the gameplay. Let Rivet handle the state, scaling, and persistence.
 						</p>
 						<div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
-							<a href="/docs" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
+							<a href="/docs/actors" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
 								Start Building
 								<ArrowRight className="h-4 w-4" />
 							</a>

--- a/website/src/components/marketing/solutions/GamesPage.tsx
+++ b/website/src/components/marketing/solutions/GamesPage.tsx
@@ -163,7 +163,7 @@ const Hero = () => (
 						transition={{ duration: 0.5, delay: 0.2 }}
 						className="flex flex-col sm:flex-row items-center gap-3"
 					>
-						<a href="/docs" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
+						<a href="/docs/actors" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
 							Start Building
 							<ArrowRight className="h-4 w-4" />
 						</a>
@@ -485,7 +485,7 @@ export default function GamesPage() {
 							Focus on the gameplay. Let Rivet handle the state, scaling, and persistence.
 						</p>
 						<div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
-							<a href="/docs" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
+							<a href="/docs/actors" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
 								Start Building
 								<ArrowRight className="h-4 w-4" />
 							</a>

--- a/website/src/components/marketing/solutions/GeoDistributedDBPage.tsx
+++ b/website/src/components/marketing/solutions/GeoDistributedDBPage.tsx
@@ -135,7 +135,7 @@ const Hero = () => (
 						transition={{ duration: 0.5, delay: 0.2 }}
 						className="flex flex-col sm:flex-row items-center gap-4"
 					>
-						<a href="/docs" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200 gap-2">
+						<a href="/docs/actors" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200 gap-2">
 							Get Started
 							<ArrowRight className="w-4 h-4" />
 						</a>
@@ -872,7 +872,7 @@ export default function GeoDistributedDBPage() {
 							transition={{ duration: 0.5, delay: 0.2 }}
 							className="flex flex-col sm:flex-row items-center justify-center gap-4"
 						>
-							<a href="/docs" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
+							<a href="/docs/actors" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
 								Start Building Now
 							</a>
 							<a href="/docs/actors/state" className="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-white/10 px-4 py-2 text-sm text-zinc-300 transition-colors hover:border-white/20">

--- a/website/src/components/marketing/solutions/PerTenantDBPage.tsx
+++ b/website/src/components/marketing/solutions/PerTenantDBPage.tsx
@@ -139,7 +139,7 @@ const Hero = () => (
 						transition={{ duration: 0.5, delay: 0.2 }}
 						className="flex flex-col sm:flex-row items-center gap-4"
 					>
-						<a href="/docs" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200 gap-2">
+						<a href="/docs/actors" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200 gap-2">
 							Get Started
 							<ArrowRight className="w-4 h-4" />
 						</a>
@@ -535,7 +535,7 @@ export default function PerTenantDBPage() {
 							transition={{ duration: 0.5, delay: 0.2 }}
 							className="flex flex-col sm:flex-row items-center justify-center gap-4"
 						>
-							<a href="/docs" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
+							<a href="/docs/actors" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
 								Start Building Now
 							</a>
 							<a href="/docs/actors/persistence" className="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-white/10 px-4 py-2 text-sm text-zinc-300 transition-colors hover:border-white/20">

--- a/website/src/components/marketing/solutions/UserSessionStorePage.tsx
+++ b/website/src/components/marketing/solutions/UserSessionStorePage.tsx
@@ -139,7 +139,7 @@ const Hero = () => (
 						transition={{ duration: 0.5, delay: 0.2 }}
 						className="flex flex-col sm:flex-row items-center gap-4"
 					>
-						<a href="/docs" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200 gap-2">
+						<a href="/docs/actors" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200 gap-2">
 							Get Started
 							<ArrowRight className="w-4 h-4" />
 						</a>
@@ -520,7 +520,7 @@ export default function CommercePage() {
 							transition={{ duration: 0.5, delay: 0.2 }}
 							className="flex flex-col sm:flex-row items-center justify-center gap-4"
 						>
-							<a href="/docs" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
+							<a href="/docs/actors" className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
 								Start Building Now
 							</a>
 							<a href="https://github.com/rivet-dev/rivet/tree/main/examples/state" className="inline-flex items-center justify-center whitespace-nowrap rounded-md border border-white/10 px-4 py-2 text-sm text-zinc-300 transition-colors hover:border-white/20 hover:text-white">

--- a/website/src/components/marketing/solutions/WorkflowsPage.tsx
+++ b/website/src/components/marketing/solutions/WorkflowsPage.tsx
@@ -150,7 +150,7 @@ const Hero = () => (
 						transition={{ duration: 0.5, delay: 0.3 }}
 						className="flex flex-col sm:flex-row items-center gap-3"
 					>
-						<a href="/docs" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
+						<a href="/docs/actors" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
 							Start Building
 							<ArrowRight className="h-4 w-4" />
 						</a>
@@ -570,7 +570,7 @@ export default function WorkflowsPage() {
 							transition={{ duration: 0.5, delay: 0.2 }}
 							className="flex flex-col items-center justify-center gap-3 sm:flex-row"
 						>
-							<a href="/docs" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
+							<a href="/docs/actors" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
 								Start Building
 								<ArrowRight className="h-4 w-4" />
 							</a>

--- a/website/src/components/marketing/solutions/page.tsx
+++ b/website/src/components/marketing/solutions/page.tsx
@@ -153,7 +153,7 @@ const Hero = () => (
 						transition={{ duration: 0.5, delay: 0.2 }}
 						className="flex flex-col sm:flex-row items-center gap-3"
 					>
-						<a href="/docs" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
+						<a href="/docs/actors" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
 							Start Building
 							<ArrowRight className="h-4 w-4" />
 						</a>
@@ -525,7 +525,7 @@ export default function AgentsPage() {
 							Start building stateful, durable, intelligent agents that actually work.
 						</p>
 						<div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
-							<a href="/docs" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
+							<a href="/docs/actors" className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
 								Start Building
 								<ArrowRight className="h-4 w-4" />
 							</a>

--- a/website/src/components/marketing/talk-to-an-engineer/form.tsx
+++ b/website/src/components/marketing/talk-to-an-engineer/form.tsx
@@ -56,7 +56,7 @@ export function TalkToAnEngineerForm() {
 				<p className="text-zinc-400">
 					We will get back to you promptly. In the meantime, feel free to
 					explore our{" "}
-					<a href="/docs" className="text-white hover:text-zinc-300 underline underline-offset-2">
+					<a href="/docs/actors" className="text-white hover:text-zinc-300 underline underline-offset-2">
 						documentation
 					</a>{" "}
 					or{" "}

--- a/website/src/components/v2/Header.tsx
+++ b/website/src/components/v2/Header.tsx
@@ -445,7 +445,7 @@ export function Header({
 							<div className="flex items-center font-v2 subpixel-antialiased">
 								<ProductsDropdown active={active === "product"} />
 								<TextNavItem
-									href="/docs"
+									href="/docs/actors"
 									ariaCurrent={active === "docs" ? "page" : undefined}
 								>
 									Documentation
@@ -526,7 +526,7 @@ export function Header({
 				<div className="flex items-center font-v2 subpixel-antialiased">
 					<ProductsDropdown active={active === "product"} />
 					<TextNavItem
-						href="/docs"
+						href="/docs/actors"
 						ariaCurrent={active === "docs" ? "page" : undefined}
 					>
 						Documentation
@@ -563,7 +563,7 @@ function DocsMobileNavigation({ tree }) {
 	};
 
 	const sections = [
-		{ id: "overview", label: "Overview", href: "/docs" },
+		{ id: "overview", label: "Overview", href: "/docs/actors" },
 		{ id: "quickstart", label: "Quickstart", href: "/docs/quickstart" },
 		{ id: "actors", label: "Actors", href: "/docs/actors" },
 		{ id: "integrations", label: "Integrations", href: "/docs/integrations" },
@@ -571,7 +571,7 @@ function DocsMobileNavigation({ tree }) {
 	];
 
 	const mainLinks = [
-		{ href: "/docs", label: "Documentation" },
+		{ href: "/docs/actors", label: "Documentation" },
 		{ href: "/cloud", label: "Cloud" },
 		{ href: "/cookbook", label: "Cookbooks" },
 	];

--- a/website/src/components/v2/LandingHeader.tsx
+++ b/website/src/components/v2/LandingHeader.tsx
@@ -37,7 +37,7 @@ export function LandingHeader() {
 						<span className="font-heading text-xl font-bold" style={{ color: '#FAFAFA' }}>Rivet</span>
 					</a>
 					<nav className="hidden md:flex items-center gap-6">
-						<a href="/docs"
+						<a href="/docs/actors"
 							className="text-sm font-medium transition-colors"
 							style={{ color: '#A0A0A0' }}
 						>

--- a/website/src/integrations/style-redirects.ts
+++ b/website/src/integrations/style-redirects.ts
@@ -1,0 +1,50 @@
+import type { AstroIntegration } from 'astro';
+import { readFile, writeFile } from 'node:fs/promises';
+import fg from 'fast-glob';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Astro integration that adds dark background styling to redirect HTML files
+ * generated during static builds. Without this, redirect pages flash white
+ * before the browser follows the meta refresh.
+ */
+export function styleRedirects(): AstroIntegration {
+	return {
+		name: 'style-redirects',
+		hooks: {
+			'astro:build:done': async ({ dir, logger }) => {
+				const outDir = fileURLToPath(dir);
+				const htmlFiles = await fg(['**/*.html'], { cwd: outDir });
+
+				let count = 0;
+				for (const file of htmlFiles) {
+					const filePath = path.join(outDir, file);
+					const content = await readFile(filePath, 'utf-8');
+
+					// Only process redirect pages (contain meta refresh but no full page body)
+					if (!content.includes('http-equiv="refresh"') && !content.includes("http-equiv='refresh'")) {
+						continue;
+					}
+
+					// Inject dark background style into the redirect HTML
+					const styled = content.replace(
+						'<head>',
+						'<head><style>html{background-color:#0c0a09}</style>'
+					);
+
+					if (styled !== content) {
+						await writeFile(filePath, styled, 'utf-8');
+						count++;
+					}
+				}
+
+				if (count > 0) {
+					logger.info(`Styled ${count} redirect pages with dark background`);
+				}
+			},
+		},
+	};
+}
+
+export default styleRedirects;

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -64,7 +64,7 @@ const showRssFeed = currentPath.startsWith('/blog') || currentPath.startsWith('/
 ---
 
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en" class="dark" style="background-color: #0c0a09">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -1,0 +1,11 @@
+---
+// Redirect /docs to /docs/actors/ with a dark background to prevent white flash.
+---
+
+<html lang="en" class="dark" style="background-color: #0c0a09">
+	<head>
+		<meta charset="utf-8" />
+		<meta http-equiv="refresh" content="0;url=/docs/actors/" />
+	</head>
+	<body></body>
+</html>

--- a/website/src/sitemap/mod.ts
+++ b/website/src/sitemap/mod.ts
@@ -90,7 +90,7 @@ const deploySidebarPages: SidebarItem[] = deployOptions.map(
 export const sitemap = [
 	{
 		title: "Overview",
-		href: "/docs",
+		href: "/docs/actors",
 		sidebar: [
 			{
 				title: "General",


### PR DESCRIPTION
## Description

Fixes white background flash that occurs when the browser follows a meta-refresh redirect on the statically-built documentation site. The fix inlines the dark background color directly on the `<html>` element so it's applied immediately by the browser before stylesheets load. Additionally, a new post-build Astro integration injects the same styling into Astro's generated redirect HTML files that only contain a meta-refresh tag and aren't covered by the base layout.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The fix can be tested by:
1. Building the website (`pnpm build` in the website directory)
2. Serving the built static files and following a redirect link
3. Observing that the dark background appears immediately instead of flashing white

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings