### PR TITLE
feat(actor): add metadata patching and projection

### DIFF
--- a/engine/artifacts/errors/actor.metadata_key_invalid.json
+++ b/engine/artifacts/errors/actor.metadata_key_invalid.json
@@ -1,0 +1,5 @@
+{
+  "code": "metadata_key_invalid",
+  "group": "actor",
+  "message": "Metadata key is invalid."
+}

--- a/engine/artifacts/errors/actor.metadata_key_too_large.json
+++ b/engine/artifacts/errors/actor.metadata_key_too_large.json
@@ -1,0 +1,5 @@
+{
+  "code": "metadata_key_too_large",
+  "group": "actor",
+  "message": "Metadata key is too large."
+}

--- a/engine/artifacts/errors/actor.metadata_patch_empty.json
+++ b/engine/artifacts/errors/actor.metadata_patch_empty.json
@@ -1,0 +1,5 @@
+{
+  "code": "metadata_patch_empty",
+  "group": "actor",
+  "message": "Metadata patch cannot be empty."
+}

--- a/engine/artifacts/errors/actor.metadata_too_large.json
+++ b/engine/artifacts/errors/actor.metadata_too_large.json
@@ -1,0 +1,5 @@
+{
+  "code": "metadata_too_large",
+  "group": "actor",
+  "message": "Actor metadata is too large."
+}

--- a/engine/artifacts/errors/actor.metadata_too_many_keys.json
+++ b/engine/artifacts/errors/actor.metadata_too_many_keys.json
@@ -1,0 +1,5 @@
+{
+  "code": "metadata_too_many_keys",
+  "group": "actor",
+  "message": "Too many metadata keys requested."
+}

--- a/engine/artifacts/errors/actor.metadata_value_too_large.json
+++ b/engine/artifacts/errors/actor.metadata_value_too_large.json
@@ -1,0 +1,5 @@
+{
+  "code": "metadata_value_too_large",
+  "group": "actor",
+  "message": "Metadata value is too large."
+}

