### PR TITLE
fix(rivetkit): validate runner version fits in u32

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/registry/config/runner.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/config/runner.ts
@@ -14,7 +14,12 @@ export const RunnerConfigSchema = z.object({
 	runnerKey: z
 		.string()
 		.optional(),
-	version: z.number().default(() => getRivetRunnerVersion() ?? 1),
+	version: z
+		.number()
+		.int()
+		.min(0)
+		.max(4294967295, "Runner version must fit in a u32 (max 4294967295). If using Date.now(), divide by 1000 to use seconds instead of milliseconds.")
+		.default(() => getRivetRunnerVersion() ?? 1),
 });
 export type RunnerConfigInput = z.input<typeof RunnerConfigSchema>;
 export type RunnerConfig = z.infer<typeof RunnerConfigSchema>;


### PR DESCRIPTION
## Summary
- The runner protocol (BARE schema) uses `u32` for runner version, but nothing prevented the TypeScript client from sending values that overflow it
- Sandbox Agent was hitting this: `Date.now()` (milliseconds) produces values like `1773390978291` which exceed `u32::MAX` (4294967295), causing the engine's metadata endpoint to return `invalid_response_json`
- Adds zod validation on the runner version config: must be a non-negative integer that fits in u32, with a helpful error message suggesting `Date.now() / 1000` if the value is too large

## Test plan
- [ ] Verify that setting a runner version > 4294967295 causes a startup validation error
- [ ] Verify that `Math.floor(Date.now() / 1000)` still works as a valid version
- [ ] Verify existing default version (1) still works