--- a/engine/packages/api-peer/src/actors/delete.rs
+++ b/engine/packages/api-peer/src/actors/delete.rs
@@ -28,6 +28,7 @@ pub async fn delete(ctx: ApiCtx, path: DeletePath, query: DeleteQuery) -> Result
 		ctx.op(pegboard::ops::actor::get::Input {
 			actor_ids: vec![path.actor_id],
 			fetch_error: false,
+			metadata: pegboard::actor_metadata::Projection::None,
 		}),
 		ctx.op(namespace::ops::resolve_for_name_global::Input {
 			name: query.namespace,

--- a/engine/packages/api-peer/src/actors/get_or_create.rs
+++ b/engine/packages/api-peer/src/actors/get_or_create.rs
@@ -76,6 +76,7 @@ pub async fn get_or_create(
 					.op(pegboard::ops::actor::get::Input {
 						actor_ids: vec![existing_actor_id],
 						fetch_error: true,
+						metadata: pegboard::actor_metadata::Projection::Full,
 					})
 					.await?;
 

--- a/engine/packages/api-peer/src/actors/kv_get.rs
+++ b/engine/packages/api-peer/src/actors/kv_get.rs
@@ -47,6 +47,7 @@ pub async fn kv_get(ctx: ApiCtx, path: KvGetPath, query: KvGetQuery) -> Result<K
 		.op(pegboard::ops::actor::get::Input {
 			actor_ids: vec![path.actor_id],
 			fetch_error: false,
+			metadata: pegboard::actor_metadata::Projection::None,
 		})
 		.await?;
 

--- a/engine/packages/api-peer/src/actors/list.rs
+++ b/engine/packages/api-peer/src/actors/list.rs
@@ -13,11 +13,12 @@ use rivet_api_types::{actors::list::*, pagination::Pagination};
 )]
 #[tracing::instrument(skip_all)]
 pub async fn list(ctx: ApiCtx, _path: (), query: ListQuery) -> Result<ListResponse> {
-	let key = query.key;
+	let key = query.key.clone();
 	let actor_ids = [
-		query.actor_id,
+		query.actor_id.clone(),
 		query
 			.actor_ids
+			.clone()
 			.map(|x| {
 				x.split(',')
 					.map(|s| {
@@ -35,6 +36,15 @@ pub async fn list(ctx: ApiCtx, _path: (), query: ListQuery) -> Result<ListRespon
 	]
 	.concat();
 	let include_destroyed = query.include_destroyed.unwrap_or(false);
+	let metadata =
+		if !actor_ids.is_empty() || (query.name.is_some() && key.is_some() && !include_destroyed) {
+			pegboard::actor_metadata::Projection::Full
+		} else if query.metadata_key.is_empty() {
+			pegboard::actor_metadata::Projection::None
+		} else {
+			pegboard::actor_metadata::validate_projection_keys(&query.metadata_key)?;
+			pegboard::actor_metadata::Projection::Selected(query.metadata_key.clone())
+		};
 
 	// TODO: Update api-peer to require including the reservation ID in the query if querying with
 	// key in order to assert the request was sent to the correct datacenter
@@ -54,6 +64,7 @@ pub async fn list(ctx: ApiCtx, _path: (), query: ListQuery) -> Result<ListRespon
 			.op(pegboard::ops::actor::get::Input {
 				actor_ids,
 				fetch_error: true,
+				metadata,
 			})
 			.await?;
 
@@ -102,6 +113,7 @@ pub async fn list(ctx: ApiCtx, _path: (), query: ListQuery) -> Result<ListRespon
 					.transpose()?,
 				limit: query.limit.unwrap_or(100),
 				fetch_error: true,
+				metadata,
 			})
 			.await?;
 

--- a/engine/packages/api-peer/src/actors/mod.rs
+++ b/engine/packages/api-peer/src/actors/mod.rs
@@ -4,3 +4,4 @@ pub mod get_or_create;
 pub mod kv_get;
 pub mod list;
 pub mod list_names;
+pub mod patch_metadata;

--- a/engine/packages/api-peer/src/actors/patch_metadata.rs
+++ b/engine/packages/api-peer/src/actors/patch_metadata.rs
@@ -1,0 +1,157 @@
+use anyhow::{Result, bail};
+use gas::prelude::*;
+use rivet_api_builder::ApiCtx;
+use rivet_api_types::actors::patch_metadata::*;
+
+#[utoipa::path(
+	patch,
+	operation_id = "actors_patch_metadata",
+	path = "/actors/{actor_id}/metadata",
+	params(
+		("actor_id" = Id, Path),
+		PatchMetadataQuery,
+	),
+	request_body(content = PatchMetadataRequest, content_type = "application/json"),
+	responses(
+		(status = 200, body = PatchMetadataResponse),
+	),
+)]
+#[tracing::instrument(skip_all)]
+pub async fn patch_metadata(
+	ctx: ApiCtx,
+	path: PatchMetadataPath,
+	query: PatchMetadataQuery,
+	body: PatchMetadataRequest,
+) -> Result<PatchMetadataResponse> {
+	let patch = body
+		.metadata
+		.into_iter()
+		.map(|(key, value)| pegboard::actor_metadata::PatchEntry { key, value })
+		.collect::<Vec<_>>();
+	pegboard::actor_metadata::validate_patch(&patch)?;
+
+	let request_id = Uuid::new_v4().to_string();
+	let mut patched_sub = ctx
+		.subscribe::<pegboard::workflows::actor::MetadataPatched>((
+			"request_id",
+			request_id.clone(),
+		))
+		.await?;
+
+	let (actors_res, namespace_res) = tokio::try_join!(
+		ctx.op(pegboard::ops::actor::get::Input {
+			actor_ids: vec![path.actor_id],
+			fetch_error: false,
+			metadata: pegboard::actor_metadata::Projection::None,
+		}),
+		ctx.op(namespace::ops::resolve_for_name_global::Input {
+			name: query.namespace,
+		}),
+	)?;
+
+	let actor = actors_res
+		.actors
+		.into_iter()
+		.next()
+		.ok_or_else(|| pegboard::errors::Actor::NotFound.build())?;
+	if actor.destroy_ts.is_some() {
+		return Err(pegboard::errors::Actor::NotFound.build());
+	}
+
+	let namespace = namespace_res.ok_or_else(|| namespace::errors::Namespace::NotFound.build())?;
+	if actor.namespace_id != namespace.namespace_id {
+		return Err(pegboard::errors::Actor::NotFound.build());
+	}
+
+	let res = ctx
+		.signal(pegboard::workflows::actor::PatchMetadata {
+			patch,
+			request_id: Some(request_id),
+		})
+		.to_workflow::<pegboard::workflows::actor::Workflow>()
+		.tag("actor_id", path.actor_id)
+		.graceful_not_found()
+		.send()
+		.await?;
+	if res.is_none() {
+		tracing::warn!(
+			actor_id=?path.actor_id,
+			"actor workflow not found while patching metadata"
+		);
+		return Err(pegboard::errors::Actor::NotFound.build());
+	}
+
+	let patched = patched_sub.next().await?;
+	if let Some(error) = &patched.error {
+		if let Some(actor_error) = rebuild_actor_error(error) {
+			return Err(actor_error);
+		}
+
+		bail!(
+			"actor metadata patch failed: {}:{} {}",
+			error.group,
+			error.code,
+			error.message
+		);
+	}
+
+	Ok(PatchMetadataResponse {})
+}
+
+fn rebuild_actor_error(
+	error: &pegboard::workflows::actor::SerializedError,
+) -> Option<anyhow::Error> {
+	if error.group != "actor" {
+		return None;
+	}
+
+	match error.code.as_str() {
+		"not_found" => Some(pegboard::errors::Actor::NotFound.build()),
+		"metadata_patch_empty" => Some(pegboard::errors::Actor::MetadataPatchEmpty.build()),
+		"metadata_key_invalid" => Some(
+			pegboard::errors::Actor::MetadataKeyInvalid {
+				key_preview: metadata_string_field(error.meta.as_ref(), "key_preview")?,
+			}
+			.build(),
+		),
+		"metadata_key_too_large" => Some(
+			pegboard::errors::Actor::MetadataKeyTooLarge {
+				max_size: metadata_usize_field(error.meta.as_ref(), "max_size")?,
+				key_preview: metadata_string_field(error.meta.as_ref(), "key_preview")?,
+			}
+			.build(),
+		),
+		"metadata_value_too_large" => Some(
+			pegboard::errors::Actor::MetadataValueTooLarge {
+				max_size: metadata_usize_field(error.meta.as_ref(), "max_size")?,
+				key_preview: metadata_string_field(error.meta.as_ref(), "key_preview")?,
+			}
+			.build(),
+		),
+		"metadata_too_large" => Some(
+			pegboard::errors::Actor::MetadataTooLarge {
+				max_size: metadata_usize_field(error.meta.as_ref(), "max_size")?,
+			}
+			.build(),
+		),
+		"metadata_too_many_keys" => Some(
+			pegboard::errors::Actor::MetadataTooManyKeys {
+				max: metadata_usize_field(error.meta.as_ref(), "max")?,
+				count: metadata_usize_field(error.meta.as_ref(), "count")?,
+			}
+			.build(),
+		),
+		_ => None,
+	}
+}
+
+fn metadata_string_field(meta: Option<&serde_json::Value>, field: &str) -> Option<String> {
+	meta?.get(field)?.as_str().map(ToString::to_string)
+}
+
+fn metadata_usize_field(meta: Option<&serde_json::Value>, field: &str) -> Option<usize> {
+	meta?
+		.get(field)?
+		.as_u64()
+		.and_then(|value| usize::try_from(value).ok())
+}

--- a/engine/packages/api-peer/src/router.rs
+++ b/engine/packages/api-peer/src/router.rs
@@ -26,6 +26,10 @@ pub async fn router(
 			.route("/actors", post(actors::create::create))
 			.route("/actors", put(actors::get_or_create::get_or_create))
 			.route("/actors/{actor_id}", delete(actors::delete::delete))
+			.route(
+				"/actors/{actor_id}/metadata",
+				patch(actors::patch_metadata::patch_metadata),
+			)
 			.route("/actors/names", get(actors::list_names::list_names))
 			.route(
 				"/actors/{actor_id}/kv/keys/{key}",

--- a/engine/packages/api-public/src/actors/list.rs
+++ b/engine/packages/api-public/src/actors/list.rs
@@ -186,6 +186,8 @@ async fn list_inner(ctx: ApiCtx, query: ListQuery) -> Result<ListResponse> {
 			.build());
 		}
 
+		pegboard::actor_metadata::validate_projection_keys(&query.metadata_key)?;
+
 		let limit = query.limit.unwrap_or(100);
 
 		// Fanout to all datacenters

--- a/engine/packages/api-public/src/actors/mod.rs
+++ b/engine/packages/api-public/src/actors/mod.rs
@@ -4,4 +4,5 @@ pub mod get_or_create;
 pub mod kv_get;
 pub mod list;
 pub mod list_names;
+pub mod patch_metadata;
 pub mod utils;

--- a/engine/packages/api-public/src/actors/patch_metadata.rs
+++ b/engine/packages/api-public/src/actors/patch_metadata.rs
@@ -1,0 +1,65 @@
+use anyhow::Result;
+use axum::response::{IntoResponse, Response};
+use rivet_api_builder::{
+	ApiError,
+	extract::{Extension, Json, Path, Query},
+};
+use rivet_api_types::actors::patch_metadata::*;
+use rivet_api_util::request_remote_datacenter_raw;
+use rivet_util::Id;
+
+use crate::ctx::ApiCtx;
+
+#[utoipa::path(
+	patch,
+	operation_id = "actors_patch_metadata",
+	path = "/actors/{actor_id}/metadata",
+	params(
+		("actor_id" = Id, Path),
+		PatchMetadataQuery,
+	),
+	request_body(content = PatchMetadataRequest, content_type = "application/json"),
+	responses(
+		(status = 200, body = PatchMetadataResponse),
+	),
+	security(("bearer_auth" = [])),
+)]
+#[tracing::instrument(skip_all)]
+pub async fn patch_metadata(
+	Extension(ctx): Extension<ApiCtx>,
+	Path(path): Path<PatchMetadataPath>,
+	Query(query): Query<PatchMetadataQuery>,
+	Json(body): Json<PatchMetadataRequest>,
+) -> Response {
+	match patch_metadata_inner(ctx, path, query, body).await {
+		Ok(response) => response,
+		Err(err) => ApiError::from(err).into_response(),
+	}
+}
+
+async fn patch_metadata_inner(
+	ctx: ApiCtx,
+	path: PatchMetadataPath,
+	query: PatchMetadataQuery,
+	body: PatchMetadataRequest,
+) -> Result<Response> {
+	ctx.auth().await?;
+
+	if path.actor_id.label() == ctx.config().dc_label() {
+		let res =
+			rivet_api_peer::actors::patch_metadata::patch_metadata(ctx.into(), path, query, body)
+				.await?;
+
+		Ok(Json(res).into_response())
+	} else {
+		request_remote_datacenter_raw(
+			&ctx,
+			path.actor_id.label(),
+			&format!("/actors/{}/metadata", path.actor_id),
+			axum::http::Method::PATCH,
+			Some(&query),
+			Some(&body),
+		)
+		.await
+	}
+}

--- a/engine/packages/api-public/src/actors/utils.rs
+++ b/engine/packages/api-public/src/actors/utils.rs
@@ -83,6 +83,7 @@ pub async fn fetch_actors_by_ids(
 				namespace: namespace.clone(),
 				name: None,
 				key: None,
+				metadata_key: Vec::new(),
 				actor_ids: None,
 				actor_id: dc_actor_ids,
 				include_destroyed,

--- a/engine/packages/api-public/src/router.rs
+++ b/engine/packages/api-public/src/router.rs
@@ -19,6 +19,7 @@ use crate::{actors, ctx, datacenters, health, metadata, namespaces, runner_confi
 		actors::list_names::list_names,
 		actors::get_or_create::get_or_create,
 		actors::kv_get::kv_get,
+		actors::patch_metadata::patch_metadata,
 		runners::list,
 		runners::list_names,
 		namespaces::list,
@@ -85,6 +86,10 @@ pub async fn router(
 			.route(
 				"/actors/{actor_id}",
 				axum::routing::delete(actors::delete::delete),
+			)
+			.route(
+				"/actors/{actor_id}/metadata",
+				axum::routing::patch(actors::patch_metadata::patch_metadata),
 			)
 			.route(
 				"/actors/names",

--- a/engine/packages/api-types/src/actors/list.rs
+++ b/engine/packages/api-types/src/actors/list.rs
@@ -11,6 +11,8 @@ pub struct ListQuery {
 	pub namespace: String,
 	pub name: Option<String>,
 	pub key: Option<String>,
+	#[serde(default)]
+	pub metadata_key: Vec<String>,
 	/// Deprecated.
 	#[serde(default)]
 	pub actor_ids: Option<String>,

--- a/engine/packages/api-types/src/actors/mod.rs
+++ b/engine/packages/api-types/src/actors/mod.rs
@@ -3,3 +3,4 @@ pub mod delete;
 pub mod get_or_create;
 pub mod list;
 pub mod list_names;
+pub mod patch_metadata;

--- a/engine/packages/api-types/src/actors/patch_metadata.rs
+++ b/engine/packages/api-types/src/actors/patch_metadata.rs
@@ -1,0 +1,31 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use utoipa::{IntoParams, ToSchema};
+
+use rivet_util::Id;
+
+#[derive(Debug, Deserialize, Serialize, IntoParams)]
+#[serde(deny_unknown_fields)]
+#[into_params(parameter_in = Query)]
+pub struct PatchMetadataQuery {
+	pub namespace: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PatchMetadataPath {
+	pub actor_id: Id,
+}
+
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+#[schema(as = ActorsPatchMetadataRequest)]
+pub struct PatchMetadataRequest {
+	#[schema(value_type = Object, additional_properties = true)]
+	pub metadata: HashMap<String, Option<String>>,
+}
+
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+#[schema(as = ActorsPatchMetadataResponse)]
+pub struct PatchMetadataResponse {}

--- a/engine/packages/engine/tests/actors_scheduling_errors.rs
+++ b/engine/packages/engine/tests/actors_scheduling_errors.rs
@@ -209,6 +209,7 @@ async fn get_actor(
 			namespace: namespace.to_string(),
 			name: None,
 			key: None,
+			metadata_key: Vec::new(),
 			include_destroyed: Some(true),
 			limit: None,
 			cursor: None,

--- a/engine/packages/engine/tests/common/actors.rs
+++ b/engine/packages/engine/tests/common/actors.rs
@@ -50,6 +50,7 @@ pub async fn try_get_actor(
 			namespace: namespace.to_string(),
 			name: None,
 			key: None,
+			metadata_key: Vec::new(),
 			include_destroyed: Some(true),
 			limit: None,
 			cursor: None,

--- a/engine/packages/pegboard-runner/src/ws_to_tunnel_task.rs
+++ b/engine/packages/pegboard-runner/src/ws_to_tunnel_task.rs
@@ -882,11 +882,10 @@ async fn handle_tunnel_message_mk1(
 
 	// Publish message to UPS
 	let gateway_reply_to = GatewayReceiverSubject::new(msg.message_id.gateway_id).to_string();
-	let msg_serialized = versioned::ToGateway::v3_to_v6(versioned::ToGateway::V3(
-		protocol::ToGateway::ToServerTunnelMessage(msg),
-	))?
-	.serialize_with_embedded_version(PROTOCOL_MK2_VERSION)
-	.context("failed to serialize tunnel message for gateway")?;
+	let msg_serialized = versioned::ToGateway::V3(protocol::ToGateway::ToServerTunnelMessage(msg))
+		.v3_to_v8()?
+		.serialize_with_embedded_version(PROTOCOL_MK2_VERSION)
+		.context("failed to serialize tunnel message for gateway")?;
 	ctx.ups()
 		.context("failed to get UPS instance for tunnel message")?
 		.publish(&gateway_reply_to, &msg_serialized, PublishOpts::one())

--- a/engine/packages/pegboard/src/actor_metadata.rs
+++ b/engine/packages/pegboard/src/actor_metadata.rs
@@ -1,0 +1,303 @@
+use anyhow::Result;
+use futures_util::{StreamExt, TryStreamExt};
+use gas::prelude::*;
+use rivet_types::actors::Actor;
+use std::collections::HashMap;
+use universaldb::options::StreamingMode;
+use universaldb::utils::IsolationLevel::*;
+
+use crate::{errors, keys};
+
+pub const MAX_KEY_SIZE: usize = 128;
+pub const MAX_VALUE_SIZE: usize = 4096;
+pub const MAX_TOTAL_SIZE: usize = 16 * 1024;
+pub const MAX_LIST_KEYS: usize = 16;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
+pub struct PatchEntry {
+	pub key: String,
+	pub value: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum Projection {
+	None,
+	Selected(Vec<String>),
+	Full,
+}
+
+impl Projection {
+	pub fn requested(&self) -> bool {
+		!matches!(self, Projection::None)
+	}
+}
+
+impl Default for Projection {
+	fn default() -> Self {
+		Self::None
+	}
+}
+
+pub fn validate_projection_keys(keys: &[String]) -> Result<()> {
+	if keys.len() > MAX_LIST_KEYS {
+		return Err(errors::Actor::MetadataTooManyKeys {
+			max: MAX_LIST_KEYS,
+			count: keys.len(),
+		}
+		.build());
+	}
+
+	for key in keys {
+		validate_key(key)?;
+	}
+
+	Ok(())
+}
+
+pub fn validate_patch(patch: &[PatchEntry]) -> Result<()> {
+	if patch.is_empty() {
+		return Err(errors::Actor::MetadataPatchEmpty.build());
+	}
+
+	for entry in patch {
+		validate_key(&entry.key)?;
+
+		if let Some(value) = &entry.value
+			&& value.as_bytes().len() > MAX_VALUE_SIZE
+		{
+			return Err(errors::Actor::MetadataValueTooLarge {
+				max_size: MAX_VALUE_SIZE,
+				key_preview: util::safe_slice(&entry.key, 0, MAX_KEY_SIZE).to_string(),
+			}
+			.build());
+		}
+	}
+
+	Ok(())
+}
+
+pub async fn get(
+	db: &universaldb::Database,
+	actor_ids: &[Id],
+	projection: &Projection,
+) -> Result<HashMap<Id, HashMap<String, String>>> {
+	if actor_ids.is_empty() || !projection.requested() {
+		return Ok(HashMap::new());
+	}
+
+	match projection {
+		Projection::None => Ok(HashMap::new()),
+		Projection::Selected(keys) => get_selected(db, actor_ids, keys).await,
+		Projection::Full => get_full(db, actor_ids).await,
+	}
+}
+
+pub async fn attach_to_actors(
+	db: &universaldb::Database,
+	actors: &mut [Actor],
+	projection: &Projection,
+) -> Result<()> {
+	if actors.is_empty() || !projection.requested() {
+		return Ok(());
+	}
+
+	let actor_ids = actors
+		.iter()
+		.map(|actor| actor.actor_id)
+		.collect::<Vec<_>>();
+	let metadata = get(db, &actor_ids, projection).await?;
+
+	for actor in actors {
+		actor.metadata = Some(metadata.get(&actor.actor_id).cloned().unwrap_or_default());
+	}
+
+	Ok(())
+}
+
+pub async fn apply_patch(
+	db: &universaldb::Database,
+	actor_id: Id,
+	patch: &[PatchEntry],
+) -> Result<HashMap<String, String>> {
+	validate_patch(patch)?;
+
+	db.run(|tx| {
+		let patch = patch.to_vec();
+		async move {
+			let tx = tx.with_subspace(keys::subspace());
+			let subspace = keys::actor_metadata::subspace(actor_id);
+			let mut current = read_all_for_actor(&tx, actor_id).await?;
+
+			for entry in &patch {
+				match &entry.value {
+					Some(value) => {
+						current.insert(entry.key.clone(), value.clone());
+					}
+					None => {
+						current.remove(&entry.key);
+					}
+				}
+			}
+
+			validate_total_size(&current)?;
+
+			for entry in patch {
+				let entry_key = keys::actor_metadata::EntryKey::new(actor_id, entry.key);
+
+				match entry.value {
+					Some(value) => {
+						tx.write(&entry_key, value)?;
+					}
+					None => {
+						tx.delete(&entry_key);
+					}
+				}
+			}
+
+			// Clear the entire subspace if the patch deleted every key.
+			if current.is_empty() {
+				tx.clear_subspace_range(&subspace);
+			}
+
+			Ok(current)
+		}
+	})
+	.await
+}
+
+async fn get_selected(
+	db: &universaldb::Database,
+	actor_ids: &[Id],
+	selected_keys: &[String],
+) -> Result<HashMap<Id, HashMap<String, String>>> {
+	db.run(|tx| {
+		let actor_ids = actor_ids.to_vec();
+		let selected_keys = selected_keys.to_vec();
+		async move {
+			let tx = tx.with_subspace(keys::subspace());
+
+			let pairs = futures_util::stream::iter(actor_ids.into_iter().flat_map(|actor_id| {
+				selected_keys
+					.iter()
+					.cloned()
+					.map(move |key| (actor_id, key))
+					.collect::<Vec<_>>()
+			}))
+			.map(|(actor_id, key)| {
+				let tx = tx.clone();
+				async move {
+					let entry_key = keys::actor_metadata::EntryKey::new(actor_id, key.clone());
+					let value = tx.read_opt(&entry_key, Serializable).await?;
+					Ok::<_, anyhow::Error>(value.map(|value| (actor_id, key, value)))
+				}
+			})
+			.buffer_unordered(256)
+			.try_filter_map(|entry| std::future::ready(Ok(entry)))
+			.try_collect::<Vec<_>>()
+			.await?;
+
+			let mut metadata = HashMap::<Id, HashMap<String, String>>::new();
+			for (actor_id, key, value) in pairs {
+				metadata.entry(actor_id).or_default().insert(key, value);
+			}
+
+			Ok(metadata)
+		}
+	})
+	.await
+}
+
+async fn get_full(
+	db: &universaldb::Database,
+	actor_ids: &[Id],
+) -> Result<HashMap<Id, HashMap<String, String>>> {
+	db.run(|tx| {
+		let actor_ids = actor_ids.to_vec();
+		async move {
+			let tx = tx.with_subspace(keys::subspace());
+
+			futures_util::stream::iter(actor_ids)
+				.map(|actor_id| {
+					let tx = tx.clone();
+					async move {
+						Ok::<_, anyhow::Error>((actor_id, read_all_for_actor(&tx, actor_id).await?))
+					}
+				})
+				.buffer_unordered(128)
+				.try_collect::<Vec<_>>()
+				.await
+				.map(|entries| entries.into_iter().collect())
+		}
+	})
+	.await
+}
+
+async fn read_all_for_actor(
+	tx: &universaldb::Transaction,
+	actor_id: Id,
+) -> Result<HashMap<String, String>> {
+	let subspace = keys::actor_metadata::subspace(actor_id);
+	let mut stream = tx.get_ranges_keyvalues(
+		universaldb::RangeOption {
+			mode: StreamingMode::Iterator,
+			..subspace.range().into()
+		},
+		Serializable,
+	);
+	let mut metadata = HashMap::new();
+
+	while let Some(entry) = stream.try_next().await? {
+		let key = tx
+			.unpack::<keys::actor_metadata::EntryKey>(&entry.key())?
+			.key;
+		let value = String::from_utf8(entry.value().to_vec())?;
+		metadata.insert(key, value);
+	}
+
+	Ok(metadata)
+}
+
+fn validate_key(key: &str) -> Result<()> {
+	if key.is_empty() {
+		return Err(errors::Actor::MetadataKeyInvalid {
+			key_preview: String::new(),
+		}
+		.build());
+	}
+
+	if key.as_bytes().len() > MAX_KEY_SIZE {
+		return Err(errors::Actor::MetadataKeyTooLarge {
+			max_size: MAX_KEY_SIZE,
+			key_preview: util::safe_slice(key, 0, MAX_KEY_SIZE).to_string(),
+		}
+		.build());
+	}
+
+	if !key
+		.as_bytes()
+		.iter()
+		.all(|byte| matches!(byte, b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'-'))
+	{
+		return Err(errors::Actor::MetadataKeyInvalid {
+			key_preview: util::safe_slice(key, 0, MAX_KEY_SIZE).to_string(),
+		}
+		.build());
+	}
+
+	Ok(())
+}
+
+fn validate_total_size(metadata: &HashMap<String, String>) -> Result<()> {
+	let total_size = metadata.iter().fold(0usize, |sum, (key, value)| {
+		sum + key.as_bytes().len() + value.as_bytes().len()
+	});
+
+	if total_size > MAX_TOTAL_SIZE {
+		return Err(errors::Actor::MetadataTooLarge {
+			max_size: MAX_TOTAL_SIZE,
+		}
+		.build());
+	}
+
+	Ok(())
+}

--- a/engine/packages/pegboard/src/errors.rs
+++ b/engine/packages/pegboard/src/errors.rs
@@ -41,6 +41,50 @@ pub enum Actor {
 	#[error("destroyed_during_creation", "Actor was destroyed during creation.")]
 	DestroyedDuringCreation,
 
+	#[error("metadata_patch_empty", "Metadata patch cannot be empty.")]
+	MetadataPatchEmpty,
+
+	#[error(
+		"metadata_key_invalid",
+		"Metadata key is invalid.",
+		"Metadata key is invalid: {key_preview}"
+	)]
+	MetadataKeyInvalid { key_preview: String },
+
+	#[error(
+		"metadata_key_too_large",
+		"Metadata key is too large.",
+		"Metadata key is too large (max {max_size} bytes): {key_preview}"
+	)]
+	MetadataKeyTooLarge {
+		max_size: usize,
+		key_preview: String,
+	},
+
+	#[error(
+		"metadata_value_too_large",
+		"Metadata value is too large.",
+		"Metadata value is too large (max {max_size} bytes) for key '{key_preview}'"
+	)]
+	MetadataValueTooLarge {
+		max_size: usize,
+		key_preview: String,
+	},
+
+	#[error(
+		"metadata_too_large",
+		"Actor metadata is too large.",
+		"Actor metadata is too large (max {max_size} bytes)."
+	)]
+	MetadataTooLarge { max_size: usize },
+
+	#[error(
+		"metadata_too_many_keys",
+		"Too many metadata keys requested.",
+		"Too many metadata keys requested. Maximum is {max}, got {count}."
+	)]
+	MetadataTooManyKeys { max: usize, count: usize },
+
 	#[error(
 		"destroyed_while_waiting_for_ready",
 		"Actor was destroyed while waiting for ready state."

--- a/engine/packages/pegboard/src/keys/actor_metadata.rs
+++ b/engine/packages/pegboard/src/keys/actor_metadata.rs
@@ -1,0 +1,55 @@
+use anyhow::Result;
+use gas::prelude::*;
+use universaldb::prelude::*;
+
+const ACTOR_METADATA: &str = "actor_metadata";
+
+pub fn subspace(actor_id: Id) -> universaldb::utils::Subspace {
+	universaldb::utils::Subspace::new(&(ACTOR_METADATA, actor_id))
+}
+
+#[derive(Debug)]
+pub struct EntryKey {
+	pub actor_id: Id,
+	pub key: String,
+}
+
+impl EntryKey {
+	pub fn new(actor_id: Id, key: String) -> Self {
+		Self { actor_id, key }
+	}
+}
+
+impl FormalKey for EntryKey {
+	type Value = String;
+
+	fn deserialize(&self, raw: &[u8]) -> Result<Self::Value> {
+		Ok(String::from_utf8(raw.to_vec())?)
+	}
+
+	fn serialize(&self, value: Self::Value) -> Result<Vec<u8>> {
+		Ok(value.into_bytes())
+	}
+}
+
+impl TuplePack for EntryKey {
+	fn pack<W: std::io::Write>(
+		&self,
+		w: &mut W,
+		tuple_depth: TupleDepth,
+	) -> std::io::Result<VersionstampOffset> {
+		(ACTOR_METADATA, self.actor_id, &self.key).pack(w, tuple_depth)
+	}
+}
+
+impl<'de> TupleUnpack<'de> for EntryKey {
+	fn unpack(input: &[u8], tuple_depth: TupleDepth) -> PackResult<(&[u8], Self)> {
+		let (input, (subspace, actor_id, key)) =
+			<(String, Id, String)>::unpack(input, tuple_depth)?;
+		if subspace != ACTOR_METADATA {
+			return Err(PackError::Message("expected actor metadata key".into()));
+		}
+
+		Ok((input, Self { actor_id, key }))
+	}
+}

--- a/engine/packages/pegboard/src/keys/mod.rs
+++ b/engine/packages/pegboard/src/keys/mod.rs
@@ -1,5 +1,6 @@
 pub mod actor;
 pub mod actor_kv;
+pub mod actor_metadata;
 pub mod backfill;
 pub mod epoxy;
 pub mod hibernating_request;

--- a/engine/packages/pegboard/src/lib.rs
+++ b/engine/packages/pegboard/src/lib.rs
@@ -1,6 +1,7 @@
 use gas::prelude::*;
 
 pub mod actor_kv;
+pub mod actor_metadata;
 pub mod errors;
 pub mod keys;
 pub mod metrics;

--- a/engine/packages/pegboard/src/ops/actor/create.rs
+++ b/engine/packages/pegboard/src/ops/actor/create.rs
@@ -95,6 +95,7 @@ pub async fn pegboard_actor_create(ctx: &OperationCtx, input: &Input) -> Result<
 		.op(crate::ops::actor::get::Input {
 			actor_ids: vec![input.actor_id],
 			fetch_error: false,
+			metadata: crate::actor_metadata::Projection::None,
 		})
 		.await?;
 

--- a/engine/packages/pegboard/src/ops/actor/get.rs
+++ b/engine/packages/pegboard/src/ops/actor/get.rs
@@ -9,6 +9,7 @@ use crate::keys;
 pub struct Input {
 	pub actor_ids: Vec<Id>,
 	pub fetch_error: bool,
+	pub metadata: crate::actor_metadata::Projection,
 }
 
 #[derive(Debug)]
@@ -59,7 +60,7 @@ pub async fn pegboard_actor_get(ctx: &OperationCtx, input: &Input) -> Result<Out
 
 	let dc_name = ctx.config().dc_name()?.to_string();
 
-	let actors = super::util::build_actors_from_workflows(
+	let mut actors = super::util::build_actors_from_workflows(
 		ctx,
 		actors_with_wf_ids,
 		wfs,
@@ -67,6 +68,8 @@ pub async fn pegboard_actor_get(ctx: &OperationCtx, input: &Input) -> Result<Out
 		input.fetch_error,
 	)
 	.await?;
+
+	crate::actor_metadata::attach_to_actors(&*ctx.udb()?, &mut actors, &input.metadata).await?;
 
 	Ok(Output { actors })
 }

--- a/engine/packages/pegboard/src/ops/actor/get_for_key.rs
+++ b/engine/packages/pegboard/src/ops/actor/get_for_key.rs
@@ -44,6 +44,7 @@ pub async fn pegboard_actor_get_for_key(ctx: &OperationCtx, input: &Input) -> Re
 				created_before: None,
 				limit: 1,
 				fetch_error: input.fetch_error,
+				metadata: crate::actor_metadata::Projection::Full,
 			})
 			.await?;
 
@@ -81,6 +82,7 @@ pub async fn pegboard_actor_get_for_key(ctx: &OperationCtx, input: &Input) -> Re
 				key: Some(input.key.clone()),
 				actor_ids: None,
 				actor_id: Vec::new(),
+				metadata_key: Vec::new(),
 				include_destroyed: Some(false),
 				limit: Some(1),
 				cursor: None,

--- a/engine/packages/pegboard/src/ops/actor/list_for_ns.rs
+++ b/engine/packages/pegboard/src/ops/actor/list_for_ns.rs
@@ -15,6 +15,7 @@ pub struct Input {
 	pub created_before: Option<i64>,
 	pub limit: usize,
 	pub fetch_error: bool,
+	pub metadata: crate::actor_metadata::Projection,
 }
 
 #[derive(Debug)]
@@ -166,7 +167,7 @@ pub async fn pegboard_actor_list_for_ns(ctx: &OperationCtx, input: &Input) -> Re
 
 	let dc_name = ctx.config().dc_name()?.to_string();
 
-	let actors = super::util::build_actors_from_workflows(
+	let mut actors = super::util::build_actors_from_workflows(
 		ctx,
 		actors_with_wf_ids,
 		wfs,
@@ -174,6 +175,8 @@ pub async fn pegboard_actor_list_for_ns(ctx: &OperationCtx, input: &Input) -> Re
 		input.fetch_error,
 	)
 	.await?;
+
+	crate::actor_metadata::attach_to_actors(&*ctx.udb()?, &mut actors, &input.metadata).await?;
 
 	Ok(Output { actors })
 }

--- a/engine/packages/pegboard/src/ops/actor/util.rs
+++ b/engine/packages/pegboard/src/ops/actor/util.rs
@@ -76,6 +76,7 @@ pub async fn build_actors_from_workflows(
 			destroy_ts: actor_state.destroy_ts,
 
 			error,
+			metadata: None,
 		});
 	}
 

--- a/engine/packages/pegboard/src/workflows/actor/destroy.rs
+++ b/engine/packages/pegboard/src/workflows/actor/destroy.rs
@@ -141,6 +141,8 @@ async fn update_state_and_db(
 					)?;
 				}
 
+				tx.clear_subspace_range(&keys::actor_metadata::subspace(input.actor_id));
+
 				// Update metrics
 				namespace::keys::metric::inc(
 					&tx.with_subspace(namespace::keys::subspace()),

--- a/engine/packages/pegboard/src/workflows/actor/metadata.rs
+++ b/engine/packages/pegboard/src/workflows/actor/metadata.rs
@@ -1,0 +1,23 @@
+use anyhow::Result;
+use gas::prelude::*;
+
+#[derive(Debug, Serialize, Deserialize, Hash)]
+pub(crate) struct ApplyPatchInput {
+	pub actor_id: Id,
+	pub patch: Vec<crate::actor_metadata::PatchEntry>,
+}
+
+#[activity(ApplyMetadataPatch)]
+pub(crate) async fn apply_patch(ctx: &ActivityCtx, input: &ApplyPatchInput) -> Result<()> {
+	crate::actor_metadata::apply_patch(&*ctx.udb()?, input.actor_id, &input.patch).await?;
+	Ok(())
+}
+
+pub(crate) fn protocol_patch_entry_to_storage(
+	entry: rivet_runner_protocol::mk2::MetadataPatchEntry,
+) -> crate::actor_metadata::PatchEntry {
+	crate::actor_metadata::PatchEntry {
+		key: entry.key,
+		value: entry.value,
+	}
+}

--- a/engine/packages/pegboard/src/workflows/actor/mod.rs
+++ b/engine/packages/pegboard/src/workflows/actor/mod.rs
@@ -7,6 +7,7 @@ use crate::{errors, workflows::runner2::AllocatePendingActorsInput};
 
 mod destroy;
 mod keys;
+mod metadata;
 pub mod metrics;
 mod runtime;
 mod setup;
@@ -534,6 +535,21 @@ pub async fn pegboard_actor(ctx: &mut WorkflowCtx, input: &Input) -> Result<()> 
 										state.alarm_ts = *alarm_ts;
 										alarms_set += 1;
 									}
+									protocol::mk2::Event::EventActorPatchMetadata(
+										protocol::mk2::EventActorPatchMetadata { patch },
+									) => {
+										handle_metadata_patch(
+											ctx,
+											input.actor_id,
+											patch
+												.iter()
+												.cloned()
+												.map(metadata::protocol_patch_entry_to_storage)
+												.collect(),
+											None,
+										)
+										.await?;
+									}
 								}
 							}
 
@@ -579,7 +595,16 @@ pub async fn pegboard_actor(ctx: &mut WorkflowCtx, input: &Input) -> Result<()> 
 								}))
 							)).await?;
 						}
-						Main::Wake(sig) => {
+							Main::PatchMetadata(sig) => {
+								handle_metadata_patch(
+									ctx,
+									input.actor_id,
+									sig.patch,
+									sig.request_id,
+								)
+								.await?;
+							}
+							Main::Wake(sig) => {
 							// Clear alarm
 							if let Some(alarm_ts) = state.alarm_ts {
 								let now = ctx.v(3).activity(GetTsInput {}).await?;
@@ -1225,6 +1250,61 @@ async fn handle_stopped(
 	Ok(StoppedResult::Continue)
 }
 
+async fn handle_metadata_patch(
+	ctx: &mut WorkflowCtx,
+	actor_id: Id,
+	patch: Vec<crate::actor_metadata::PatchEntry>,
+	request_id: Option<String>,
+) -> Result<()> {
+	let result = ctx
+		.activity(metadata::ApplyPatchInput { actor_id, patch })
+		.await;
+
+	match result {
+		Ok(_) => {
+			if let Some(request_id) = request_id {
+				ctx.msg(MetadataPatched {
+					request_id: request_id.clone(),
+					error: None,
+				})
+				.topic(("request_id", request_id))
+				.send()
+				.await?;
+			}
+		}
+		Err(err) => {
+			let actor_error = rivet_error::RivetError::extract(&err);
+			if actor_error.group() == "actor" {
+				tracing::warn!(
+					?actor_id,
+					group = actor_error.group(),
+					code = actor_error.code(),
+					"failed to patch actor metadata"
+				);
+			} else {
+				tracing::error!(?actor_id, ?err, "internal actor metadata patch failure");
+			}
+
+			if let Some(request_id) = request_id {
+				ctx.msg(MetadataPatched {
+					request_id: request_id.clone(),
+					error: Some(SerializedError {
+						group: actor_error.group().to_string(),
+						code: actor_error.code().to_string(),
+						message: actor_error.message().to_string(),
+						meta: actor_error.metadata(),
+					}),
+				})
+				.topic(("request_id", request_id))
+				.send()
+				.await?;
+			}
+		}
+	}
+
+	Ok(())
+}
+
 #[derive(Debug, Serialize, Deserialize, Hash)]
 struct GetTsInput {}
 
@@ -1249,6 +1329,12 @@ pub struct Ready {
 #[message("pegboard_actor_stopped")]
 pub struct Stopped {}
 
+#[message("pegboard_actor_metadata_patched")]
+pub struct MetadataPatched {
+	pub request_id: String,
+	pub error: Option<SerializedError>,
+}
+
 #[signal("pegboard_actor_allocate")]
 #[derive(Debug)]
 pub struct Allocate {
@@ -1269,6 +1355,23 @@ pub struct Event {
 pub struct Events {
 	pub runner_id: Id,
 	pub events: Vec<protocol::mk2::EventWrapper>,
+}
+
+#[derive(Debug)]
+#[signal("pegboard_actor_patch_metadata")]
+pub struct PatchMetadata {
+	pub patch: Vec<crate::actor_metadata::PatchEntry>,
+	#[serde(default)]
+	pub request_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerializedError {
+	pub group: String,
+	pub code: String,
+	pub message: String,
+	#[serde(default)]
+	pub meta: Option<serde_json::Value>,
 }
 
 #[signal("pegboard_actor_wake")]
@@ -1333,6 +1436,7 @@ join_signal!(PendingAllocation {
 join_signal!(Main {
 	Event,
 	Events,
+	PatchMetadata,
 	Wake,
 	Lost,
 	GoingAway,

--- a/engine/packages/types/src/actors.rs
+++ b/engine/packages/types/src/actors.rs
@@ -1,6 +1,7 @@
 use gas::prelude::*;
 use rivet_util::Id;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::ops::Deref;
 use utoipa::ToSchema;
 
@@ -35,6 +36,10 @@ pub struct Actor {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[schema(value_type = Option<Object>, additional_properties = true)]
 	pub error: Option<crate::actor::ActorError>,
+
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[schema(value_type = Option<Object>, additional_properties = true)]
+	pub metadata: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Copy, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, ToSchema)]

--- a/engine/sdks/rust/runner-protocol/src/lib.rs
+++ b/engine/sdks/rust/runner-protocol/src/lib.rs
@@ -6,10 +6,10 @@ pub mod versioned;
 
 // Re-export latest
 pub use generated::v3::*;
-pub use generated::v7 as mk2;
+pub use generated::v8 as mk2;
 
 pub const PROTOCOL_MK1_VERSION: u16 = 3;
-pub const PROTOCOL_MK2_VERSION: u16 = 7;
+pub const PROTOCOL_MK2_VERSION: u16 = 8;
 
 pub fn is_mk2(protocol_version: u16) -> bool {
 	protocol_version > PROTOCOL_MK1_VERSION

--- a/engine/sdks/rust/runner-protocol/src/versioned.rs
+++ b/engine/sdks/rust/runner-protocol/src/versioned.rs
@@ -1,25 +1,35 @@
 use anyhow::{Ok, Result, bail};
+use serde::{Serialize, de::DeserializeOwned};
 use vbare::OwnedVersionedData;
 
 use crate::PROTOCOL_MK1_VERSION;
-use crate::generated::{v1, v2, v3, v4, v5, v6, v7};
+use crate::generated::{v1, v2, v3, v4, v5, v6, v7, v8};
 use crate::uuid_compat::{decode_bytes_from_uuid, encode_bytes_to_uuid};
+
+fn transcode<T, U>(value: T) -> Result<U>
+where
+	T: Serialize,
+	U: DeserializeOwned,
+{
+	Ok(serde_bare::from_slice(&serde_bare::to_vec(&value)?)?)
+}
 
 pub enum ToClientMk2 {
 	V4(v4::ToClient),
 	V5(v5::ToClient),
 	V7(v7::ToClient),
+	V8(v8::ToClient),
 }
 
 impl OwnedVersionedData for ToClientMk2 {
-	type Latest = v7::ToClient;
+	type Latest = v8::ToClient;
 
-	fn wrap_latest(latest: v7::ToClient) -> Self {
-		ToClientMk2::V7(latest)
+	fn wrap_latest(latest: v8::ToClient) -> Self {
+		ToClientMk2::V8(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
-		if let ToClientMk2::V7(data) = self {
+		if let ToClientMk2::V8(data) = self {
 			Ok(data)
 		} else {
 			bail!("version not latest");
@@ -31,6 +41,7 @@ impl OwnedVersionedData for ToClientMk2 {
 			4 => Ok(ToClientMk2::V4(serde_bare::from_slice(payload)?)),
 			5 => Ok(ToClientMk2::V5(serde_bare::from_slice(payload)?)),
 			6 | 7 => Ok(ToClientMk2::V7(serde_bare::from_slice(payload)?)),
+			8 => Ok(ToClientMk2::V8(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -40,15 +51,32 @@ impl OwnedVersionedData for ToClientMk2 {
 			ToClientMk2::V4(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ToClientMk2::V5(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ToClientMk2::V7(data) => serde_bare::to_vec(&data).map_err(Into::into),
+			ToClientMk2::V8(data) => serde_bare::to_vec(&data).map_err(Into::into),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Self::v4_to_v5, Self::v5_to_v7, Ok]
+		vec![
+			Ok,
+			Ok,
+			Ok,
+			Self::v4_to_v5,
+			Self::v5_to_v7,
+			Self::v7_to_v8,
+			Ok,
+		]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Self::v7_to_v5, Self::v5_to_v4, Ok, Ok, Ok]
+		vec![
+			Ok,
+			Self::v8_to_v7,
+			Self::v7_to_v5,
+			Self::v5_to_v4,
+			Ok,
+			Ok,
+			Ok,
+		]
 	}
 }
 
@@ -396,23 +424,40 @@ impl ToClientMk2 {
 			bail!("unexpected version");
 		}
 	}
+
+	fn v7_to_v8(self) -> Result<Self> {
+		if let ToClientMk2::V7(x) = self {
+			Ok(ToClientMk2::V8(transcode(x)?))
+		} else {
+			bail!("unexpected version");
+		}
+	}
+
+	fn v8_to_v7(self) -> Result<Self> {
+		if let ToClientMk2::V8(x) = self {
+			Ok(ToClientMk2::V7(transcode(x)?))
+		} else {
+			bail!("unexpected version");
+		}
+	}
 }
 
 pub enum ToServerMk2 {
 	V4(v4::ToServer),
 	V6(v6::ToServer),
 	V7(v7::ToServer),
+	V8(v8::ToServer),
 }
 
 impl OwnedVersionedData for ToServerMk2 {
-	type Latest = v7::ToServer;
+	type Latest = v8::ToServer;
 
-	fn wrap_latest(latest: v7::ToServer) -> Self {
-		ToServerMk2::V7(latest)
+	fn wrap_latest(latest: v8::ToServer) -> Self {
+		ToServerMk2::V8(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
-		if let ToServerMk2::V7(data) = self {
+		if let ToServerMk2::V8(data) = self {
 			Ok(data)
 		} else {
 			bail!("version not latest");
@@ -425,6 +470,7 @@ impl OwnedVersionedData for ToServerMk2 {
 			// v5 and v6 have the same ToServer binary format
 			5 | 6 => Ok(ToServerMk2::V6(serde_bare::from_slice(payload)?)),
 			7 => Ok(ToServerMk2::V7(serde_bare::from_slice(payload)?)),
+			8 => Ok(ToServerMk2::V8(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -434,17 +480,34 @@ impl OwnedVersionedData for ToServerMk2 {
 			ToServerMk2::V4(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ToServerMk2::V6(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ToServerMk2::V7(data) => serde_bare::to_vec(&data).map_err(Into::into),
+			ToServerMk2::V8(data) => serde_bare::to_vec(&data).map_err(Into::into),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
 		// No changes between v1 and v4, no changes between v5 and v6
-		vec![Ok, Ok, Ok, Self::v4_to_v6, Ok, Self::v6_to_v7]
+		vec![
+			Ok,
+			Ok,
+			Ok,
+			Self::v4_to_v6,
+			Ok,
+			Self::v6_to_v7,
+			Self::v7_to_v8,
+		]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
 		// No changes between v1 and v4, no changes between v5 and v6
-		vec![Self::v7_to_v6, Ok, Self::v6_to_v4, Ok, Ok, Ok]
+		vec![
+			Self::v8_to_v7,
+			Self::v7_to_v6,
+			Ok,
+			Self::v6_to_v4,
+			Ok,
+			Ok,
+			Ok,
+		]
 	}
 }
 
@@ -984,22 +1047,39 @@ impl ToServerMk2 {
 			bail!("unexpected version");
 		}
 	}
+
+	fn v7_to_v8(self) -> Result<Self> {
+		if let ToServerMk2::V7(x) = self {
+			Ok(ToServerMk2::V8(transcode(x)?))
+		} else {
+			bail!("unexpected version");
+		}
+	}
+
+	fn v8_to_v7(self) -> Result<Self> {
+		if let ToServerMk2::V8(x) = self {
+			Ok(ToServerMk2::V7(transcode(x)?))
+		} else {
+			bail!("unexpected version");
+		}
+	}
 }
 
 pub enum ToRunnerMk2 {
 	V4(v4::ToRunner),
 	V7(v7::ToRunner),
+	V8(v8::ToRunner),
 }
 
 impl OwnedVersionedData for ToRunnerMk2 {
-	type Latest = v7::ToRunner;
+	type Latest = v8::ToRunner;
 
-	fn wrap_latest(latest: v7::ToRunner) -> Self {
-		ToRunnerMk2::V7(latest)
+	fn wrap_latest(latest: v8::ToRunner) -> Self {
+		ToRunnerMk2::V8(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
-		if let ToRunnerMk2::V7(data) = self {
+		if let ToRunnerMk2::V8(data) = self {
 			Ok(data)
 		} else {
 			bail!("version not latest");
@@ -1010,6 +1090,7 @@ impl OwnedVersionedData for ToRunnerMk2 {
 		match version {
 			4 => Ok(ToRunnerMk2::V4(serde_bare::from_slice(payload)?)),
 			5 | 6 | 7 => Ok(ToRunnerMk2::V7(serde_bare::from_slice(payload)?)),
+			8 => Ok(ToRunnerMk2::V8(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -1018,15 +1099,16 @@ impl OwnedVersionedData for ToRunnerMk2 {
 		match self {
 			ToRunnerMk2::V4(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ToRunnerMk2::V7(data) => serde_bare::to_vec(&data).map_err(Into::into),
+			ToRunnerMk2::V8(data) => serde_bare::to_vec(&data).map_err(Into::into),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Self::v4_to_v7, Ok, Ok]
+		vec![Ok, Ok, Ok, Self::v4_to_v7, Ok, Ok, Self::v7_to_v8]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Self::v7_to_v4, Ok, Ok, Ok]
+		vec![Ok, Self::v8_to_v7, Ok, Self::v7_to_v4, Ok, Ok, Ok]
 	}
 }
 
@@ -1182,6 +1264,22 @@ impl ToRunnerMk2 {
 			};
 
 			Ok(ToRunnerMk2::V4(inner))
+		} else {
+			bail!("unexpected version");
+		}
+	}
+
+	fn v7_to_v8(self) -> Result<Self> {
+		if let ToRunnerMk2::V7(x) = self {
+			Ok(ToRunnerMk2::V8(transcode(x)?))
+		} else {
+			bail!("unexpected version");
+		}
+	}
+
+	fn v8_to_v7(self) -> Result<Self> {
+		if let ToRunnerMk2::V8(x) = self {
+			Ok(ToRunnerMk2::V7(transcode(x)?))
 		} else {
 			bail!("unexpected version");
 		}
@@ -1919,18 +2017,19 @@ impl OwnedVersionedData for ToRunner {
 pub enum ToGateway {
 	V3(v3::ToGateway),
 	V7(v7::ToGateway),
+	V8(v8::ToGateway),
 }
 
 impl OwnedVersionedData for ToGateway {
-	type Latest = v7::ToGateway;
+	type Latest = v8::ToGateway;
 
-	fn wrap_latest(latest: v7::ToGateway) -> Self {
-		ToGateway::V7(latest)
+	fn wrap_latest(latest: v8::ToGateway) -> Self {
+		ToGateway::V8(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
 		#[allow(irrefutable_let_patterns)]
-		if let ToGateway::V7(data) = self {
+		if let ToGateway::V8(data) = self {
 			Ok(data)
 		} else {
 			bail!("version not latest");
@@ -1941,6 +2040,7 @@ impl OwnedVersionedData for ToGateway {
 		match version {
 			1 | 2 | 3 => Ok(ToGateway::V3(serde_bare::from_slice(payload)?)),
 			4 | 5 | 6 | 7 => Ok(ToGateway::V7(serde_bare::from_slice(payload)?)),
+			8 => Ok(ToGateway::V8(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -1949,15 +2049,16 @@ impl OwnedVersionedData for ToGateway {
 		match self {
 			ToGateway::V3(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ToGateway::V7(data) => serde_bare::to_vec(&data).map_err(Into::into),
+			ToGateway::V8(data) => serde_bare::to_vec(&data).map_err(Into::into),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Self::v3_to_v7, Ok, Ok, Ok]
+		vec![Ok, Ok, Self::v3_to_v7, Ok, Ok, Ok, Self::v7_to_v8]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Self::v7_to_v3, Ok, Ok]
+		vec![Ok, Self::v8_to_v7, Ok, Ok, Self::v7_to_v3, Ok, Ok]
 	}
 }
 
@@ -1991,6 +2092,10 @@ impl ToGateway {
 		}
 	}
 
+	pub fn v3_to_v8(self) -> Result<Self> {
+		self.v3_to_v7()?.v7_to_v8()
+	}
+
 	fn v7_to_v3(self) -> Result<Self> {
 		if let ToGateway::V7(x) = self {
 			let inner = match x {
@@ -2019,23 +2124,40 @@ impl ToGateway {
 			bail!("unexpected version");
 		}
 	}
+
+	fn v7_to_v8(self) -> Result<Self> {
+		if let ToGateway::V7(x) = self {
+			Ok(ToGateway::V8(transcode(x)?))
+		} else {
+			bail!("unexpected version");
+		}
+	}
+
+	fn v8_to_v7(self) -> Result<Self> {
+		if let ToGateway::V8(x) = self {
+			Ok(ToGateway::V7(transcode(x)?))
+		} else {
+			bail!("unexpected version");
+		}
+	}
 }
 
 pub enum ToServerlessServer {
 	V3(v3::ToServerlessServer),
 	V7(v7::ToServerlessServer),
+	V8(v8::ToServerlessServer),
 }
 
 impl OwnedVersionedData for ToServerlessServer {
-	type Latest = v7::ToServerlessServer;
+	type Latest = v8::ToServerlessServer;
 
-	fn wrap_latest(latest: v7::ToServerlessServer) -> Self {
-		ToServerlessServer::V7(latest)
+	fn wrap_latest(latest: v8::ToServerlessServer) -> Self {
+		ToServerlessServer::V8(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
 		#[allow(irrefutable_let_patterns)]
-		if let ToServerlessServer::V7(data) = self {
+		if let ToServerlessServer::V8(data) = self {
 			Ok(data)
 		} else {
 			bail!("version not latest");
@@ -2046,6 +2168,7 @@ impl OwnedVersionedData for ToServerlessServer {
 		match version {
 			1 | 2 | 3 => Ok(ToServerlessServer::V3(serde_bare::from_slice(payload)?)),
 			4 | 5 | 6 | 7 => Ok(ToServerlessServer::V7(serde_bare::from_slice(payload)?)),
+			8 => Ok(ToServerlessServer::V8(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -2054,15 +2177,16 @@ impl OwnedVersionedData for ToServerlessServer {
 		match self {
 			ToServerlessServer::V3(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ToServerlessServer::V7(data) => serde_bare::to_vec(&data).map_err(Into::into),
+			ToServerlessServer::V8(data) => serde_bare::to_vec(&data).map_err(Into::into),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Self::v3_to_v7, Ok, Ok, Ok]
+		vec![Ok, Ok, Self::v3_to_v7, Ok, Ok, Ok, Self::v7_to_v8]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Self::v7_to_v3, Ok, Ok]
+		vec![Ok, Self::v8_to_v7, Ok, Ok, Self::v7_to_v3, Ok, Ok]
 	}
 }
 
@@ -2099,22 +2223,39 @@ impl ToServerlessServer {
 			bail!("unexpected version");
 		}
 	}
+
+	fn v7_to_v8(self) -> Result<Self> {
+		if let ToServerlessServer::V7(x) = self {
+			Ok(ToServerlessServer::V8(transcode(x)?))
+		} else {
+			bail!("unexpected version");
+		}
+	}
+
+	fn v8_to_v7(self) -> Result<Self> {
+		if let ToServerlessServer::V8(x) = self {
+			Ok(ToServerlessServer::V7(transcode(x)?))
+		} else {
+			bail!("unexpected version");
+		}
+	}
 }
 
 pub enum ActorCommandKeyData {
 	V4(v4::ActorCommandKeyData),
 	V7(v7::ActorCommandKeyData),
+	V8(v8::ActorCommandKeyData),
 }
 
 impl OwnedVersionedData for ActorCommandKeyData {
-	type Latest = v7::ActorCommandKeyData;
+	type Latest = v8::ActorCommandKeyData;
 
-	fn wrap_latest(latest: v7::ActorCommandKeyData) -> Self {
-		ActorCommandKeyData::V7(latest)
+	fn wrap_latest(latest: v8::ActorCommandKeyData) -> Self {
+		ActorCommandKeyData::V8(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
-		if let ActorCommandKeyData::V7(data) = self {
+		if let ActorCommandKeyData::V8(data) = self {
 			Ok(data)
 		} else {
 			bail!("version not latest");
@@ -2125,6 +2266,7 @@ impl OwnedVersionedData for ActorCommandKeyData {
 		match version {
 			4 => Ok(ActorCommandKeyData::V4(serde_bare::from_slice(payload)?)),
 			5 | 6 | 7 => Ok(ActorCommandKeyData::V7(serde_bare::from_slice(payload)?)),
+			8 => Ok(ActorCommandKeyData::V8(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -2133,15 +2275,16 @@ impl OwnedVersionedData for ActorCommandKeyData {
 		match self {
 			ActorCommandKeyData::V4(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ActorCommandKeyData::V7(data) => serde_bare::to_vec(&data).map_err(Into::into),
+			ActorCommandKeyData::V8(data) => serde_bare::to_vec(&data).map_err(Into::into),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Self::v4_to_v7, Ok, Ok]
+		vec![Ok, Ok, Ok, Self::v4_to_v7, Ok, Ok, Self::v7_to_v8]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Self::v7_to_v4, Ok, Ok, Ok]
+		vec![Ok, Self::v8_to_v7, Ok, Self::v7_to_v4, Ok, Ok, Ok]
 	}
 }
 
@@ -2209,6 +2352,22 @@ impl ActorCommandKeyData {
 			};
 
 			Ok(ActorCommandKeyData::V4(inner))
+		} else {
+			bail!("unexpected version");
+		}
+	}
+
+	fn v7_to_v8(self) -> Result<Self> {
+		if let ActorCommandKeyData::V7(x) = self {
+			Ok(ActorCommandKeyData::V8(transcode(x)?))
+		} else {
+			bail!("unexpected version");
+		}
+	}
+
+	fn v8_to_v7(self) -> Result<Self> {
+		if let ActorCommandKeyData::V8(x) = self {
+			Ok(ActorCommandKeyData::V7(transcode(x)?))
 		} else {
 			bail!("unexpected version");
 		}
@@ -3224,7 +3383,7 @@ fn convert_to_server_tunnel_message_kind_v4_to_v3(
 
 // Used specifically for the gateway because there were no changes between mk2 and mk1 for the tunnel messages
 pub fn to_client_tunnel_message_mk2_to_mk1(
-	msg: v7::ToClientTunnelMessage,
+	msg: v8::ToClientTunnelMessage,
 ) -> v3::ToClientTunnelMessage {
 	v3::ToClientTunnelMessage {
 		message_id: v3::MessageId {
@@ -3237,10 +3396,10 @@ pub fn to_client_tunnel_message_mk2_to_mk1(
 }
 
 fn convert_to_client_tunnel_message_kind_mk2_to_mk1(
-	kind: v7::ToClientTunnelMessageKind,
+	kind: v8::ToClientTunnelMessageKind,
 ) -> v3::ToClientTunnelMessageKind {
 	match kind {
-		v7::ToClientTunnelMessageKind::ToClientRequestStart(req) => {
+		v8::ToClientTunnelMessageKind::ToClientRequestStart(req) => {
 			v3::ToClientTunnelMessageKind::ToClientRequestStart(v3::ToClientRequestStart {
 				actor_id: req.actor_id,
 				method: req.method,
@@ -3250,29 +3409,29 @@ fn convert_to_client_tunnel_message_kind_mk2_to_mk1(
 				stream: req.stream,
 			})
 		}
-		v7::ToClientTunnelMessageKind::ToClientRequestChunk(chunk) => {
+		v8::ToClientTunnelMessageKind::ToClientRequestChunk(chunk) => {
 			v3::ToClientTunnelMessageKind::ToClientRequestChunk(v3::ToClientRequestChunk {
 				body: chunk.body,
 				finish: chunk.finish,
 			})
 		}
-		v7::ToClientTunnelMessageKind::ToClientRequestAbort => {
+		v8::ToClientTunnelMessageKind::ToClientRequestAbort => {
 			v3::ToClientTunnelMessageKind::ToClientRequestAbort
 		}
-		v7::ToClientTunnelMessageKind::ToClientWebSocketOpen(ws) => {
+		v8::ToClientTunnelMessageKind::ToClientWebSocketOpen(ws) => {
 			v3::ToClientTunnelMessageKind::ToClientWebSocketOpen(v3::ToClientWebSocketOpen {
 				actor_id: ws.actor_id,
 				path: ws.path,
 				headers: ws.headers,
 			})
 		}
-		v7::ToClientTunnelMessageKind::ToClientWebSocketMessage(msg) => {
+		v8::ToClientTunnelMessageKind::ToClientWebSocketMessage(msg) => {
 			v3::ToClientTunnelMessageKind::ToClientWebSocketMessage(v3::ToClientWebSocketMessage {
 				data: msg.data,
 				binary: msg.binary,
 			})
 		}
-		v7::ToClientTunnelMessageKind::ToClientWebSocketClose(close) => {
+		v8::ToClientTunnelMessageKind::ToClientWebSocketClose(close) => {
 			v3::ToClientTunnelMessageKind::ToClientWebSocketClose(v3::ToClientWebSocketClose {
 				code: close.code,
 				reason: close.reason,

--- a/engine/sdks/schemas/runner-protocol/v8.bare
+++ b/engine/sdks/schemas/runner-protocol/v8.bare
@@ -1,0 +1,448 @@
+# Runner Protocol v1
+
+# MARK: Core Primitives
+
+type Id str
+type Json str
+
+type GatewayId data[4]
+type RequestId data[4]
+type MessageIndex u16
+
+# MARK: KV
+
+# Basic types
+type KvKey data
+type KvValue data
+type KvMetadata struct {
+	version: data
+	updateTs: i64
+}
+
+# Query types
+type KvListAllQuery void
+type KvListRangeQuery struct {
+	start: KvKey
+	end: KvKey
+	exclusive: bool
+}
+
+type KvListPrefixQuery struct {
+	key: KvKey
+}
+
+type KvListQuery union {
+	KvListAllQuery |
+	KvListRangeQuery |
+	KvListPrefixQuery
+}
+
+# Request types
+type KvGetRequest struct {
+	keys: list<KvKey>
+}
+
+type KvListRequest struct {
+	query: KvListQuery
+	reverse: optional<bool>
+	limit: optional<u64>
+}
+
+type KvPutRequest struct {
+	keys: list<KvKey>
+	values: list<KvValue>
+}
+
+type KvDeleteRequest struct {
+	keys: list<KvKey>
+}
+
+type KvDeleteRangeRequest struct {
+	start: KvKey
+	end: KvKey
+}
+
+type KvDropRequest void
+
+# Response types
+type KvErrorResponse struct {
+	message: str
+}
+
+type KvGetResponse struct {
+	keys: list<KvKey>
+	values: list<KvValue>
+	metadata: list<KvMetadata>
+}
+
+type KvListResponse struct {
+	keys: list<KvKey>
+	values: list<KvValue>
+	metadata: list<KvMetadata>
+}
+
+type KvPutResponse void
+type KvDeleteResponse void
+type KvDropResponse void
+
+# Request/Response unions
+type KvRequestData union {
+	KvGetRequest |
+	KvListRequest |
+	KvPutRequest |
+	KvDeleteRequest |
+	KvDeleteRangeRequest |
+	KvDropRequest
+}
+
+type KvResponseData union {
+	KvErrorResponse |
+	KvGetResponse |
+	KvListResponse |
+	KvPutResponse |
+	KvDeleteResponse |
+	KvDropResponse
+}
+
+# MARK: Actor
+
+# Core
+type StopCode enum {
+	OK
+	ERROR
+}
+
+type ActorName struct {
+	metadata: Json
+}
+
+type ActorConfig struct {
+	name: str
+	key: optional<str>
+	createTs: i64
+	input: optional<data>
+}
+
+type ActorCheckpoint struct {
+	actorId: Id
+	generation: u32
+	index: i64
+}
+
+# Intent
+type ActorIntentSleep void
+
+type ActorIntentStop void
+
+type ActorIntent union {
+	ActorIntentSleep |
+	ActorIntentStop
+}
+
+# State
+type ActorStateRunning void
+
+type ActorStateStopped struct {
+	code: StopCode
+	message: optional<str>
+}
+
+type ActorState union {
+	ActorStateRunning |
+	ActorStateStopped
+}
+
+# MARK: Events
+type EventActorIntent struct {
+	intent: ActorIntent
+}
+
+type EventActorStateUpdate struct {
+	state: ActorState
+}
+
+type EventActorSetAlarm struct {
+	alarmTs: optional<i64>
+}
+
+type MetadataPatchEntry struct {
+	key: str
+	value: optional<str>
+}
+
+type EventActorPatchMetadata struct {
+	patch: list<MetadataPatchEntry>
+}
+
+type Event union {
+	EventActorIntent |
+	EventActorStateUpdate |
+	EventActorSetAlarm |
+	EventActorPatchMetadata
+}
+
+type EventWrapper struct {
+	checkpoint: ActorCheckpoint
+	inner: Event
+}
+
+# MARK: Commands
+
+type HibernatingRequest struct {
+	gatewayId: GatewayId
+	requestId: RequestId
+}
+
+type CommandStartActor struct {
+	config: ActorConfig
+	hibernatingRequests: list<HibernatingRequest>
+}
+
+type CommandStopActor void
+
+type Command union {
+	CommandStartActor |
+	CommandStopActor
+}
+
+type CommandWrapper struct {
+	checkpoint: ActorCheckpoint
+	inner: Command
+}
+
+# We redeclare this so its top level
+type ActorCommandKeyData union {
+	CommandStartActor |
+	CommandStopActor
+}
+
+# MARK: Tunnel
+
+# Message ID
+
+type MessageId struct {
+	# Globally unique ID
+	gatewayId: GatewayId
+	# Unique ID to the gateway
+	requestId: RequestId
+	# Unique ID to the request
+	messageIndex: MessageIndex
+}
+
+
+# HTTP
+type ToClientRequestStart struct {
+	actorId: Id
+	method: str
+	path: str
+	headers: map<str><str>
+	body: optional<data>
+	stream: bool
+}
+
+type ToClientRequestChunk struct {
+	body: data
+	finish: bool
+}
+
+type ToClientRequestAbort void
+
+type ToServerResponseStart struct {
+	status: u16
+	headers: map<str><str>
+	body: optional<data>
+	stream: bool
+}
+
+type ToServerResponseChunk struct {
+	body: data
+	finish: bool
+}
+
+type ToServerResponseAbort void
+
+# WebSocket
+type ToClientWebSocketOpen struct {
+	actorId: Id
+	path: str
+	headers: map<str><str>
+}
+
+type ToClientWebSocketMessage struct {
+	data: data
+	binary: bool
+}
+
+type ToClientWebSocketClose struct {
+	code: optional<u16>
+	reason: optional<str>
+}
+
+type ToServerWebSocketOpen struct {
+	canHibernate: bool
+}
+
+type ToServerWebSocketMessage struct {
+	data: data
+	binary: bool
+}
+
+type ToServerWebSocketMessageAck struct {
+	index: MessageIndex
+}
+
+type ToServerWebSocketClose struct {
+	code: optional<u16>
+	reason: optional<str>
+	hibernate: bool
+}
+
+# To Server
+type ToServerTunnelMessageKind union {
+	# HTTP
+	ToServerResponseStart |
+	ToServerResponseChunk |
+	ToServerResponseAbort |
+
+	# WebSocket
+	ToServerWebSocketOpen |
+	ToServerWebSocketMessage |
+	ToServerWebSocketMessageAck |
+	ToServerWebSocketClose
+}
+
+type ToServerTunnelMessage struct {
+	messageId: MessageId
+	messageKind: ToServerTunnelMessageKind
+}
+
+# To Client
+type ToClientTunnelMessageKind union {
+	# HTTP
+	ToClientRequestStart |
+	ToClientRequestChunk |
+	ToClientRequestAbort |
+
+	# WebSocket
+	ToClientWebSocketOpen |
+	ToClientWebSocketMessage |
+	ToClientWebSocketClose
+}
+
+type ToClientTunnelMessage struct {
+	messageId: MessageId
+	messageKind: ToClientTunnelMessageKind
+}
+
+type ToClientPing struct {
+	ts: i64
+}
+
+# MARK: To Server
+type ToServerInit struct {
+	name: str
+	version: u32
+	totalSlots: u32
+	prepopulateActorNames: optional<map<str><ActorName>>
+	metadata: optional<Json>
+}
+
+type ToServerEvents list<EventWrapper>
+
+type ToServerAckCommands struct {
+	lastCommandCheckpoints: list<ActorCheckpoint>
+}
+
+type ToServerStopping void
+
+type ToServerPong struct {
+	ts: i64
+}
+
+type ToServerKvRequest struct {
+	actorId: Id
+	requestId: u32
+	data: KvRequestData
+}
+
+type ToServer union {
+	ToServerInit |
+	ToServerEvents |
+	ToServerAckCommands |
+	ToServerStopping |
+	ToServerPong |
+	ToServerKvRequest |
+	ToServerTunnelMessage
+}
+
+# MARK: To Client
+type ProtocolMetadata struct {
+	runnerLostThreshold: i64
+	actorStopThreshold: i64
+	serverlessDrainGracePeriod: optional<i64>
+}
+
+type ToClientInit struct {
+	runnerId: Id
+	metadata: ProtocolMetadata
+}
+
+type ToClientCommands list<CommandWrapper>
+
+type ToClientAckEvents struct {
+	lastEventCheckpoints: list<ActorCheckpoint>
+}
+
+type ToClientKvResponse struct {
+	requestId: u32
+	data: KvResponseData
+}
+
+type ToClient union {
+	ToClientInit |
+	ToClientCommands |
+	ToClientAckEvents |
+	ToClientKvResponse |
+	ToClientTunnelMessage |
+	ToClientPing
+}
+
+# MARK: To Runner
+type ToRunnerPing struct {
+	gatewayId: GatewayId
+	requestId: RequestId
+	ts: i64
+}
+
+type ToRunnerClose void
+
+# We have to re-declare the entire union since BARE will not generate the
+# ser/de for ToClient if it's not a top-level type
+type ToRunner union {
+	ToRunnerPing |
+	ToRunnerClose |
+	ToClientCommands |
+	ToClientAckEvents |
+	ToClientTunnelMessage
+}
+
+# MARK: To Gateway
+type ToGatewayPong struct {
+	requestId: RequestId
+	ts: i64
+}
+
+type ToGateway union {
+	ToGatewayPong |
+	ToServerTunnelMessage
+}
+
+# MARK: Serverless
+type ToServerlessServerInit struct {
+	runnerId: Id
+	runnerProtocolVersion: u16
+}
+
+type ToServerlessServer union {
+	ToServerlessServerInit
+}

--- a/engine/sdks/typescript/runner-protocol/src/index.ts
+++ b/engine/sdks/typescript/runner-protocol/src/index.ts
@@ -806,10 +806,61 @@ export function writeEventActorSetAlarm(bc: bare.ByteCursor, x: EventActorSetAla
     write7(bc, x.alarmTs)
 }
 
+export type MetadataPatchEntry = {
+    readonly key: string
+    readonly value: string | null
+}
+
+export function readMetadataPatchEntry(bc: bare.ByteCursor): MetadataPatchEntry {
+    return {
+        key: bare.readString(bc),
+        value: read5(bc),
+    }
+}
+
+export function writeMetadataPatchEntry(bc: bare.ByteCursor, x: MetadataPatchEntry): void {
+    bare.writeString(bc, x.key)
+    write5(bc, x.value)
+}
+
+function readMetadataPatchEntryList(bc: bare.ByteCursor): readonly MetadataPatchEntry[] {
+    const len = bare.readUintSafe(bc)
+    if (len === 0) {
+        return []
+    }
+    const result = [readMetadataPatchEntry(bc)]
+    for (let i = 1; i < len; i++) {
+        result[i] = readMetadataPatchEntry(bc)
+    }
+    return result
+}
+
+function writeMetadataPatchEntryList(bc: bare.ByteCursor, x: readonly MetadataPatchEntry[]): void {
+    bare.writeUintSafe(bc, x.length)
+    for (let i = 0; i < x.length; i++) {
+        writeMetadataPatchEntry(bc, x[i])
+    }
+}
+
+export type EventActorPatchMetadata = {
+    readonly patch: readonly MetadataPatchEntry[]
+}
+
+export function readEventActorPatchMetadata(bc: bare.ByteCursor): EventActorPatchMetadata {
+    return {
+        patch: readMetadataPatchEntryList(bc),
+    }
+}
+
+export function writeEventActorPatchMetadata(bc: bare.ByteCursor, x: EventActorPatchMetadata): void {
+    writeMetadataPatchEntryList(bc, x.patch)
+}
+
 export type Event =
     | { readonly tag: "EventActorIntent"; readonly val: EventActorIntent }
     | { readonly tag: "EventActorStateUpdate"; readonly val: EventActorStateUpdate }
     | { readonly tag: "EventActorSetAlarm"; readonly val: EventActorSetAlarm }
+    | { readonly tag: "EventActorPatchMetadata"; readonly val: EventActorPatchMetadata }
 
 export function readEvent(bc: bare.ByteCursor): Event {
     const offset = bc.offset
@@ -821,6 +872,8 @@ export function readEvent(bc: bare.ByteCursor): Event {
             return { tag: "EventActorStateUpdate", val: readEventActorStateUpdate(bc) }
         case 2:
             return { tag: "EventActorSetAlarm", val: readEventActorSetAlarm(bc) }
+        case 3:
+            return { tag: "EventActorPatchMetadata", val: readEventActorPatchMetadata(bc) }
         default: {
             bc.offset = offset
             throw new bare.BareError(offset, "invalid tag")
@@ -843,6 +896,11 @@ export function writeEvent(bc: bare.ByteCursor, x: Event): void {
         case "EventActorSetAlarm": {
             bare.writeU8(bc, 2)
             writeEventActorSetAlarm(bc, x.val)
+            break
+        }
+        case "EventActorPatchMetadata": {
+            bare.writeU8(bc, 3)
+            writeEventActorPatchMetadata(bc, x.val)
             break
         }
     }

--- a/engine/sdks/typescript/runner/src/mod.ts
+++ b/engine/sdks/typescript/runner/src/mod.ts
@@ -21,7 +21,11 @@ export { RunnerActor, type ActorConfig };
 export { idToStr } from "./utils";
 
 const KV_EXPIRE: number = 30_000;
-const PROTOCOL_VERSION: number = 7;
+const PROTOCOL_VERSION: number = 8;
+const METADATA_KEY_REGEX = /^[a-z0-9._-]+$/;
+const METADATA_KEY_MAX_BYTES = 128;
+const METADATA_VALUE_MAX_BYTES = 4096;
+const UTF8_ENCODER = new TextEncoder();
 
 /** Warn once the backlog significantly exceeds the server's ack batch size. */
 const EVENT_BACKLOG_WARN_THRESHOLD = 10_000;
@@ -1624,6 +1628,69 @@ export class Runner {
 
 	clearAlarm(actorId: string, generation?: number) {
 		this.setAlarm(actorId, null, generation);
+	}
+
+	async patchMetadata(
+		actorId: string,
+		patch: Record<string, string | null>,
+		generation?: number,
+	): Promise<void> {
+		const actor = this.getActor(actorId, generation);
+		if (!actor) return;
+
+		const entries = Object.entries(patch);
+		if (entries.length === 0) {
+			throw new Error("Metadata patch cannot be empty");
+		}
+
+		const metadataPatch: protocol.MetadataPatchEntry[] = entries.map(
+			([key, value]) => {
+				const keyBytes = UTF8_ENCODER.encode(key).length;
+				if (keyBytes === 0) {
+					throw new Error("Metadata key cannot be empty");
+				}
+				if (keyBytes > METADATA_KEY_MAX_BYTES) {
+					throw new Error("Metadata key is too large");
+				}
+				if (!METADATA_KEY_REGEX.test(key)) {
+					throw new Error(`Invalid metadata key: ${key}`);
+				}
+				if (
+					value !== null &&
+					UTF8_ENCODER.encode(value).length > METADATA_VALUE_MAX_BYTES
+				) {
+					throw new Error(`Metadata value is too large for key: ${key}`);
+				}
+
+				return {
+					key,
+					value,
+				};
+			},
+		);
+
+		const metadataPatchEvent: protocol.EventActorPatchMetadata = {
+			patch: metadataPatch,
+		};
+
+		const eventWrapper: protocol.EventWrapper = {
+			checkpoint: {
+				actorId,
+				generation: actor.generation,
+				index: actor.nextEventIdx++,
+			},
+			inner: {
+				tag: "EventActorPatchMetadata",
+				val: metadataPatchEvent,
+			},
+		};
+
+		this.#recordEvent(eventWrapper);
+
+		this.__sendToServer({
+			tag: "ToServerEvents",
+			val: [eventWrapper],
+		});
 	}
 
 	#sendKvRequest(

--- a/engine/sdks/typescript/runner/src/stringify.ts
+++ b/engine/sdks/typescript/runner/src/stringify.ts
@@ -179,6 +179,15 @@ export function stringifyEvent(event: protocol.Event): string {
 				alarmTs === null ? "null" : stringifyBigInt(alarmTs);
 			return `EventActorSetAlarm{alarmTs: ${alarmTsStr}}`;
 		}
+		case "EventActorPatchMetadata": {
+			const patch = event.val.patch
+				.map(
+					(entry) =>
+						`{key: "${entry.key}", value: ${entry.value === null ? "null" : `"${entry.value}"`}}`,
+				)
+				.join(", ");
+			return `EventActorPatchMetadata{patch: [${patch}]}`;
+		}
 	}
 }
 

--- a/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/metadata.ts
+++ b/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/metadata.ts
@@ -67,6 +67,13 @@ export const metadataActor = actor({
 			return c.state.actorName;
 		},
 
+		patchMetadata: async (
+			c,
+			patch: Record<string, string | null>,
+		) => {
+			await c.patchMetadata(patch);
+		},
+
 		// Get last retrieved metadata
 		getLastMetadata: (c) => {
 			return c.state.lastMetadata;

--- a/rivetkit-typescript/packages/rivetkit/src/actor/contexts/base/actor.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/contexts/base/actor.ts
@@ -223,6 +223,12 @@ export class ActorContext<
 		return this.#actor.schedule;
 	}
 
+	async patchMetadata(
+		patch: Record<string, string | null>,
+	): Promise<void> {
+		await this.#actor.driver.patchMetadata(this.#actor, patch);
+	}
+
 	/**
 	 * Gets the map of connections.
 	 */

--- a/rivetkit-typescript/packages/rivetkit/src/actor/driver.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/driver.ts
@@ -68,6 +68,10 @@ export interface ActorDriver {
 	// Schedule
 	/** ActorInstance ensure that only one instance of setAlarm is called in parallel at a time. */
 	setAlarm(actor: AnyActorInstance, timestamp: number): Promise<void>;
+	patchMetadata(
+		actor: AnyActorInstance,
+		patch: Record<string, string | null>,
+	): Promise<void>;
 
 	// Database
 	/**

--- a/rivetkit-typescript/packages/rivetkit/src/driver-test-suite/test-inline-client-driver.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/driver-test-suite/test-inline-client-driver.ts
@@ -80,6 +80,15 @@ export function createTestInlineClientDriver(
 		listActors(input: ListActorsInput): Promise<ActorOutput[]> {
 			return makeInlineRequest(endpoint, encoding, "listActors", [input]);
 		},
+		patchMetadata(
+			actorId: string,
+			patch: Record<string, string | null>,
+		): Promise<void> {
+			return makeInlineRequest(endpoint, encoding, "patchMetadata", [
+				actorId,
+				patch,
+			]);
+		},
 		async sendRequest(
 			actorId: string,
 			actorRequest: Request,

--- a/rivetkit-typescript/packages/rivetkit/src/driver-test-suite/tests/actor-metadata.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/driver-test-suite/tests/actor-metadata.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "vitest";
+import { serializeActorKey } from "@/actor/keys";
+import type { ActorsListResponse } from "@/manager-api/actors";
 import type { DriverTestConfig } from "../mod";
 import { setupDriverTest } from "../utils";
 
@@ -112,5 +114,212 @@ export function runActorMetadataTests(driverTestConfig: DriverTestConfig) {
 				expect(region).toBe("eu-central-1");
 			});
 		});
+
+		describe("Metadata Patching", () => {
+			test("should patch metadata from inside the actor and return full metadata for actor_id lookups", async (c) => {
+				const { client, endpoint, namespace } = await setupDriverTest(
+					c,
+					driverTestConfig,
+				);
+
+				const handle = client.metadataActor.getOrCreate([
+					`metadata-${crypto.randomUUID()}`,
+				]);
+				const actorId = await handle.resolve();
+
+				await handle.patchMetadata({
+					workflow_state: "failed",
+					workflow_reason: "generate_report_failed",
+				});
+
+				const response = await fetchActors(
+					endpoint,
+					buildQueryParams({
+						namespace,
+						actor_ids: actorId,
+					}),
+				);
+				const actor = response.actors.find(
+					(candidate) => candidate.actor_id === actorId,
+				);
+
+				expect(actor?.metadata).toEqual({
+					workflow_state: "failed",
+					workflow_reason: "generate_report_failed",
+				});
+			});
+
+			test("should patch metadata over rest and support overwrite and delete", async (c) => {
+				const { client, endpoint, namespace } = await setupDriverTest(
+					c,
+					driverTestConfig,
+				);
+
+				const key = [`metadata-${crypto.randomUUID()}`];
+				const handle = client.metadataActor.getOrCreate(key);
+				const actorId = await handle.resolve();
+
+				await sendMetadataPatch(endpoint, namespace, actorId, {
+					workflow_state: "running",
+					old_key: "stale",
+				});
+				await sendMetadataPatch(endpoint, namespace, actorId, {
+					workflow_state: "failed",
+					last_error: "timeout",
+					old_key: null,
+				});
+
+				const response = await fetchActors(
+					endpoint,
+					buildQueryParams({
+						namespace,
+						name: "metadataActor",
+						key: serializeActorKey(key),
+					}),
+				);
+
+				expect(response.actors[0]?.metadata).toEqual({
+					workflow_state: "failed",
+					last_error: "timeout",
+				});
+			});
+
+			test("should omit metadata by default and project only requested keys for list queries", async (c) => {
+				const { client, endpoint, namespace } = await setupDriverTest(
+					c,
+					driverTestConfig,
+				);
+
+				const handle = client.metadataActor.getOrCreate([
+					`metadata-${crypto.randomUUID()}`,
+				]);
+				const actorId = await handle.resolve();
+
+				await sendMetadataPatch(endpoint, namespace, actorId, {
+					workflow_state: "failed",
+					last_error: "timeout",
+				});
+
+				const unprojected = await fetchActors(
+					endpoint,
+					buildQueryParams({
+						namespace,
+						name: "metadataActor",
+					}),
+				);
+				expect(findActor(unprojected, actorId)?.metadata).toBeUndefined();
+
+				const projected = await fetchActors(
+					endpoint,
+					buildQueryParams(
+						{
+							namespace,
+							name: "metadataActor",
+						},
+						["workflow_state", "missing_key"],
+					),
+				);
+				expect(findActor(projected, actorId)?.metadata).toEqual({
+					workflow_state: "failed",
+				});
+
+				const emptyProjection = await fetchActors(
+					endpoint,
+					buildQueryParams(
+						{
+							namespace,
+							name: "metadataActor",
+						},
+						["missing_key"],
+					),
+				);
+				expect(findActor(emptyProjection, actorId)?.metadata).toEqual({});
+			});
+
+			test("should reject list queries with too many metadata keys", async (c) => {
+				const { endpoint, namespace } = await setupDriverTest(
+					c,
+					driverTestConfig,
+				);
+
+				const response = await fetch(
+					buildManagerUrl(
+						endpoint,
+						"/actors",
+						buildQueryParams(
+							{
+								namespace,
+								name: "metadataActor",
+							},
+							Array.from({ length: 17 }, (_, i) => `k${i}`),
+						),
+					),
+				);
+
+				expect(response.status).toBe(400);
+			});
+		});
 	});
+}
+
+function buildQueryParams(
+	values: Record<string, string>,
+	metadataKeys: string[] = [],
+): URLSearchParams {
+	const query = new URLSearchParams(values);
+	for (const metadataKey of metadataKeys) {
+		query.append("metadata_key", metadataKey);
+	}
+	return query;
+}
+
+function buildManagerUrl(
+	endpoint: string,
+	path: string,
+	query?: URLSearchParams,
+): string {
+	const normalizedEndpoint = endpoint.endsWith("/")
+		? endpoint.slice(0, -1)
+		: endpoint;
+	return `${normalizedEndpoint}${path}${query ? `?${query.toString()}` : ""}`;
+}
+
+async function fetchActors(
+	endpoint: string,
+	query: URLSearchParams,
+): Promise<ActorsListResponse> {
+	const response = await fetch(buildManagerUrl(endpoint, "/actors", query));
+	expect(response.ok).toBe(true);
+	return (await response.json()) as ActorsListResponse;
+}
+
+async function sendMetadataPatch(
+	endpoint: string,
+	namespace: string,
+	actorId: string,
+	metadata: Record<string, string | null>,
+): Promise<void> {
+	const response = await fetch(
+		buildManagerUrl(
+			endpoint,
+			`/actors/${encodeURIComponent(actorId)}/metadata`,
+			buildQueryParams({ namespace }),
+		),
+		{
+			method: "PATCH",
+			headers: {
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({ metadata }),
+		},
+	);
+
+	expect(response.ok).toBe(true);
+}
+
+function findActor(
+	response: ActorsListResponse,
+	actorId: string,
+) {
+	return response.actors.find((actor) => actor.actor_id === actorId);
 }

--- a/rivetkit-typescript/packages/rivetkit/src/driver-test-suite/utils.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/driver-test-suite/utils.ts
@@ -17,6 +17,7 @@ export async function setupDriverTest(
 ): Promise<{
 	client: Client<typeof registry>;
 	endpoint: string;
+	namespace: string;
 }> {
 	if (!driverTestConfig.useRealTimers) {
 		vi.useFakeTimers();
@@ -64,6 +65,7 @@ export async function setupDriverTest(
 	return {
 		client,
 		endpoint,
+		namespace,
 	};
 }
 

--- a/rivetkit-typescript/packages/rivetkit/src/drivers/engine/actor-driver.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/drivers/engine/actor-driver.ts
@@ -247,6 +247,13 @@ export class EngineActorDriver implements ActorDriver {
 		this.#runner.setAlarm(actor.id, timestamp);
 	}
 
+	async patchMetadata(
+		actor: AnyActorInstance,
+		patch: Record<string, string | null>,
+	): Promise<void> {
+		await this.#runner.patchMetadata(actor.id, patch);
+	}
+
 	// No database overrides - will use KV-backed implementation from rivetkit/db
 
 	// MARK: - Batch KV operations

--- a/rivetkit-typescript/packages/rivetkit/src/drivers/file-system/actor.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/drivers/file-system/actor.ts
@@ -116,6 +116,13 @@ export class FileSystemActorDriver implements ActorDriver {
 		await this.#state.setActorAlarm(actor.id, timestamp);
 	}
 
+	async patchMetadata(
+		actor: AnyActorInstance,
+		patch: Record<string, string | null>,
+	): Promise<void> {
+		await this.#state.patchActorMetadata(actor.id, patch);
+	}
+
 	/** Creates a SQLite VFS instance for creating KV-backed databases */
 	async createSqliteVfs(): Promise<SqliteVfs> {
 		return await importSqliteVfs();

--- a/rivetkit-typescript/packages/rivetkit/src/drivers/file-system/global-state.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/drivers/file-system/global-state.ts
@@ -1,6 +1,9 @@
 import invariant from "invariant";
 import { lookupInRegistry } from "@/actor/definition";
-import { ActorDuplicateKey } from "@/actor/errors";
+import {
+	ActorDuplicateKey,
+	ActorNotFound,
+} from "@/actor/errors";
 import type { AnyActorInstance } from "@/actor/instance/mod";
 import type { ActorKey } from "@/actor/mod";
 import type { AnyClient } from "@/client/client";
@@ -43,6 +46,10 @@ import {
 	validateKvKey,
 	validateKvKeys,
 } from "./kv-limits";
+import {
+	validateMetadataMap,
+	validateMetadataPatchEntries,
+} from "./metadata-limits";
 
 const DEFAULT_LIST_LIMIT = 16_384;
 
@@ -70,6 +77,8 @@ interface ActorEntry {
 	id: string;
 
 	state?: schema.ActorState;
+	metadata?: Record<string, string>;
+	metadataLoaded?: boolean;
 
 	/** Promise for loading the actor state. */
 	loadPromise?: Promise<ActorEntry>;
@@ -112,6 +121,7 @@ export class FileSystemGlobalState {
 	#stateDir: string;
 	#dbsDir: string;
 	#alarmsDir: string;
+	#metadataDir: string;
 
 	#persist: boolean;
 	#sqliteRuntime: SqliteRuntime;
@@ -156,12 +166,14 @@ export class FileSystemGlobalState {
 		this.#stateDir = path.join(this.#storagePath, "state");
 		this.#dbsDir = path.join(this.#storagePath, "databases");
 		this.#alarmsDir = path.join(this.#storagePath, "alarms");
+		this.#metadataDir = path.join(this.#storagePath, "metadata");
 
 		if (this.#persist) {
 			// Ensure storage directories exist synchronously during initialization
 			ensureDirectoryExistsSync(this.#stateDir);
 			ensureDirectoryExistsSync(this.#dbsDir);
 			ensureDirectoryExistsSync(this.#alarmsDir);
+			ensureDirectoryExistsSync(this.#metadataDir);
 
 			try {
 				const fsSync = getNodeFsSync();
@@ -215,6 +227,10 @@ export class FileSystemGlobalState {
 
 	getActorAlarmPath(actorId: string): string {
 		return getNodePath().join(this.#alarmsDir, actorId);
+	}
+
+	getActorMetadataPath(actorId: string): string {
+		return getNodePath().join(this.#metadataDir, `${actorId}.json`);
 	}
 
 	#getActorKvDatabasePath(actorId: string): string {
@@ -415,6 +431,8 @@ export class FileSystemGlobalState {
 
 		entry = {
 			id: actorId,
+			metadata: this.#persist ? undefined : {},
+			metadataLoaded: !this.#persist,
 			lifecycleState: ActorLifecycleState.NONEXISTENT,
 			generation: crypto.randomUUID(),
 		};
@@ -467,6 +485,8 @@ export class FileSystemGlobalState {
 				sleepTs: null,
 				destroyTs: null,
 			};
+			lockedEntry.metadata = {};
+			lockedEntry.metadataLoaded = true;
 			lockedEntry.lifecycleState = ActorLifecycleState.AWAKE;
 			if (this.#persist) {
 				await this.#performWrite(
@@ -590,6 +610,8 @@ export class FileSystemGlobalState {
 					sleepTs: null,
 					destroyTs: null,
 				};
+				lockedEntry.metadata = {};
+				lockedEntry.metadataLoaded = true;
 				if (this.#persist) {
 					await this.#performWrite(
 						actorId,
@@ -760,6 +782,20 @@ export class FileSystemGlobalState {
 							}
 						}
 					})(),
+					// Delete actor metadata file
+					(async () => {
+						try {
+							await fs.unlink(this.getActorMetadataPath(actorId));
+						} catch (err: any) {
+							if (err?.code !== "ENOENT") {
+								logger().error({
+									msg: "failed to delete actor metadata file",
+									actorId,
+									error: stringifyError(err),
+								});
+							}
+						}
+					})(),
 					// Delete actor alarm file
 					(async () => {
 						try {
@@ -792,6 +828,8 @@ export class FileSystemGlobalState {
 			actor.startPromise = undefined;
 			actor.alarmTimeout = undefined;
 			actor.alarmTimeout = undefined;
+			actor.metadata = undefined;
+			actor.metadataLoaded = false;
 			actor.pendingWriteResolver = undefined;
 			actor.lifecycleState = ActorLifecycleState.DESTROYED;
 		}
@@ -1168,6 +1206,56 @@ export class FileSystemGlobalState {
 		return state;
 	}
 
+	async readActorMetadata(actorId: string): Promise<Record<string, string>> {
+		await this.#waitForActorStop(actorId);
+		await this.loadActor(actorId);
+
+		return await this.#withActorWrite(actorId, async (entry) => {
+			if (!entry.state) {
+				throw new ActorNotFound(actorId);
+			}
+
+			return { ...(await this.#loadActorMetadata(entry)) };
+		});
+	}
+
+	async patchActorMetadata(
+		actorId: string,
+		patch: Record<string, string | null>,
+	): Promise<void> {
+		const entries = Object.entries(patch);
+		validateMetadataPatchEntries(entries);
+
+		await this.#waitForActorStop(actorId);
+		await this.loadActor(actorId);
+
+		await this.#withActorWrite(actorId, async (entry) => {
+			if (!entry.state) {
+				throw new ActorNotFound(actorId);
+			}
+
+			const nextMetadata = {
+				...(await this.#loadActorMetadata(entry)),
+			};
+			for (const [key, value] of entries) {
+				if (value === null) {
+					delete nextMetadata[key];
+				} else {
+					nextMetadata[key] = value;
+				}
+			}
+
+			validateMetadataMap(nextMetadata);
+			await this.#writeActorMetadata(
+				entry.id,
+				entry.generation,
+				nextMetadata,
+			);
+			entry.metadata = nextMetadata;
+			entry.metadataLoaded = true;
+		});
+	}
+
 	getActorOrError(actorId: string): ActorEntry {
 		const entry = this.#actors.get(actorId);
 		if (!entry) throw new Error(`No entry for actor: ${actorId}`);
@@ -1176,6 +1264,106 @@ export class FileSystemGlobalState {
 
 	async createDatabase(actorId: string): Promise<string | undefined> {
 		return this.getActorDbPath(actorId);
+	}
+
+	async #loadActorMetadata(entry: ActorEntry): Promise<Record<string, string>> {
+		if (entry.metadataLoaded) {
+			return entry.metadata ?? {};
+		}
+
+		entry.metadata = await this.#readPersistedActorMetadata(entry.id);
+		entry.metadataLoaded = true;
+		return entry.metadata;
+	}
+
+	async #readPersistedActorMetadata(
+		actorId: string,
+	): Promise<Record<string, string>> {
+		if (!this.#persist) {
+			return {};
+		}
+
+		try {
+			const raw = await getNodeFs().readFile(
+				this.getActorMetadataPath(actorId),
+				"utf8",
+			);
+			const parsed = JSON.parse(raw) as unknown;
+			if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+				throw new Error("metadata file must contain an object");
+			}
+
+			const metadata = Object.fromEntries(
+				Object.entries(parsed).map(([key, value]) => {
+					if (typeof value !== "string") {
+						throw new Error(
+							`metadata value for key '${key}' must be a string`,
+						);
+					}
+
+					return [key, value];
+				}),
+			) as Record<string, string>;
+			validateMetadataMap(metadata);
+			return metadata;
+		} catch (error: any) {
+			if (error?.code === "ENOENT") {
+				return {};
+			}
+
+			throw error;
+		}
+	}
+
+	async #writeActorMetadata(
+		actorId: string,
+		generation: string,
+		metadata: Record<string, string>,
+	): Promise<void> {
+		if (!this.#persist) {
+			return;
+		}
+
+		const metadataPath = this.getActorMetadataPath(actorId);
+		const crypto = getNodeCrypto();
+		const tempPath = `${metadataPath}.tmp.${crypto.randomUUID()}`;
+
+		try {
+			await ensureDirectoryExists(getNodePath().dirname(metadataPath));
+
+			if (Object.keys(metadata).length === 0) {
+				if (!this.isGenerationCurrentAndNotDestroyed(actorId, generation)) {
+					return;
+				}
+
+				try {
+					await getNodeFs().unlink(metadataPath);
+				} catch (error: any) {
+					if (error?.code !== "ENOENT") {
+						throw error;
+					}
+				}
+
+				return;
+			}
+
+			await getNodeFs().writeFile(tempPath, JSON.stringify(metadata));
+
+			if (!this.isGenerationCurrentAndNotDestroyed(actorId, generation)) {
+				try {
+					await getNodeFs().unlink(tempPath);
+				} catch { }
+				return;
+			}
+
+			await getNodeFs().rename(tempPath, metadataPath);
+		} catch (error) {
+			try {
+				await getNodeFs().unlink(tempPath);
+			} catch { }
+
+			throw error;
+		}
 	}
 
 	/**
@@ -1308,40 +1496,45 @@ export class FileSystemGlobalState {
 	 * Cleanup stale temp files on startup (synchronous)
 	 */
 	#cleanupTempFilesSync(): void {
-		try {
-			const fsSync = getNodeFsSync();
-			const files = fsSync.readdirSync(this.#stateDir);
-			const tempFiles = files.filter((f) => f.includes(".tmp."));
+		const directories = [this.#stateDir, this.#metadataDir, this.#alarmsDir];
+		const fsSync = getNodeFsSync();
+		const path = getNodePath();
+		const oneHourAgo = Date.now() - 3600000; // 1 hour in ms
 
-			const oneHourAgo = Date.now() - 3600000; // 1 hour in ms
+		for (const directory of directories) {
+			try {
+				const files = fsSync.existsSync(directory)
+					? fsSync.readdirSync(directory)
+					: [];
+				const tempFiles = files.filter((f) => f.includes(".tmp."));
 
-			for (const tempFile of tempFiles) {
-				try {
-					const path = getNodePath();
-					const fullPath = path.join(this.#stateDir, tempFile);
-					const stat = fsSync.statSync(fullPath);
+				for (const tempFile of tempFiles) {
+					try {
+						const fullPath = path.join(directory, tempFile);
+						const stat = fsSync.statSync(fullPath);
 
-					// Remove if older than 1 hour
-					if (stat.mtimeMs < oneHourAgo) {
-						fsSync.unlinkSync(fullPath);
-						logger().info({
-							msg: "cleaned up stale temp file",
+						if (stat.mtimeMs < oneHourAgo) {
+							fsSync.unlinkSync(fullPath);
+							logger().info({
+								msg: "cleaned up stale temp file",
+								file: tempFile,
+							});
+						}
+					} catch (err) {
+						logger().debug({
+							msg: "failed to cleanup temp file",
 							file: tempFile,
+							error: err,
 						});
 					}
-				} catch (err) {
-					logger().debug({
-						msg: "failed to cleanup temp file",
-						file: tempFile,
-						error: err,
-					});
 				}
+			} catch (err) {
+				logger().error({
+					msg: "failed to read actors directory for cleanup",
+					directory,
+					error: err,
+				});
 			}
-		} catch (err) {
-			logger().error({
-				msg: "failed to read actors directory for cleanup",
-				error: err,
-			});
 		}
 	}
 

--- a/rivetkit-typescript/packages/rivetkit/src/drivers/file-system/manager.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/drivers/file-system/manager.ts
@@ -24,6 +24,10 @@ import type * as schema from "@/schemas/file-system-driver/mod";
 import type { GetUpgradeWebSocket } from "@/utils";
 import type { FileSystemGlobalState } from "./global-state";
 import { logger } from "./log";
+import {
+	projectMetadata,
+	validateMetadataProjectionKeys,
+} from "./metadata-limits";
 import { generateActorId } from "./utils";
 
 export class FileSystemManagerDriver implements ManagerDriver {
@@ -166,7 +170,10 @@ export class FileSystemManagerDriver implements ManagerDriver {
 			throw new ActorStopping(actorId);
 		}
 
-		return actorStateToOutput(actor.state);
+		return actorStateToOutput(
+			actor.state,
+			await this.#state.readActorMetadata(actorId),
+		);
 	}
 
 	async getWithKey({
@@ -179,7 +186,10 @@ export class FileSystemManagerDriver implements ManagerDriver {
 		// Check if actor exists
 		const actor = await this.#state.loadActor(actorId);
 		if (actor.state) {
-			return actorStateToOutput(actor.state);
+			return actorStateToOutput(
+				actor.state,
+				await this.#state.readActorMetadata(actorId),
+			);
 		}
 
 		return undefined;
@@ -221,13 +231,27 @@ export class FileSystemManagerDriver implements ManagerDriver {
 		return actorStateToOutput(state);
 	}
 
-	async listActors({ name }: ListActorsInput): Promise<ActorOutput[]> {
+	async listActors({
+		name,
+		metadataKeys,
+	}: ListActorsInput): Promise<ActorOutput[]> {
+		if (metadataKeys && metadataKeys.length > 0) {
+			validateMetadataProjectionKeys(metadataKeys);
+		}
+
 		const actors: ActorOutput[] = [];
 		const itr = this.#state.getActorsIterator({});
+		const includeMetadata = (metadataKeys?.length ?? 0) > 0;
 
 		for await (const actor of itr) {
 			if (actor.name === name) {
-				actors.push(actorStateToOutput(actor));
+				const metadata = includeMetadata
+					? projectMetadata(
+							await this.#state.readActorMetadata(actor.actorId),
+							metadataKeys ?? [],
+						)
+					: undefined;
+				actors.push(actorStateToOutput(actor, metadata));
 			}
 		}
 
@@ -239,6 +263,13 @@ export class FileSystemManagerDriver implements ManagerDriver {
 		});
 
 		return actors;
+	}
+
+	async patchMetadata(
+		actorId: string,
+		patch: Record<string, string | null>,
+	): Promise<void> {
+		await this.#state.patchActorMetadata(actorId, patch);
 	}
 
 	async kvGet(actorId: string, key: Uint8Array): Promise<string | null> {
@@ -271,7 +302,10 @@ export class FileSystemManagerDriver implements ManagerDriver {
 	}
 }
 
-function actorStateToOutput(state: schema.ActorState): ActorOutput {
+function actorStateToOutput(
+	state: schema.ActorState,
+	metadata?: Record<string, string>,
+): ActorOutput {
 	return {
 		actorId: state.actorId,
 		name: state.name,
@@ -282,6 +316,7 @@ function actorStateToOutput(state: schema.ActorState): ActorOutput {
 			state.connectableTs !== null ? Number(state.connectableTs) : null,
 		sleepTs: state.sleepTs !== null ? Number(state.sleepTs) : null,
 		destroyTs: state.destroyTs !== null ? Number(state.destroyTs) : null,
+		metadata,
 	};
 }
 

--- a/rivetkit-typescript/packages/rivetkit/src/drivers/file-system/metadata-limits.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/drivers/file-system/metadata-limits.ts
@@ -1,0 +1,101 @@
+import { InvalidParams } from "@/actor/errors";
+
+export const METADATA_KEY_REGEX = /^[a-z0-9._-]+$/;
+export const METADATA_KEY_MAX_BYTES = 128;
+export const METADATA_VALUE_MAX_BYTES = 4096;
+export const METADATA_TOTAL_MAX_BYTES = 16 * 1024;
+export const METADATA_LIST_MAX_KEYS = 16;
+
+const UTF8_ENCODER = new TextEncoder();
+
+export function validateMetadataProjectionKeys(keys: string[]): void {
+	if (keys.length > METADATA_LIST_MAX_KEYS) {
+		throw new InvalidParams(
+			`a maximum of ${METADATA_LIST_MAX_KEYS} metadata keys is allowed`,
+		);
+	}
+
+	for (const key of keys) {
+		validateMetadataKey(key);
+	}
+}
+
+export function validateMetadataPatchEntries(
+	entries: [string, string | null][],
+): void {
+	if (entries.length === 0) {
+		throw new InvalidParams("metadata patch cannot be empty");
+	}
+
+	for (const [key, value] of entries) {
+		validateMetadataKey(key);
+
+		if (
+			value !== null &&
+			UTF8_ENCODER.encode(value).length > METADATA_VALUE_MAX_BYTES
+		) {
+			throw new InvalidParams(
+				`metadata value is too large for key '${key}' (max ${METADATA_VALUE_MAX_BYTES} bytes)`,
+			);
+		}
+	}
+}
+
+export function validateMetadataMap(
+	metadata: Record<string, string>,
+): void {
+	let totalSize = 0;
+
+	for (const [key, value] of Object.entries(metadata)) {
+		validateMetadataKey(key);
+
+		if (UTF8_ENCODER.encode(value).length > METADATA_VALUE_MAX_BYTES) {
+			throw new InvalidParams(
+				`metadata value is too large for key '${key}' (max ${METADATA_VALUE_MAX_BYTES} bytes)`,
+			);
+		}
+
+		totalSize +=
+			UTF8_ENCODER.encode(key).length + UTF8_ENCODER.encode(value).length;
+	}
+
+	if (totalSize > METADATA_TOTAL_MAX_BYTES) {
+		throw new InvalidParams(
+			`metadata is too large (max ${METADATA_TOTAL_MAX_BYTES} bytes)`,
+		);
+	}
+}
+
+export function projectMetadata(
+	metadata: Record<string, string>,
+	keys: string[],
+): Record<string, string> {
+	const projected: Record<string, string> = {};
+
+	for (const key of keys) {
+		const value = metadata[key];
+		if (value !== undefined) {
+			projected[key] = value;
+		}
+	}
+
+	return projected;
+}
+
+function validateMetadataKey(key: string): void {
+	const keyBytes = UTF8_ENCODER.encode(key).length;
+
+	if (keyBytes === 0) {
+		throw new InvalidParams("metadata key cannot be empty");
+	}
+
+	if (keyBytes > METADATA_KEY_MAX_BYTES) {
+		throw new InvalidParams(
+			`metadata key is too large (max ${METADATA_KEY_MAX_BYTES} bytes)`,
+		);
+	}
+
+	if (!METADATA_KEY_REGEX.test(key)) {
+		throw new InvalidParams(`invalid metadata key: ${key}`);
+	}
+}

--- a/rivetkit-typescript/packages/rivetkit/src/manager-api/actors.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/manager-api/actors.ts
@@ -13,6 +13,7 @@ export const ActorSchema = z.object({
 	sleep_ts: z.number().nullable().optional(),
 	start_ts: z.number().nullable().optional(),
 	error: z.unknown().nullable().optional(),
+	metadata: z.record(z.string(), z.string()).optional(),
 });
 export type Actor = z.infer<typeof ActorSchema>;
 
@@ -81,3 +82,16 @@ export const ActorsKvGetResponseSchema = z.object({
 	value: z.string().nullable(),
 });
 export type ActorsKvGetResponse = z.infer<typeof ActorsKvGetResponseSchema>;
+
+// MARK: PATCH /actors/{actor_id}/metadata
+export const ActorsPatchMetadataRequestSchema = z.object({
+	metadata: z.record(z.string(), z.string().nullable()),
+});
+export type ActorsPatchMetadataRequest = z.infer<
+	typeof ActorsPatchMetadataRequestSchema
+>;
+
+export const ActorsPatchMetadataResponseSchema = z.object({});
+export type ActorsPatchMetadataResponse = z.infer<
+	typeof ActorsPatchMetadataResponseSchema
+>;

--- a/rivetkit-typescript/packages/rivetkit/src/manager/driver.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/manager/driver.ts
@@ -11,6 +11,10 @@ export interface ManagerDriver {
 	getOrCreateWithKey(input: GetOrCreateWithKeyInput): Promise<ActorOutput>;
 	createActor(input: CreateInput): Promise<ActorOutput>;
 	listActors(input: ListActorsInput): Promise<ActorOutput[]>;
+	patchMetadata(
+		actorId: string,
+		patch: Record<string, string | null>,
+	): Promise<void>;
 
 	sendRequest(actorId: string, actorRequest: Request): Promise<Response>;
 	openWebSocket(
@@ -91,6 +95,7 @@ export interface ListActorsInput<E extends Env = any> {
 	name: string;
 	key?: string;
 	includeDestroyed?: boolean;
+	metadataKeys?: string[];
 }
 
 export interface ActorOutput {
@@ -103,4 +108,5 @@ export interface ActorOutput {
 	sleepTs?: number | null;
 	destroyTs?: number | null;
 	error?: unknown;
+	metadata?: Record<string, string>;
 }

--- a/rivetkit-typescript/packages/rivetkit/src/manager/router.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/manager/router.ts
@@ -34,6 +34,9 @@ import {
 	ActorsListNamesResponseSchema,
 	type ActorsListResponse,
 	ActorsListResponseSchema,
+	type ActorsPatchMetadataResponse,
+	ActorsPatchMetadataRequestSchema,
+	ActorsPatchMetadataResponseSchema,
 	type Actor as ApiActor,
 } from "@/manager-api/actors";
 import { buildActorNames, type RegistryConfig } from "@/registry/config";
@@ -92,6 +95,9 @@ export function buildManagerRouter(
 
 			router.openapi(route, async (c) => {
 				const { name, actor_ids, key } = c.req.valid("query");
+				const metadataKeys = new URL(c.req.url).searchParams.getAll(
+					"metadata_key",
+				);
 
 				const actorIdsParsed = actor_ids
 					? actor_ids
@@ -192,6 +198,7 @@ export function buildManagerRouter(
 						name,
 						key,
 						includeDestroyed: false,
+						metadataKeys,
 					});
 					actors.push(...actorOutputs);
 				}
@@ -302,6 +309,32 @@ export function buildManagerRouter(
 				const actor = createApiActor(actorOutput);
 
 				return c.json<ActorsCreateResponse>({ actor });
+			});
+		}
+
+		// PATCH /actors/{actor_id}/metadata
+		{
+			const route = createRoute({
+				method: "patch",
+				path: "/actors/{actor_id}/metadata",
+				request: {
+					params: z.object({
+						actor_id: z.string(),
+					}),
+					body: buildOpenApiRequestBody(ActorsPatchMetadataRequestSchema),
+				},
+				responses: buildOpenApiResponses(
+					ActorsPatchMetadataResponseSchema,
+				),
+			});
+
+			router.openapi(route, async (c) => {
+				const { actor_id: actorId } = c.req.valid("param");
+				const body = c.req.valid("json");
+
+				await managerDriver.patchMetadata(actorId, body.metadata);
+
+				return c.json<ActorsPatchMetadataResponse>({});
 			});
 		}
 
@@ -656,5 +689,6 @@ function createApiActor(actor: ActorOutput): ApiActor {
 		destroy_ts: actor.destroyTs ?? null,
 		sleep_ts: actor.sleepTs ?? null,
 		start_ts: actor.startTs ?? null,
+		metadata: actor.metadata ?? undefined,
 	};
 }

--- a/rivetkit-typescript/packages/rivetkit/src/remote-manager-driver/api-endpoints.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/remote-manager-driver/api-endpoints.ts
@@ -8,6 +8,8 @@ import type {
 	ActorsGetOrCreateRequest,
 	ActorsGetOrCreateResponse,
 	ActorsListResponse,
+	ActorsPatchMetadataRequest,
+	ActorsPatchMetadataResponse,
 } from "@/manager-api/actors";
 import type { RivetId } from "@/manager-api/common";
 import { apiCall } from "./api-utils";
@@ -43,11 +45,15 @@ export async function getActorByKey(
 export async function listActorsByName(
 	config: ClientConfig,
 	name: string,
+	metadataKeys: string[] = [],
 ): Promise<ActorsListResponse> {
+	const metadataKeyQuery = metadataKeys
+		.map((key) => `metadata_key=${encodeURIComponent(key)}`)
+		.join("&");
 	return apiCall<never, ActorsListResponse>(
 		config,
 		"GET",
-		`/actors?name=${encodeURIComponent(name)}`,
+		`/actors?name=${encodeURIComponent(name)}${metadataKeyQuery ? `&${metadataKeyQuery}` : ""}`,
 	);
 }
 
@@ -86,6 +92,19 @@ export async function destroyActor(
 		config,
 		"DELETE",
 		`/actors/${encodeURIComponent(actorId)}`,
+	);
+}
+
+export async function patchActorMetadata(
+	config: ClientConfig,
+	actorId: RivetId,
+	request: ActorsPatchMetadataRequest,
+): Promise<ActorsPatchMetadataResponse> {
+	return apiCall<ActorsPatchMetadataRequest, ActorsPatchMetadataResponse>(
+		config,
+		"PATCH",
+		`/actors/${encodeURIComponent(actorId)}/metadata`,
+		request,
 	);
 }
 

--- a/rivetkit-typescript/packages/rivetkit/src/remote-manager-driver/mod.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/remote-manager-driver/mod.ts
@@ -33,6 +33,7 @@ import {
 	getOrCreateActor,
 	kvGet,
 	listActorsByName,
+	patchActorMetadata,
 } from "./api-endpoints";
 import { EngineApiError, getEndpoint } from "./api-utils";
 import { logger } from "./log";
@@ -248,7 +249,11 @@ export class RemoteManagerDriver implements ManagerDriver {
 		return apiActorToOutput(result.actor);
 	}
 
-	async listActors({ c, name }: ListActorsInput): Promise<ActorOutput[]> {
+	async listActors({
+		c,
+		name,
+		metadataKeys,
+	}: ListActorsInput): Promise<ActorOutput[]> {
 		// Wait for metadata check to complete if in progress
 		if (this.#metadataPromise) {
 			await this.#metadataPromise;
@@ -256,9 +261,26 @@ export class RemoteManagerDriver implements ManagerDriver {
 
 		logger().debug({ msg: "listing actors via engine api", name });
 
-		const response = await listActorsByName(this.#config, name);
+		const response = await listActorsByName(
+			this.#config,
+			name,
+			metadataKeys,
+		);
 
 		return response.actors.map(apiActorToOutput);
+	}
+
+	async patchMetadata(
+		actorId: string,
+		patch: Record<string, string | null>,
+	): Promise<void> {
+		if (this.#metadataPromise) {
+			await this.#metadataPromise;
+		}
+
+		await patchActorMetadata(this.#config, actorId, {
+			metadata: patch,
+		});
 	}
 
 	async destroyActor(actorId: string): Promise<void> {
@@ -410,5 +432,6 @@ function apiActorToOutput(actor: ApiActor): ActorOutput {
 		sleepTs: actor.sleep_ts ?? null,
 		destroyTs: actor.destroy_ts ?? null,
 		error: actor.error ?? undefined,
+		metadata: actor.metadata ?? undefined,
 	};
 }


### PR DESCRIPTION
# Description

This adds per-actor metadata patching and read projection across the engine, runner protocol, and RivetKit surfaces. Actors can now patch metadata internally, the REST API can patch metadata without waking sleeping actors, point lookups return full metadata, and list queries can project selected `metadata_key` values. The change also adds mk2 protocol v8 support for metadata patch events and wires the RivetKit file-system and remote manager paths through the same feature.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `cargo check --manifest-path engine/sdks/rust/runner-protocol/Cargo.toml`
- `cargo check --manifest-path engine/packages/pegboard/Cargo.toml`
- `cargo check --manifest-path engine/packages/api-peer/Cargo.toml`
- `cargo check --manifest-path engine/packages/api-public/Cargo.toml`
- Added RivetKit metadata driver tests, but `pnpm -C rivetkit-typescript/packages/rivetkit check-types` could not run in this workspace because `node_modules` are missing.
- `cargo check --manifest-path engine/packages/engine/Cargo.toml --tests` is still blocked by existing engine test drift outside this feature, and `engine/packages/engine/tests/api_actors_list.rs` still needs `metadata_key` literals added.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
