### PR TITLE
feat(pegboard): actor startup KV preloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ lib/**/Cargo.lock
 # Local agent notes
 /.agent/notes/
 
+# Ralph automation (keep ralph.sh, ignore generated artifacts)
+/.ralph/
+/scripts/ralph/CLAUDE.md
+/scripts/ralph/progress.txt
+
 # Cloudflare
 .wrangler/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,14 @@ Key points:
 - When adding or modifying inspector endpoints, also update the driver test at `rivetkit-typescript/packages/rivetkit/src/driver-test-suite/tests/actor-inspector.ts` to cover all inspector HTTP endpoints.
 - When adding or modifying inspector endpoints, also update the documentation in `website/src/metadata/skill-base-rivetkit.md` and `website/src/content/docs/actors/debugging.mdx` to keep them in sync.
 
+**Actor Startup KV Preloading**
+- Actor startup preloads KV data to avoid round-trips to FoundationDB. When adding new KV reads to the actor startup path (anything awaited in `ActorInstance.start()` or its callees), ensure those keys are included in the automatic preload list. The `#expectNoKvRoundTrips` flag will log warnings for any missed keys during development.
+- Internal KV key prefixes are defined in `rivetkit-typescript/packages/rivetkit/src/actor/instance/keys.ts`. Each subsystem has a reserved prefix (`[1]`-`[8]`). Do not reuse or collide with existing prefixes. The Rust preload function in `engine/packages/pegboard/src/actor_kv/preload.rs` (`build_startup_preload_params`) hardcodes the same byte prefixes. When adding or changing a key prefix in `keys.ts`, update the corresponding bytes in `preload.rs` to match.
+- Each prefix scan has a `partial` flag. SQLite `[8]` uses `partial: true` (return whatever fits, VFS handles misses via KV fallback). Connections `[2]` and workflows `[6]` use `partial: false` (if data exceeds budget, return nothing and subsystem falls back to `kvListPrefix`).
+- Preloaded KV is fetched fresh at send time and NOT persisted in workflow history or the command queue. The engine uses `EntryBuilder`/`KeyWrapper::unpack` to reassemble FDB values and strip tuple encoding before sending raw bytes to TypeScript.
+- Every unbounded prefix must have a `preload_max_*_bytes` limit in the engine config (`engine/packages/config/src/config/pegboard.rs`) with an optional per-actor override in actor options. Do not hard-code constants in the engine. All tunable limits belong in the engine config.
+- Internal developer reference at `rivetkit-typescript/packages/rivetkit/src/actor/instance/KV_PRELOADING.md`. Keep `.agent/notes/actor-startup-kv-preload-status.md` up to date as bugs are fixed or the design changes.
+
 **Database Usage**
 - UniversalDB for distributed state storage
 - ClickHouse for analytics and time-series data
@@ -260,6 +268,9 @@ Data structures often include:
 - Log messages should be lowercase unless mentioning specific code symbols. For example, `tracing::info!("inserted UserRow")` instead of `tracing::info!("Inserted UserRow")`
 
 ## Configuration Management
+
+### Engine Configuration
+- Do not hard-code tunable constants (limits, sizes, timeouts, thresholds) in the engine. All tunable values belong in the Rivet Engine config at `engine/packages/config/src/config/`. When adding a new constant, add it to the appropriate config struct with a sensible default and update `website/src/content/docs/self-hosting/configuration.mdx`.
 
 ### Docker Development Configuration
 - Do not make changes to docker/dev* configs. Instead, edit the template in docker/template/ and rerun (cd docker/template && pnpm start). This will regenerate the docker compose config for you.

--- a/engine/artifacts/config-schema.json
+++ b/engine/artifacts/config-schema.json
@@ -638,6 +638,42 @@
           "format": "uint32",
           "minimum": 0.0
         },
+        "preload_max_connections_bytes": {
+          "description": "Maximum size of preloaded connection data sent with the actor start command. Setting to 0 disables connection preloading.\n\nUnit is in bytes. Default: 65,536 (64 KiB).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "preload_max_sqlite_bytes": {
+          "description": "Maximum size of preloaded SQLite VFS data sent with the actor start command. Setting to 0 disables SQLite preloading.\n\nUnit is in bytes. Default: 786,432 (768 KiB).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "preload_max_total_bytes": {
+          "description": "Maximum total size of all preloaded KV data sent with the actor start command. Setting to 0 disables all preloading.\n\nUnit is in bytes. Default: 1,048,576 (1 MiB).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "preload_max_workflow_bytes": {
+          "description": "Maximum size of preloaded workflow data sent with the actor start command. Setting to 0 disables workflow preloading.\n\nUnit is in bytes. Default: 131,072 (128 KiB).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "reschedule_backoff_max_exponent": {
           "description": "Maximum exponent for the reschedule backoff calculation.\n\nThis controls the maximum backoff duration when rescheduling actors.",
           "type": [

--- a/engine/packages/config/src/config/pegboard.rs
+++ b/engine/packages/config/src/config/pegboard.rs
@@ -117,6 +117,31 @@ pub struct Pegboard {
 	///
 	/// Unit is in milliseconds.
 	pub serverless_drain_grace_period: Option<u64>,
+
+	// === KV Preload Settings ===
+	/// Maximum total size of all preloaded KV data sent with the actor start command.
+	/// Setting to 0 disables all preloading.
+	///
+	/// Unit is in bytes. Default: 1,048,576 (1 MiB).
+	pub preload_max_total_bytes: Option<u64>,
+
+	/// Maximum size of preloaded SQLite VFS data sent with the actor start command.
+	/// Setting to 0 disables SQLite preloading.
+	///
+	/// Unit is in bytes. Default: 786,432 (768 KiB).
+	pub preload_max_sqlite_bytes: Option<u64>,
+
+	/// Maximum size of preloaded workflow data sent with the actor start command.
+	/// Setting to 0 disables workflow preloading.
+	///
+	/// Unit is in bytes. Default: 131,072 (128 KiB).
+	pub preload_max_workflow_bytes: Option<u64>,
+
+	/// Maximum size of preloaded connection data sent with the actor start command.
+	/// Setting to 0 disables connection preloading.
+	///
+	/// Unit is in bytes. Default: 65,536 (64 KiB).
+	pub preload_max_connections_bytes: Option<u64>,
 }
 
 impl Pegboard {
@@ -238,5 +263,21 @@ impl Pegboard {
 
 	pub fn serverless_drain_grace_period(&self) -> u64 {
 		self.serverless_drain_grace_period.unwrap_or(10_000)
+	}
+
+	pub fn preload_max_total_bytes(&self) -> u64 {
+		self.preload_max_total_bytes.unwrap_or(1_048_576) // 1 MiB
+	}
+
+	pub fn preload_max_sqlite_bytes(&self) -> u64 {
+		self.preload_max_sqlite_bytes.unwrap_or(786_432) // 768 KiB
+	}
+
+	pub fn preload_max_workflow_bytes(&self) -> u64 {
+		self.preload_max_workflow_bytes.unwrap_or(131_072) // 128 KiB
+	}
+
+	pub fn preload_max_connections_bytes(&self) -> u64 {
+		self.preload_max_connections_bytes.unwrap_or(65_536) // 64 KiB
 	}
 }

--- a/engine/packages/pegboard-runner/src/conn.rs
+++ b/engine/packages/pegboard-runner/src/conn.rs
@@ -287,7 +287,7 @@ pub async fn handle_init(
 		})?;
 
 	let udb = ctx.udb()?;
-	let (runner_config_res, missed_commands) = tokio::try_join!(
+	let (runner_config_res, mut missed_commands) = tokio::try_join!(
 		ctx.op(pegboard::ops::runner_config::get::Input {
 			runners: vec![(conn.namespace_id, conn.runner_name.clone())],
 			bypass_cache: false,
@@ -402,8 +402,28 @@ pub async fn handle_init(
 		.send(Message::Binary(init_msg_serialized.into()))
 		.await?;
 
-	// Send missed commands
+	// Send missed commands with preloaded KV injected at send time.
 	if !missed_commands.is_empty() {
+		let db = ctx.udb()?;
+		for cmd_wrapper in &mut missed_commands {
+			if let protocol::mk2::Command::CommandStartActor(ref mut start) = cmd_wrapper.inner {
+				let actor_id = cmd_wrapper
+					.checkpoint
+					.actor_id
+					.parse::<Id>()
+					.context("failed to parse actor_id from missed command")?;
+				let preloaded = pegboard::actor_kv::preload::fetch_preloaded_kv(
+					&db,
+					pb,
+					actor_id,
+					conn.namespace_id,
+					&start.config.name,
+				)
+				.await?;
+				start.preloaded_kv = preloaded;
+			}
+		}
+
 		let msg = versioned::ToClientMk2::wrap_latest(protocol::mk2::ToClient::ToClientCommands(
 			missed_commands,
 		));

--- a/engine/packages/pegboard-runner/src/tunnel_to_ws_task.rs
+++ b/engine/packages/pegboard-runner/src/tunnel_to_ws_task.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use gas::prelude::*;
 use hyper_tungstenite::tungstenite::Message;
+use pegboard::actor_kv;
 use pegboard::pubsub_subjects::GatewayReceiverSubject;
 use rivet_runner_protocol::{self as protocol, PROTOCOL_MK2_VERSION, versioned};
 use std::sync::Arc;
@@ -126,27 +127,39 @@ async fn handle_message_mk2(
 		protocol::mk2::ToRunner::ToRunnerClose => return Err(errors::WsError::Eviction.build()),
 		protocol::mk2::ToRunner::ToClientCommands(mut command_wrappers) => {
 			for command_wrapper in &mut command_wrappers {
-				if let protocol::mk2::Command::CommandStartActor(
-					protocol::mk2::CommandStartActor {
-						hibernating_requests,
-						..
-					},
-				) = &mut command_wrapper.inner
+				if let protocol::mk2::Command::CommandStartActor(ref mut start) =
+					command_wrapper.inner
 				{
+					let actor_id = Id::parse(&command_wrapper.checkpoint.actor_id)?;
+
+					// Dynamically populate hibernating request ids.
 					let ids = ctx
 						.op(pegboard::ops::actor::hibernating_request::list::Input {
-							actor_id: Id::parse(&command_wrapper.checkpoint.actor_id)?,
+							actor_id,
 						})
 						.await?;
-
-					// Dynamically populate hibernating request ids
-					*hibernating_requests = ids
+					start.hibernating_requests = ids
 						.into_iter()
 						.map(|x| protocol::mk2::HibernatingRequest {
 							gateway_id: x.gateway_id,
 							request_id: x.request_id,
 						})
 						.collect();
+
+					// Inject preloaded KV if not already populated by the engine.
+					if start.preloaded_kv.is_none() {
+						let db = ctx.udb()?;
+						let pb = ctx.config().pegboard();
+						start.preloaded_kv = actor_kv::preload::fetch_preloaded_kv(
+							&db,
+							pb,
+							actor_id,
+							conn.namespace_id,
+							&start.config.name,
+						)
+						.await
+						.context("failed to fetch preloaded KV for start command")?;
+					}
 				}
 			}
 

--- a/engine/packages/pegboard-runner/src/ws_to_tunnel_task.rs
+++ b/engine/packages/pegboard-runner/src/ws_to_tunnel_task.rs
@@ -882,7 +882,7 @@ async fn handle_tunnel_message_mk1(
 
 	// Publish message to UPS
 	let gateway_reply_to = GatewayReceiverSubject::new(msg.message_id.gateway_id).to_string();
-	let msg_serialized = versioned::ToGateway::v3_to_v7(versioned::ToGateway::V3(
+	let msg_serialized = versioned::ToGateway::v3_to_v8(versioned::ToGateway::V3(
 		protocol::ToGateway::ToServerTunnelMessage(msg),
 	))?
 	.serialize_with_embedded_version(PROTOCOL_MK2_VERSION)

--- a/engine/packages/pegboard/src/actor_kv/mod.rs
+++ b/engine/packages/pegboard/src/actor_kv/mod.rs
@@ -10,6 +10,7 @@ use utils::{validate_entries, validate_keys, validate_range};
 use crate::keys;
 
 mod entry;
+pub mod preload;
 mod utils;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/engine/packages/pegboard/src/actor_kv/preload.rs
+++ b/engine/packages/pegboard/src/actor_kv/preload.rs
@@ -1,0 +1,387 @@
+use anyhow::Result;
+use futures_util::TryStreamExt;
+use gas::prelude::*;
+use rivet_config::config::pegboard::Pegboard;
+use rivet_runner_protocol::mk2 as rp;
+use universaldb::prelude::*;
+use universaldb::tuple::Subspace;
+
+use super::entry::EntryBuilder;
+use crate::keys;
+
+/// Request to preload a prefix range from the actor's KV store.
+pub struct PreloadPrefixRequest {
+	/// The raw key prefix bytes (e.g., [2] for connections, [8] for SQLite).
+	pub prefix: rp::KvKey,
+	/// Maximum bytes to preload for this prefix.
+	pub max_bytes: u64,
+	/// If true, return whatever fits even if truncated (for per-key lookup subsystems
+	/// like SQLite VFS). If false, return nothing if the total data exceeds max_bytes
+	/// (for list-based subsystems like connections and workflows).
+	pub partial: bool,
+}
+
+/// Fetches all preload data for an actor in a single FDB snapshot transaction.
+///
+/// Reads exact get-keys and prefix ranges, reassembles chunked FDB values using
+/// EntryBuilder, strips tuple encoding via KeyWrapper::unpack, and returns raw
+/// byte key-value pairs ready for TypeScript consumption.
+///
+/// Prefix requests should be passed in descending priority order (highest priority
+/// first). When the global byte cap is reached, lower-priority prefixes are
+/// truncated first.
+#[tracing::instrument(skip_all)]
+pub async fn batch_preload(
+	db: &universaldb::Database,
+	actor_id: Id,
+	get_keys: Vec<rp::KvKey>,
+	prefix_requests: Vec<PreloadPrefixRequest>,
+	max_total_bytes: u64,
+) -> Result<rp::PreloadedKv> {
+	let subspace = keys::actor_kv::subspace(actor_id);
+
+	// Break prefix_requests into separate vectors so they can be cloned for the
+	// FDB transaction closure (which may retry on conflicts).
+	let prefix_keys: Vec<rp::KvKey> = prefix_requests.iter().map(|r| r.prefix.clone()).collect();
+	let prefix_params: Vec<(u64, bool)> = prefix_requests
+		.iter()
+		.map(|r| (r.max_bytes, r.partial))
+		.collect();
+
+	db.run(|tx| {
+		let subspace = subspace.clone();
+		let get_keys = get_keys.clone();
+		let prefix_keys = prefix_keys.clone();
+		let prefix_params = prefix_params.clone();
+
+		async move {
+			let tx = tx.with_subspace(subspace.clone());
+			let mut entries = Vec::new();
+			let mut total_bytes: u64 = 0;
+
+			// Build requested lists dynamically so they only contain keys/prefixes
+			// that were actually scanned. Keys or prefixes skipped due to budget
+			// exhaustion or disabled config must not appear, otherwise the actor
+			// would mistake "not scanned" for "scanned and not found".
+			let mut requested_get_keys: Vec<rp::KvKey> = Vec::new();
+			let mut requested_prefixes: Vec<rp::KvKey> = Vec::new();
+
+			// 1. Read exact get-keys. Each key maps to a single logical entry
+			// (or nothing if the key doesn't exist in FDB).
+			for key in &get_keys {
+				if total_bytes >= max_total_bytes {
+					tracing::debug!(
+						skipped_keys = get_keys.len() - requested_get_keys.len(),
+						"preload get-keys skipped due to global budget exhaustion"
+					);
+					break;
+				}
+
+				// Mark this key as scanned regardless of whether it exists in FDB.
+				requested_get_keys.push(key.clone());
+
+				let key_subspace =
+					subspace.subspace(&keys::actor_kv::KeyWrapper(key.clone()));
+				let mut stream = tx.get_ranges_keyvalues(
+					universaldb::RangeOption {
+						mode: universaldb::options::StreamingMode::WantAll,
+						..key_subspace.range().into()
+					},
+					Snapshot,
+				);
+
+				let mut builder: Option<EntryBuilder> = None;
+
+				while let Some(fdb_kv) = stream.try_next().await? {
+					if builder.is_none() {
+						let parsed_key =
+							tx.unpack::<keys::actor_kv::EntryBaseKey>(&fdb_kv.key())?
+								.key;
+						builder = Some(EntryBuilder::new(parsed_key));
+					}
+
+					let b = builder.as_mut().unwrap();
+
+					if let Ok(chunk_key) =
+						tx.unpack::<keys::actor_kv::EntryValueChunkKey>(&fdb_kv.key())
+					{
+						b.append_chunk(chunk_key.chunk, fdb_kv.value());
+					} else if let Ok(metadata_key) =
+						tx.unpack::<keys::actor_kv::EntryMetadataKey>(&fdb_kv.key())
+					{
+						let metadata = metadata_key.deserialize(fdb_kv.value())?;
+						b.append_metadata(metadata);
+					} else {
+						bail!("unexpected sub key in preload get");
+					}
+				}
+
+				if let Some(b) = builder {
+					let (k, v, m) = b.build()?;
+					let size = entry_size(&k, &v, &m);
+					if total_bytes + size <= max_total_bytes {
+						total_bytes += size;
+						entries.push(rp::PreloadedKvEntry {
+							key: k,
+							value: v,
+							metadata: m,
+						});
+					}
+				}
+			}
+
+			// 2. Read prefix ranges in priority order. Each prefix is bounded by
+			// its per-prefix max_bytes and the remaining global budget.
+			for (i, prefix) in prefix_keys.iter().enumerate() {
+				let (max_bytes, partial) = prefix_params[i];
+
+				// Skip prefixes disabled by config (max_bytes == 0) or when
+				// global budget is exhausted. Do not include in requested_prefixes
+				// so the actor falls back to kvListPrefix.
+				let remaining_budget = max_total_bytes.saturating_sub(total_bytes);
+				let effective_limit = max_bytes.min(remaining_budget);
+
+				if effective_limit == 0 {
+					tracing::debug!(
+						?prefix,
+						max_bytes,
+						remaining_budget,
+						"preload prefix skipped, effective limit is 0"
+					);
+					continue;
+				}
+
+				let range = prefix_range(prefix, &subspace);
+				let mut stream = tx.get_ranges_keyvalues(
+					universaldb::RangeOption {
+						mode: universaldb::options::StreamingMode::Iterator,
+						..range.into()
+					},
+					Snapshot,
+				);
+
+				let mut prefix_entries: Vec<rp::PreloadedKvEntry> = Vec::new();
+				let mut prefix_bytes: u64 = 0;
+				let mut current_entry: Option<EntryBuilder> = None;
+				let mut exceeded = false;
+
+				while let Some(fdb_kv) = stream.try_next().await? {
+					let key =
+						tx.unpack::<keys::actor_kv::EntryBaseKey>(&fdb_kv.key())?.key;
+
+					let curr = if let Some(inner) = &mut current_entry {
+						if inner.key != key {
+							// Finalize the previous entry.
+							let prev =
+								std::mem::replace(inner, EntryBuilder::new(key));
+							let (k, v, m) = prev.build()?;
+							let size = entry_size(&k, &v, &m);
+
+							if prefix_bytes + size > effective_limit {
+								exceeded = true;
+								break;
+							}
+
+							prefix_bytes += size;
+							prefix_entries.push(rp::PreloadedKvEntry {
+								key: k,
+								value: v,
+								metadata: m,
+							});
+						}
+
+						inner
+					} else {
+						current_entry = Some(EntryBuilder::new(key));
+						current_entry.as_mut().expect("just set")
+					};
+
+					if let Ok(chunk_key) =
+						tx.unpack::<keys::actor_kv::EntryValueChunkKey>(&fdb_kv.key())
+					{
+						curr.append_chunk(chunk_key.chunk, fdb_kv.value());
+					} else if let Ok(metadata_key) =
+						tx.unpack::<keys::actor_kv::EntryMetadataKey>(&fdb_kv.key())
+					{
+						let metadata = metadata_key.deserialize(fdb_kv.value())?;
+						curr.append_metadata(metadata);
+					} else {
+						bail!("unexpected sub key in preload prefix scan");
+					}
+				}
+
+				// Finalize the last entry if the stream ended without exceeding.
+				if !exceeded {
+					if let Some(b) = current_entry {
+						let (k, v, m) = b.build()?;
+						let size = entry_size(&k, &v, &m);
+						if prefix_bytes + size > effective_limit {
+							exceeded = true;
+						} else {
+							prefix_bytes += size;
+							prefix_entries.push(rp::PreloadedKvEntry {
+								key: k,
+								value: v,
+								metadata: m,
+							});
+						}
+					}
+				}
+
+				// For non-partial prefixes, discard all entries if the data exceeded
+				// the limit. The subsystem will fall back to a full kvListPrefix.
+				// Do not include in requested_prefixes so the actor knows to fall back.
+				if exceeded && !partial {
+					tracing::debug!(
+						?prefix,
+						prefix_bytes,
+						effective_limit,
+						"preload prefix truncated (partial: false), discarding entries"
+					);
+					continue;
+				}
+
+				if exceeded {
+					tracing::debug!(
+						?prefix,
+						prefix_bytes,
+						effective_limit,
+						"preload prefix truncated (partial: true), keeping partial data"
+					);
+				}
+
+				requested_prefixes.push(prefix.clone());
+				total_bytes += prefix_bytes;
+				entries.extend(prefix_entries);
+			}
+
+			Ok(rp::PreloadedKv {
+				entries,
+				requested_get_keys,
+				requested_prefixes,
+			})
+		}
+	})
+	.custom_instrument(tracing::info_span!("kv_batch_preload_tx"))
+	.await
+	.map_err(Into::<anyhow::Error>::into)
+}
+
+/// Builds the standard get-keys and prefix-requests used to preload an actor's
+/// startup data. Per-actor overrides from actor name metadata take precedence
+/// over engine config defaults. Returns `None` if the global max total bytes
+/// is 0 (preloading disabled).
+pub fn build_startup_preload_params(
+	config: &Pegboard,
+	metadata: &serde_json::Map<String, serde_json::Value>,
+) -> Option<(Vec<rp::KvKey>, Vec<PreloadPrefixRequest>)> {
+	let max_total = config.preload_max_total_bytes();
+	if max_total == 0 {
+		return None;
+	}
+
+	let get_override = |key: &str| -> Option<u64> {
+		metadata.get(key).and_then(|v| v.as_u64())
+	};
+
+	// Exact key lookups.
+	//
+	// These byte prefixes must match the TypeScript key constants in
+	// rivetkit-typescript/packages/rivetkit/src/actor/instance/keys.ts.
+	// See CLAUDE.md "Actor Startup KV Preloading" for the sync rule.
+	let get_keys: Vec<rp::KvKey> = vec![
+		vec![1u8],       // PERSIST_DATA (keys.ts KEYS.PERSIST_DATA)
+		vec![3u8],       // INSPECTOR_TOKEN (keys.ts KEYS.INSPECTOR_TOKEN)
+		vec![5, 1, 1],   // QUEUE_METADATA_KEY (keys.ts QUEUE_PREFIX + STORAGE_VERSION.QUEUE + QUEUE_NAMESPACE.METADATA)
+	];
+
+	// Prefix scans in descending priority order. When the global cap is
+	// reached, lower-priority prefixes are truncated first.
+	//
+	// These byte prefixes must match the TypeScript key constants in
+	// rivetkit-typescript/packages/rivetkit/src/actor/instance/keys.ts.
+	// See CLAUDE.md "Actor Startup KV Preloading" for the sync rule.
+	let prefix_requests = vec![
+		PreloadPrefixRequest {
+			prefix: vec![8u8, 1], // SQLITE_STORAGE_PREFIX (keys.ts SQLITE_PREFIX + STORAGE_VERSION.SQLITE)
+			max_bytes: get_override("preloadMaxSqliteBytes")
+				.unwrap_or_else(|| config.preload_max_sqlite_bytes()),
+			partial: true,
+		},
+		PreloadPrefixRequest {
+			prefix: vec![6u8, 1], // WORKFLOW_STORAGE_PREFIX (keys.ts WORKFLOW_PREFIX + STORAGE_VERSION.WORKFLOW)
+			max_bytes: get_override("preloadMaxWorkflowBytes")
+				.unwrap_or_else(|| config.preload_max_workflow_bytes()),
+			partial: false,
+		},
+		PreloadPrefixRequest {
+			prefix: vec![2u8], // CONN_PREFIX (keys.ts KEYS.CONN_PREFIX)
+			max_bytes: get_override("preloadMaxConnectionsBytes")
+				.unwrap_or_else(|| config.preload_max_connections_bytes()),
+			partial: false,
+		},
+	];
+
+	Some((get_keys, prefix_requests))
+}
+
+/// Fetches preloaded KV data for an actor using engine config and actor name
+/// metadata. Returns `None` if preloading is disabled. Fails if the FDB
+/// transaction fails (no silent fallback).
+#[tracing::instrument(skip_all)]
+pub async fn fetch_preloaded_kv(
+	db: &universaldb::Database,
+	config: &Pegboard,
+	actor_id: Id,
+	namespace_id: Id,
+	actor_name: &str,
+) -> Result<Option<rp::PreloadedKv>> {
+	// Read actor name metadata from FDB.
+	let metadata = db
+		.run(|tx| {
+			let tx = tx.with_subspace(keys::subspace());
+			let name_key =
+				keys::ns::ActorNameKey::new(namespace_id, actor_name.to_string());
+			async move { tx.read_opt(&name_key, Snapshot).await }
+		})
+		.await?;
+
+	let metadata_map = metadata
+		.map(|d: rivet_data::converted::ActorNameKeyData| d.metadata)
+		.unwrap_or_default();
+
+	let Some((get_keys, prefix_requests)) =
+		build_startup_preload_params(config, &metadata_map)
+	else {
+		return Ok(None);
+	};
+
+	let preloaded = batch_preload(
+		db,
+		actor_id,
+		get_keys,
+		prefix_requests,
+		config.preload_max_total_bytes(),
+	)
+	.await?;
+
+	Ok(Some(preloaded))
+}
+
+/// Computes the serialized size of a preloaded KV entry, including key, value,
+/// and metadata (version bytes + i64 timestamp).
+fn entry_size(key: &rp::KvKey, value: &rp::KvValue, metadata: &rp::KvMetadata) -> u64 {
+	(key.len() + value.len() + metadata.version.len() + std::mem::size_of::<i64>()) as u64
+}
+
+/// Computes the FDB key range for a prefix scan within the actor KV subspace.
+fn prefix_range(prefix: &rp::KvKey, subspace: &Subspace) -> (Vec<u8>, Vec<u8>) {
+	let mut start = subspace.pack(&keys::actor_kv::ListKeyWrapper(prefix.clone()));
+	// Remove the trailing 0 byte that tuple encoding adds to bytes.
+	if let Some(&0) = start.last() {
+		start.pop();
+	}
+	let mut end = start.clone();
+	end.push(0xFF);
+	(start, end)
+}

--- a/engine/packages/pegboard/src/workflows/actor/mod.rs
+++ b/engine/packages/pegboard/src/workflows/actor/mod.rs
@@ -455,6 +455,7 @@ pub async fn pegboard_actor(ctx: &mut WorkflowCtx, input: &Input) -> Result<()> 
 
 												ctx.activity(runtime::InsertAndSendCommandsInput {
 													actor_id: input.actor_id,
+													namespace_id: input.namespace_id,
 													generation: state.generation,
 													runner_id,
 													commands: vec![protocol::mk2::Command::CommandStopActor],
@@ -480,6 +481,7 @@ pub async fn pegboard_actor(ctx: &mut WorkflowCtx, input: &Input) -> Result<()> 
 
 												ctx.activity(runtime::InsertAndSendCommandsInput {
 													actor_id: input.actor_id,
+													namespace_id: input.namespace_id,
 													generation: state.generation,
 													runner_id,
 													commands: vec![protocol::mk2::Command::CommandStopActor],
@@ -712,6 +714,7 @@ pub async fn pegboard_actor(ctx: &mut WorkflowCtx, input: &Input) -> Result<()> 
 								if protocol::is_mk2(runner_protocol_version) {
 									ctx.activity(runtime::InsertAndSendCommandsInput {
 										actor_id: input.actor_id,
+										namespace_id: input.namespace_id,
 										generation: state.generation,
 										runner_id,
 										commands: vec![protocol::mk2::Command::CommandStopActor],
@@ -740,6 +743,7 @@ pub async fn pegboard_actor(ctx: &mut WorkflowCtx, input: &Input) -> Result<()> 
 								if protocol::is_mk2(runner_protocol_version) {
 									ctx.activity(runtime::InsertAndSendCommandsInput {
 										actor_id: input.actor_id,
+										namespace_id: input.namespace_id,
 										generation: state.generation,
 										runner_id,
 										commands: vec![protocol::mk2::Command::CommandStopActor],
@@ -1084,6 +1088,7 @@ async fn handle_stopped(
 		if protocol::is_mk2(old_runner_protocol_version) {
 			ctx.activity(runtime::InsertAndSendCommandsInput {
 				actor_id: input.actor_id,
+				namespace_id: input.namespace_id,
 				generation: state.generation,
 				runner_id: old_runner_id,
 				commands: vec![protocol::mk2::Command::CommandStopActor],

--- a/engine/packages/pegboard/src/workflows/actor/runtime.rs
+++ b/engine/packages/pegboard/src/workflows/actor/runtime.rs
@@ -688,6 +688,7 @@ pub async fn spawn_actor(
 			if protocol::is_mk2(runner_protocol_version) {
 				ctx.activity(InsertAndSendCommandsInput {
 					actor_id: input.actor_id,
+					namespace_id: input.namespace_id,
 					generation,
 					runner_id,
 					commands: vec![protocol::mk2::Command::CommandStartActor(
@@ -706,6 +707,8 @@ pub async fn spawn_actor(
 							// Empty because request ids are ephemeral. This is intercepted by guard and
 							// populated before it reaches the runner
 							hibernating_requests: Vec::new(),
+							// Preloaded KV is populated at send time, not at persistence time.
+							preloaded_kv: None,
 						},
 					)],
 				})
@@ -805,6 +808,7 @@ pub async fn spawn_actor(
 					if protocol::is_mk2(runner_protocol_version) {
 						ctx.activity(InsertAndSendCommandsInput {
 							actor_id: input.actor_id,
+							namespace_id: input.namespace_id,
 							generation,
 							runner_id: sig.runner_id,
 							commands: vec![protocol::mk2::Command::CommandStartActor(
@@ -822,6 +826,8 @@ pub async fn spawn_actor(
 									// Empty because request ids are ephemeral. This is intercepted by guard and
 									// populated before it reaches the runner
 									hibernating_requests: Vec::new(),
+									// Preloaded KV is populated at send time, not at persistence time.
+									preloaded_kv: None,
 								},
 							)],
 						})
@@ -940,6 +946,7 @@ pub async fn spawn_actor(
 						if protocol::is_mk2(runner_protocol_version) {
 							ctx.activity(InsertAndSendCommandsInput {
 								actor_id: input.actor_id,
+								namespace_id: input.namespace_id,
 								generation,
 								runner_id: sig.runner_id,
 								commands: vec![protocol::mk2::Command::CommandStartActor(
@@ -957,6 +964,8 @@ pub async fn spawn_actor(
 										// Empty because request ids are ephemeral. This is intercepted by guard and
 										// populated before it reaches the runner
 										hibernating_requests: Vec::new(),
+										// Preloaded KV is populated at send time, not at persistence time.
+										preloaded_kv: None,
 									},
 								)],
 							})
@@ -1282,6 +1291,7 @@ fn reschedule_backoff(
 #[derive(Debug, Serialize, Deserialize, Hash)]
 pub struct InsertAndSendCommandsInput {
 	pub actor_id: Id,
+	pub namespace_id: Id,
 	pub generation: u32,
 	pub runner_id: Id,
 	pub commands: Vec<protocol::mk2::Command>,
@@ -1336,6 +1346,36 @@ pub async fn insert_and_send_commands(
 		})
 		.await?;
 
+	// Fetch preloaded KV at send time for any CommandStartActor commands.
+	// Preloaded KV is never persisted in the command queue or workflow history.
+	let preloaded_kv = {
+		let has_start_cmd = input
+			.commands
+			.iter()
+			.any(|c| matches!(c, protocol::mk2::Command::CommandStartActor(_)));
+		if has_start_cmd {
+			let db = ctx.udb()?;
+			crate::actor_kv::preload::fetch_preloaded_kv(
+				&db,
+				ctx.config().pegboard(),
+				input.actor_id,
+				input.namespace_id,
+				// Extract actor name from the start command.
+				&input
+					.commands
+					.iter()
+					.find_map(|c| match c {
+						protocol::mk2::Command::CommandStartActor(x) => Some(x.config.name.clone()),
+						_ => None,
+					})
+					.unwrap_or_default(),
+			)
+			.await?
+		} else {
+			None
+		}
+	};
+
 	let receiver_subject =
 		crate::pubsub_subjects::RunnerReceiverSubject::new(input.runner_id).to_string();
 
@@ -1345,13 +1385,20 @@ pub async fn insert_and_send_commands(
 				.commands
 				.iter()
 				.enumerate()
-				.map(|(i, command)| protocol::mk2::CommandWrapper {
-					checkpoint: protocol::mk2::ActorCheckpoint {
-						actor_id: input.actor_id.to_string(),
-						generation: input.generation,
-						index: old_last_command_idx + i as i64 + 1,
-					},
-					inner: command.clone(),
+				.map(|(i, command)| {
+					let mut cmd = command.clone();
+					// Inject preloaded KV into start commands.
+					if let protocol::mk2::Command::CommandStartActor(ref mut start) = cmd {
+						start.preloaded_kv = preloaded_kv.clone();
+					}
+					protocol::mk2::CommandWrapper {
+						checkpoint: protocol::mk2::ActorCheckpoint {
+							actor_id: input.actor_id.to_string(),
+							generation: input.generation,
+							index: old_last_command_idx + i as i64 + 1,
+						},
+						inner: cmd,
+					}
 				})
 				.collect(),
 		))

--- a/engine/sdks/rust/runner-protocol/src/lib.rs
+++ b/engine/sdks/rust/runner-protocol/src/lib.rs
@@ -6,10 +6,10 @@ pub mod versioned;
 
 // Re-export latest
 pub use generated::v3::*;
-pub use generated::v7 as mk2;
+pub use generated::v8 as mk2;
 
 pub const PROTOCOL_MK1_VERSION: u16 = 3;
-pub const PROTOCOL_MK2_VERSION: u16 = 7;
+pub const PROTOCOL_MK2_VERSION: u16 = 8;
 
 pub fn is_mk2(protocol_version: u16) -> bool {
 	protocol_version > PROTOCOL_MK1_VERSION

--- a/engine/sdks/rust/runner-protocol/src/versioned.rs
+++ b/engine/sdks/rust/runner-protocol/src/versioned.rs
@@ -2,24 +2,25 @@ use anyhow::{Ok, Result, bail};
 use vbare::OwnedVersionedData;
 
 use crate::PROTOCOL_MK1_VERSION;
-use crate::generated::{v1, v2, v3, v4, v5, v6, v7};
+use crate::generated::{v1, v2, v3, v4, v5, v6, v7, v8};
 use crate::uuid_compat::{decode_bytes_from_uuid, encode_bytes_to_uuid};
 
 pub enum ToClientMk2 {
 	V4(v4::ToClient),
 	V5(v5::ToClient),
 	V7(v7::ToClient),
+	V8(v8::ToClient),
 }
 
 impl OwnedVersionedData for ToClientMk2 {
-	type Latest = v7::ToClient;
+	type Latest = v8::ToClient;
 
-	fn wrap_latest(latest: v7::ToClient) -> Self {
-		ToClientMk2::V7(latest)
+	fn wrap_latest(latest: v8::ToClient) -> Self {
+		ToClientMk2::V8(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
-		if let ToClientMk2::V7(data) = self {
+		if let ToClientMk2::V8(data) = self {
 			Ok(data)
 		} else {
 			bail!("version not latest");
@@ -31,6 +32,7 @@ impl OwnedVersionedData for ToClientMk2 {
 			4 => Ok(ToClientMk2::V4(serde_bare::from_slice(payload)?)),
 			5 => Ok(ToClientMk2::V5(serde_bare::from_slice(payload)?)),
 			6 | 7 => Ok(ToClientMk2::V7(serde_bare::from_slice(payload)?)),
+			8 => Ok(ToClientMk2::V8(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -40,15 +42,16 @@ impl OwnedVersionedData for ToClientMk2 {
 			ToClientMk2::V4(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ToClientMk2::V5(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ToClientMk2::V7(data) => serde_bare::to_vec(&data).map_err(Into::into),
+			ToClientMk2::V8(data) => serde_bare::to_vec(&data).map_err(Into::into),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Self::v4_to_v5, Self::v5_to_v7, Ok]
+		vec![Ok, Ok, Ok, Self::v4_to_v5, Self::v5_to_v7, Ok, Self::v7_to_v8]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Self::v7_to_v5, Self::v5_to_v4, Ok, Ok, Ok]
+		vec![Self::v8_to_v7, Ok, Self::v7_to_v5, Self::v5_to_v4, Ok, Ok, Ok]
 	}
 }
 
@@ -396,23 +399,197 @@ impl ToClientMk2 {
 			bail!("unexpected version");
 		}
 	}
+
+	fn v7_to_v8(self) -> Result<Self> {
+		if let ToClientMk2::V7(x) = self {
+			let inner = match x {
+				v7::ToClient::ToClientInit(init) => v8::ToClient::ToClientInit(v8::ToClientInit {
+					runner_id: init.runner_id,
+					metadata: v8::ProtocolMetadata {
+						runner_lost_threshold: init.metadata.runner_lost_threshold,
+						actor_stop_threshold: init.metadata.actor_stop_threshold,
+						serverless_drain_grace_period: init.metadata.serverless_drain_grace_period,
+					},
+				}),
+				v7::ToClient::ToClientCommands(commands) => v8::ToClient::ToClientCommands(
+					commands
+						.into_iter()
+						.map(|cmd| v8::CommandWrapper {
+							checkpoint: v8::ActorCheckpoint {
+								actor_id: cmd.checkpoint.actor_id,
+								generation: cmd.checkpoint.generation,
+								index: cmd.checkpoint.index,
+							},
+							inner: match cmd.inner {
+								v7::Command::CommandStartActor(start) => {
+									v8::Command::CommandStartActor(v8::CommandStartActor {
+										config: v8::ActorConfig {
+											name: start.config.name,
+											key: start.config.key,
+											create_ts: start.config.create_ts,
+											input: start.config.input,
+										},
+										hibernating_requests: start
+											.hibernating_requests
+											.into_iter()
+											.map(|req| v8::HibernatingRequest {
+												gateway_id: req.gateway_id,
+												request_id: req.request_id,
+											})
+											.collect(),
+										preloaded_kv: None,
+									})
+								}
+								v7::Command::CommandStopActor => v8::Command::CommandStopActor,
+							},
+						})
+						.collect(),
+				),
+				v7::ToClient::ToClientAckEvents(ack) => {
+					v8::ToClient::ToClientAckEvents(v8::ToClientAckEvents {
+						last_event_checkpoints: ack
+							.last_event_checkpoints
+							.into_iter()
+							.map(|cp| v8::ActorCheckpoint {
+								actor_id: cp.actor_id,
+								generation: cp.generation,
+								index: cp.index,
+							})
+							.collect(),
+					})
+				}
+				v7::ToClient::ToClientKvResponse(resp) => {
+					v8::ToClient::ToClientKvResponse(v8::ToClientKvResponse {
+						request_id: resp.request_id,
+						data: convert_kv_response_data_v7_to_v8(resp.data),
+					})
+				}
+				v7::ToClient::ToClientTunnelMessage(msg) => {
+					v8::ToClient::ToClientTunnelMessage(v8::ToClientTunnelMessage {
+						message_id: v8::MessageId {
+							gateway_id: msg.message_id.gateway_id,
+							request_id: msg.message_id.request_id,
+							message_index: msg.message_id.message_index,
+						},
+						message_kind: convert_to_client_tunnel_message_kind_v7_to_v8(
+							msg.message_kind,
+						),
+					})
+				}
+				v7::ToClient::ToClientPing(ping) => {
+					v8::ToClient::ToClientPing(v8::ToClientPing { ts: ping.ts })
+				}
+			};
+
+			Ok(ToClientMk2::V8(inner))
+		} else {
+			bail!("unexpected version");
+		}
+	}
+
+	fn v8_to_v7(self) -> Result<Self> {
+		if let ToClientMk2::V8(x) = self {
+			let inner = match x {
+				v8::ToClient::ToClientInit(init) => v7::ToClient::ToClientInit(v7::ToClientInit {
+					runner_id: init.runner_id,
+					metadata: v7::ProtocolMetadata {
+						runner_lost_threshold: init.metadata.runner_lost_threshold,
+						actor_stop_threshold: init.metadata.actor_stop_threshold,
+						serverless_drain_grace_period: init.metadata.serverless_drain_grace_period,
+					},
+				}),
+				v8::ToClient::ToClientCommands(commands) => v7::ToClient::ToClientCommands(
+					commands
+						.into_iter()
+						.map(|cmd| v7::CommandWrapper {
+							checkpoint: v7::ActorCheckpoint {
+								actor_id: cmd.checkpoint.actor_id,
+								generation: cmd.checkpoint.generation,
+								index: cmd.checkpoint.index,
+							},
+							inner: match cmd.inner {
+								v8::Command::CommandStartActor(start) => {
+									v7::Command::CommandStartActor(v7::CommandStartActor {
+										config: v7::ActorConfig {
+											name: start.config.name,
+											key: start.config.key,
+											create_ts: start.config.create_ts,
+											input: start.config.input,
+										},
+										hibernating_requests: start
+											.hibernating_requests
+											.into_iter()
+											.map(|req| v7::HibernatingRequest {
+												gateway_id: req.gateway_id,
+												request_id: req.request_id,
+											})
+											.collect(),
+									})
+								}
+								v8::Command::CommandStopActor => v7::Command::CommandStopActor,
+							},
+						})
+						.collect(),
+				),
+				v8::ToClient::ToClientAckEvents(ack) => {
+					v7::ToClient::ToClientAckEvents(v7::ToClientAckEvents {
+						last_event_checkpoints: ack
+							.last_event_checkpoints
+							.into_iter()
+							.map(|cp| v7::ActorCheckpoint {
+								actor_id: cp.actor_id,
+								generation: cp.generation,
+								index: cp.index,
+							})
+							.collect(),
+					})
+				}
+				v8::ToClient::ToClientKvResponse(resp) => {
+					v7::ToClient::ToClientKvResponse(v7::ToClientKvResponse {
+						request_id: resp.request_id,
+						data: convert_kv_response_data_v8_to_v7(resp.data),
+					})
+				}
+				v8::ToClient::ToClientTunnelMessage(msg) => {
+					v7::ToClient::ToClientTunnelMessage(v7::ToClientTunnelMessage {
+						message_id: v7::MessageId {
+							gateway_id: msg.message_id.gateway_id,
+							request_id: msg.message_id.request_id,
+							message_index: msg.message_id.message_index,
+						},
+						message_kind: convert_to_client_tunnel_message_kind_v8_to_v7(
+							msg.message_kind,
+						),
+					})
+				}
+				v8::ToClient::ToClientPing(ping) => {
+					v7::ToClient::ToClientPing(v7::ToClientPing { ts: ping.ts })
+				}
+			};
+
+			Ok(ToClientMk2::V7(inner))
+		} else {
+			bail!("unexpected version");
+		}
+	}
 }
 
 pub enum ToServerMk2 {
 	V4(v4::ToServer),
 	V6(v6::ToServer),
-	V7(v7::ToServer),
+	// v7 and v8 have the same ToServer binary format.
+	V8(v8::ToServer),
 }
 
 impl OwnedVersionedData for ToServerMk2 {
-	type Latest = v7::ToServer;
+	type Latest = v8::ToServer;
 
-	fn wrap_latest(latest: v7::ToServer) -> Self {
-		ToServerMk2::V7(latest)
+	fn wrap_latest(latest: v8::ToServer) -> Self {
+		ToServerMk2::V8(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
-		if let ToServerMk2::V7(data) = self {
+		if let ToServerMk2::V8(data) = self {
 			Ok(data)
 		} else {
 			bail!("version not latest");
@@ -424,7 +601,8 @@ impl OwnedVersionedData for ToServerMk2 {
 			4 => Ok(ToServerMk2::V4(serde_bare::from_slice(payload)?)),
 			// v5 and v6 have the same ToServer binary format
 			5 | 6 => Ok(ToServerMk2::V6(serde_bare::from_slice(payload)?)),
-			7 => Ok(ToServerMk2::V7(serde_bare::from_slice(payload)?)),
+			// v7 and v8 have the same ToServer binary format
+			7 | 8 => Ok(ToServerMk2::V8(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -433,18 +611,18 @@ impl OwnedVersionedData for ToServerMk2 {
 		match self {
 			ToServerMk2::V4(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ToServerMk2::V6(data) => serde_bare::to_vec(&data).map_err(Into::into),
-			ToServerMk2::V7(data) => serde_bare::to_vec(&data).map_err(Into::into),
+			ToServerMk2::V8(data) => serde_bare::to_vec(&data).map_err(Into::into),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		// No changes between v1 and v4, no changes between v5 and v6
-		vec![Ok, Ok, Ok, Self::v4_to_v6, Ok, Self::v6_to_v7]
+		// No changes between v1 and v4, no changes between v5 and v6, no changes between v7 and v8
+		vec![Ok, Ok, Ok, Self::v4_to_v6, Ok, Self::v6_to_v8, Ok]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		// No changes between v1 and v4, no changes between v5 and v6
-		vec![Self::v7_to_v6, Ok, Self::v6_to_v4, Ok, Ok, Ok]
+		// No changes between v1 and v4, no changes between v5 and v6, no changes between v7 and v8
+		vec![Ok, Self::v8_to_v6, Ok, Self::v6_to_v4, Ok, Ok, Ok]
 	}
 }
 
@@ -651,10 +829,10 @@ impl ToServerMk2 {
 		}
 	}
 
-	fn v6_to_v7(self) -> Result<Self> {
+	fn v6_to_v8(self) -> Result<Self> {
 		if let ToServerMk2::V6(x) = self {
 			let inner = match x {
-				v6::ToServer::ToServerInit(init) => v7::ToServer::ToServerInit(v7::ToServerInit {
+				v6::ToServer::ToServerInit(init) => v8::ToServer::ToServerInit(v8::ToServerInit {
 					name: init.name,
 					version: init.version,
 					total_slots: init.total_slots,
@@ -663,7 +841,7 @@ impl ToServerMk2 {
 							.map(|(k, v)| {
 								(
 									k,
-									v7::ActorName {
+									v8::ActorName {
 										metadata: v.metadata,
 									},
 								)
@@ -672,41 +850,41 @@ impl ToServerMk2 {
 					}),
 					metadata: init.metadata,
 				}),
-				v6::ToServer::ToServerEvents(events) => v7::ToServer::ToServerEvents(
+				v6::ToServer::ToServerEvents(events) => v8::ToServer::ToServerEvents(
 					events
 						.into_iter()
-						.map(|event| v7::EventWrapper {
-							checkpoint: v7::ActorCheckpoint {
+						.map(|event| v8::EventWrapper {
+							checkpoint: v8::ActorCheckpoint {
 								actor_id: event.checkpoint.actor_id,
 								generation: event.checkpoint.generation,
 								index: event.checkpoint.index,
 							},
 							inner: match event.inner {
 								v6::Event::EventActorIntent(intent) => {
-									v7::Event::EventActorIntent(v7::EventActorIntent {
+									v8::Event::EventActorIntent(v8::EventActorIntent {
 										intent: match intent.intent {
 											v6::ActorIntent::ActorIntentSleep => {
-												v7::ActorIntent::ActorIntentSleep
+												v8::ActorIntent::ActorIntentSleep
 											}
 											v6::ActorIntent::ActorIntentStop => {
-												v7::ActorIntent::ActorIntentStop
+												v8::ActorIntent::ActorIntentStop
 											}
 										},
 									})
 								}
 								v6::Event::EventActorStateUpdate(state) => {
-									v7::Event::EventActorStateUpdate(v7::EventActorStateUpdate {
+									v8::Event::EventActorStateUpdate(v8::EventActorStateUpdate {
 										state: match state.state {
 											v6::ActorState::ActorStateRunning => {
-												v7::ActorState::ActorStateRunning
+												v8::ActorState::ActorStateRunning
 											}
 											v6::ActorState::ActorStateStopped(stopped) => {
-												v7::ActorState::ActorStateStopped(
-													v7::ActorStateStopped {
+												v8::ActorState::ActorStateStopped(
+													v8::ActorStateStopped {
 														code: match stopped.code {
-															v6::StopCode::Ok => v7::StopCode::Ok,
+															v6::StopCode::Ok => v8::StopCode::Ok,
 															v6::StopCode::Error => {
-																v7::StopCode::Error
+																v8::StopCode::Error
 															}
 														},
 														message: stopped.message,
@@ -717,7 +895,7 @@ impl ToServerMk2 {
 									})
 								}
 								v6::Event::EventActorSetAlarm(alarm) => {
-									v7::Event::EventActorSetAlarm(v7::EventActorSetAlarm {
+									v8::Event::EventActorSetAlarm(v8::EventActorSetAlarm {
 										alarm_ts: alarm.alarm_ts,
 									})
 								}
@@ -726,11 +904,11 @@ impl ToServerMk2 {
 						.collect(),
 				),
 				v6::ToServer::ToServerAckCommands(ack) => {
-					v7::ToServer::ToServerAckCommands(v7::ToServerAckCommands {
+					v8::ToServer::ToServerAckCommands(v8::ToServerAckCommands {
 						last_command_checkpoints: ack
 							.last_command_checkpoints
 							.into_iter()
-							.map(|cp| v7::ActorCheckpoint {
+							.map(|cp| v8::ActorCheckpoint {
 								actor_id: cp.actor_id,
 								generation: cp.generation,
 								index: cp.index,
@@ -738,28 +916,28 @@ impl ToServerMk2 {
 							.collect(),
 					})
 				}
-				v6::ToServer::ToServerStopping => v7::ToServer::ToServerStopping,
+				v6::ToServer::ToServerStopping => v8::ToServer::ToServerStopping,
 				v6::ToServer::ToServerPong(pong) => {
-					v7::ToServer::ToServerPong(v7::ToServerPong { ts: pong.ts })
+					v8::ToServer::ToServerPong(v8::ToServerPong { ts: pong.ts })
 				}
 				v6::ToServer::ToServerKvRequest(req) => {
-					v7::ToServer::ToServerKvRequest(v7::ToServerKvRequest {
+					v8::ToServer::ToServerKvRequest(v8::ToServerKvRequest {
 						actor_id: req.actor_id,
 						request_id: req.request_id,
-						data: convert_kv_request_data_v6_to_v7(req.data),
+						data: convert_kv_request_data_v6_to_v8(req.data),
 					})
 				}
 				v6::ToServer::ToServerTunnelMessage(msg) => {
-					v7::ToServer::ToServerTunnelMessage(v7::ToServerTunnelMessage {
-						message_id: v7::MessageId {
+					v8::ToServer::ToServerTunnelMessage(v8::ToServerTunnelMessage {
+						message_id: v8::MessageId {
 							gateway_id: msg.message_id.gateway_id,
 							request_id: msg.message_id.request_id,
 							message_index: msg.message_id.message_index,
 						},
 						message_kind: match msg.message_kind {
 							v6::ToServerTunnelMessageKind::ToServerResponseStart(resp) => {
-								v7::ToServerTunnelMessageKind::ToServerResponseStart(
-									v7::ToServerResponseStart {
+								v8::ToServerTunnelMessageKind::ToServerResponseStart(
+									v8::ToServerResponseStart {
 										status: resp.status,
 										headers: resp.headers,
 										body: resp.body,
@@ -768,39 +946,39 @@ impl ToServerMk2 {
 								)
 							}
 							v6::ToServerTunnelMessageKind::ToServerResponseChunk(chunk) => {
-								v7::ToServerTunnelMessageKind::ToServerResponseChunk(
-									v7::ToServerResponseChunk {
+								v8::ToServerTunnelMessageKind::ToServerResponseChunk(
+									v8::ToServerResponseChunk {
 										body: chunk.body,
 										finish: chunk.finish,
 									},
 								)
 							}
 							v6::ToServerTunnelMessageKind::ToServerResponseAbort => {
-								v7::ToServerTunnelMessageKind::ToServerResponseAbort
+								v8::ToServerTunnelMessageKind::ToServerResponseAbort
 							}
 							v6::ToServerTunnelMessageKind::ToServerWebSocketOpen(open) => {
-								v7::ToServerTunnelMessageKind::ToServerWebSocketOpen(
-									v7::ToServerWebSocketOpen {
+								v8::ToServerTunnelMessageKind::ToServerWebSocketOpen(
+									v8::ToServerWebSocketOpen {
 										can_hibernate: open.can_hibernate,
 									},
 								)
 							}
 							v6::ToServerTunnelMessageKind::ToServerWebSocketMessage(message) => {
-								v7::ToServerTunnelMessageKind::ToServerWebSocketMessage(
-									v7::ToServerWebSocketMessage {
+								v8::ToServerTunnelMessageKind::ToServerWebSocketMessage(
+									v8::ToServerWebSocketMessage {
 										data: message.data,
 										binary: message.binary,
 									},
 								)
 							}
 							v6::ToServerTunnelMessageKind::ToServerWebSocketMessageAck(ack) => {
-								v7::ToServerTunnelMessageKind::ToServerWebSocketMessageAck(
-									v7::ToServerWebSocketMessageAck { index: ack.index },
+								v8::ToServerTunnelMessageKind::ToServerWebSocketMessageAck(
+									v8::ToServerWebSocketMessageAck { index: ack.index },
 								)
 							}
 							v6::ToServerTunnelMessageKind::ToServerWebSocketClose(close) => {
-								v7::ToServerTunnelMessageKind::ToServerWebSocketClose(
-									v7::ToServerWebSocketClose {
+								v8::ToServerTunnelMessageKind::ToServerWebSocketClose(
+									v8::ToServerWebSocketClose {
 										code: close.code,
 										reason: close.reason,
 										hibernate: close.hibernate,
@@ -812,16 +990,16 @@ impl ToServerMk2 {
 				}
 			};
 
-			Ok(ToServerMk2::V7(inner))
+			Ok(ToServerMk2::V8(inner))
 		} else {
 			bail!("unexpected version");
 		}
 	}
 
-	fn v7_to_v6(self) -> Result<Self> {
-		if let ToServerMk2::V7(x) = self {
+	fn v8_to_v6(self) -> Result<Self> {
+		if let ToServerMk2::V8(x) = self {
 			let inner = match x {
-				v7::ToServer::ToServerInit(init) => v6::ToServer::ToServerInit(v6::ToServerInit {
+				v8::ToServer::ToServerInit(init) => v6::ToServer::ToServerInit(v6::ToServerInit {
 					name: init.name,
 					version: init.version,
 					total_slots: init.total_slots,
@@ -839,7 +1017,7 @@ impl ToServerMk2 {
 					}),
 					metadata: init.metadata,
 				}),
-				v7::ToServer::ToServerEvents(events) => v6::ToServer::ToServerEvents(
+				v8::ToServer::ToServerEvents(events) => v6::ToServer::ToServerEvents(
 					events
 						.into_iter()
 						.map(|event| v6::EventWrapper {
@@ -849,30 +1027,30 @@ impl ToServerMk2 {
 								index: event.checkpoint.index,
 							},
 							inner: match event.inner {
-								v7::Event::EventActorIntent(intent) => {
+								v8::Event::EventActorIntent(intent) => {
 									v6::Event::EventActorIntent(v6::EventActorIntent {
 										intent: match intent.intent {
-											v7::ActorIntent::ActorIntentSleep => {
+											v8::ActorIntent::ActorIntentSleep => {
 												v6::ActorIntent::ActorIntentSleep
 											}
-											v7::ActorIntent::ActorIntentStop => {
+											v8::ActorIntent::ActorIntentStop => {
 												v6::ActorIntent::ActorIntentStop
 											}
 										},
 									})
 								}
-								v7::Event::EventActorStateUpdate(state) => {
+								v8::Event::EventActorStateUpdate(state) => {
 									v6::Event::EventActorStateUpdate(v6::EventActorStateUpdate {
 										state: match state.state {
-											v7::ActorState::ActorStateRunning => {
+											v8::ActorState::ActorStateRunning => {
 												v6::ActorState::ActorStateRunning
 											}
-											v7::ActorState::ActorStateStopped(stopped) => {
+											v8::ActorState::ActorStateStopped(stopped) => {
 												v6::ActorState::ActorStateStopped(
 													v6::ActorStateStopped {
 														code: match stopped.code {
-															v7::StopCode::Ok => v6::StopCode::Ok,
-															v7::StopCode::Error => {
+															v8::StopCode::Ok => v6::StopCode::Ok,
+															v8::StopCode::Error => {
 																v6::StopCode::Error
 															}
 														},
@@ -883,7 +1061,7 @@ impl ToServerMk2 {
 										},
 									})
 								}
-								v7::Event::EventActorSetAlarm(alarm) => {
+								v8::Event::EventActorSetAlarm(alarm) => {
 									v6::Event::EventActorSetAlarm(v6::EventActorSetAlarm {
 										alarm_ts: alarm.alarm_ts,
 									})
@@ -892,7 +1070,7 @@ impl ToServerMk2 {
 						})
 						.collect(),
 				),
-				v7::ToServer::ToServerAckCommands(ack) => {
+				v8::ToServer::ToServerAckCommands(ack) => {
 					v6::ToServer::ToServerAckCommands(v6::ToServerAckCommands {
 						last_command_checkpoints: ack
 							.last_command_checkpoints
@@ -905,18 +1083,18 @@ impl ToServerMk2 {
 							.collect(),
 					})
 				}
-				v7::ToServer::ToServerStopping => v6::ToServer::ToServerStopping,
-				v7::ToServer::ToServerPong(pong) => {
+				v8::ToServer::ToServerStopping => v6::ToServer::ToServerStopping,
+				v8::ToServer::ToServerPong(pong) => {
 					v6::ToServer::ToServerPong(v6::ToServerPong { ts: pong.ts })
 				}
-				v7::ToServer::ToServerKvRequest(req) => {
+				v8::ToServer::ToServerKvRequest(req) => {
 					v6::ToServer::ToServerKvRequest(v6::ToServerKvRequest {
 						actor_id: req.actor_id,
 						request_id: req.request_id,
-						data: convert_kv_request_data_v7_to_v6(req.data)?,
+						data: convert_kv_request_data_v8_to_v6(req.data)?,
 					})
 				}
-				v7::ToServer::ToServerTunnelMessage(msg) => {
+				v8::ToServer::ToServerTunnelMessage(msg) => {
 					v6::ToServer::ToServerTunnelMessage(v6::ToServerTunnelMessage {
 						message_id: v6::MessageId {
 							gateway_id: msg.message_id.gateway_id,
@@ -924,7 +1102,7 @@ impl ToServerMk2 {
 							message_index: msg.message_id.message_index,
 						},
 						message_kind: match msg.message_kind {
-							v7::ToServerTunnelMessageKind::ToServerResponseStart(resp) => {
+							v8::ToServerTunnelMessageKind::ToServerResponseStart(resp) => {
 								v6::ToServerTunnelMessageKind::ToServerResponseStart(
 									v6::ToServerResponseStart {
 										status: resp.status,
@@ -934,7 +1112,7 @@ impl ToServerMk2 {
 									},
 								)
 							}
-							v7::ToServerTunnelMessageKind::ToServerResponseChunk(chunk) => {
+							v8::ToServerTunnelMessageKind::ToServerResponseChunk(chunk) => {
 								v6::ToServerTunnelMessageKind::ToServerResponseChunk(
 									v6::ToServerResponseChunk {
 										body: chunk.body,
@@ -942,17 +1120,17 @@ impl ToServerMk2 {
 									},
 								)
 							}
-							v7::ToServerTunnelMessageKind::ToServerResponseAbort => {
+							v8::ToServerTunnelMessageKind::ToServerResponseAbort => {
 								v6::ToServerTunnelMessageKind::ToServerResponseAbort
 							}
-							v7::ToServerTunnelMessageKind::ToServerWebSocketOpen(open) => {
+							v8::ToServerTunnelMessageKind::ToServerWebSocketOpen(open) => {
 								v6::ToServerTunnelMessageKind::ToServerWebSocketOpen(
 									v6::ToServerWebSocketOpen {
 										can_hibernate: open.can_hibernate,
 									},
 								)
 							}
-							v7::ToServerTunnelMessageKind::ToServerWebSocketMessage(message) => {
+							v8::ToServerTunnelMessageKind::ToServerWebSocketMessage(message) => {
 								v6::ToServerTunnelMessageKind::ToServerWebSocketMessage(
 									v6::ToServerWebSocketMessage {
 										data: message.data,
@@ -960,12 +1138,12 @@ impl ToServerMk2 {
 									},
 								)
 							}
-							v7::ToServerTunnelMessageKind::ToServerWebSocketMessageAck(ack) => {
+							v8::ToServerTunnelMessageKind::ToServerWebSocketMessageAck(ack) => {
 								v6::ToServerTunnelMessageKind::ToServerWebSocketMessageAck(
 									v6::ToServerWebSocketMessageAck { index: ack.index },
 								)
 							}
-							v7::ToServerTunnelMessageKind::ToServerWebSocketClose(close) => {
+							v8::ToServerTunnelMessageKind::ToServerWebSocketClose(close) => {
 								v6::ToServerTunnelMessageKind::ToServerWebSocketClose(
 									v6::ToServerWebSocketClose {
 										code: close.code,
@@ -989,17 +1167,18 @@ impl ToServerMk2 {
 pub enum ToRunnerMk2 {
 	V4(v4::ToRunner),
 	V7(v7::ToRunner),
+	V8(v8::ToRunner),
 }
 
 impl OwnedVersionedData for ToRunnerMk2 {
-	type Latest = v7::ToRunner;
+	type Latest = v8::ToRunner;
 
-	fn wrap_latest(latest: v7::ToRunner) -> Self {
-		ToRunnerMk2::V7(latest)
+	fn wrap_latest(latest: v8::ToRunner) -> Self {
+		ToRunnerMk2::V8(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
-		if let ToRunnerMk2::V7(data) = self {
+		if let ToRunnerMk2::V8(data) = self {
 			Ok(data)
 		} else {
 			bail!("version not latest");
@@ -1010,6 +1189,7 @@ impl OwnedVersionedData for ToRunnerMk2 {
 		match version {
 			4 => Ok(ToRunnerMk2::V4(serde_bare::from_slice(payload)?)),
 			5 | 6 | 7 => Ok(ToRunnerMk2::V7(serde_bare::from_slice(payload)?)),
+			8 => Ok(ToRunnerMk2::V8(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -1018,15 +1198,16 @@ impl OwnedVersionedData for ToRunnerMk2 {
 		match self {
 			ToRunnerMk2::V4(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ToRunnerMk2::V7(data) => serde_bare::to_vec(&data).map_err(Into::into),
+			ToRunnerMk2::V8(data) => serde_bare::to_vec(&data).map_err(Into::into),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Self::v4_to_v7, Ok, Ok]
+		vec![Ok, Ok, Ok, Self::v4_to_v7, Ok, Ok, Self::v7_to_v8]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Self::v7_to_v4, Ok, Ok, Ok]
+		vec![Self::v8_to_v7, Ok, Ok, Self::v7_to_v4, Ok, Ok, Ok]
 	}
 }
 
@@ -1182,6 +1363,157 @@ impl ToRunnerMk2 {
 			};
 
 			Ok(ToRunnerMk2::V4(inner))
+		} else {
+			bail!("unexpected version");
+		}
+	}
+
+	fn v7_to_v8(self) -> Result<Self> {
+		if let ToRunnerMk2::V7(x) = self {
+			let inner = match x {
+				v7::ToRunner::ToRunnerPing(ping) => v8::ToRunner::ToRunnerPing(v8::ToRunnerPing {
+					gateway_id: ping.gateway_id,
+					request_id: ping.request_id,
+					ts: ping.ts,
+				}),
+				v7::ToRunner::ToRunnerClose => v8::ToRunner::ToRunnerClose,
+				v7::ToRunner::ToClientCommands(commands) => v8::ToRunner::ToClientCommands(
+					commands
+						.into_iter()
+						.map(|cmd| v8::CommandWrapper {
+							checkpoint: v8::ActorCheckpoint {
+								actor_id: cmd.checkpoint.actor_id,
+								generation: cmd.checkpoint.generation,
+								index: cmd.checkpoint.index,
+							},
+							inner: match cmd.inner {
+								v7::Command::CommandStartActor(start) => {
+									v8::Command::CommandStartActor(v8::CommandStartActor {
+										config: v8::ActorConfig {
+											name: start.config.name,
+											key: start.config.key,
+											create_ts: start.config.create_ts,
+											input: start.config.input,
+										},
+										hibernating_requests: start
+											.hibernating_requests
+											.into_iter()
+											.map(|req| v8::HibernatingRequest {
+												gateway_id: req.gateway_id,
+												request_id: req.request_id,
+											})
+											.collect(),
+										preloaded_kv: None,
+									})
+								}
+								v7::Command::CommandStopActor => v8::Command::CommandStopActor,
+							},
+						})
+						.collect(),
+				),
+				v7::ToRunner::ToClientAckEvents(ack) => {
+					v8::ToRunner::ToClientAckEvents(v8::ToClientAckEvents {
+						last_event_checkpoints: ack
+							.last_event_checkpoints
+							.into_iter()
+							.map(|cp| v8::ActorCheckpoint {
+								actor_id: cp.actor_id,
+								generation: cp.generation,
+								index: cp.index,
+							})
+							.collect(),
+					})
+				}
+				v7::ToRunner::ToClientTunnelMessage(msg) => {
+					v8::ToRunner::ToClientTunnelMessage(v8::ToClientTunnelMessage {
+						message_id: v8::MessageId {
+							gateway_id: msg.message_id.gateway_id,
+							request_id: msg.message_id.request_id,
+							message_index: msg.message_id.message_index,
+						},
+						message_kind: convert_to_client_tunnel_message_kind_v7_to_v8(
+							msg.message_kind,
+						),
+					})
+				}
+			};
+
+			Ok(ToRunnerMk2::V8(inner))
+		} else {
+			bail!("unexpected version");
+		}
+	}
+
+	fn v8_to_v7(self) -> Result<Self> {
+		if let ToRunnerMk2::V8(x) = self {
+			let inner = match x {
+				v8::ToRunner::ToRunnerPing(ping) => v7::ToRunner::ToRunnerPing(v7::ToRunnerPing {
+					gateway_id: ping.gateway_id,
+					request_id: ping.request_id,
+					ts: ping.ts,
+				}),
+				v8::ToRunner::ToRunnerClose => v7::ToRunner::ToRunnerClose,
+				v8::ToRunner::ToClientCommands(commands) => v7::ToRunner::ToClientCommands(
+					commands
+						.into_iter()
+						.map(|cmd| v7::CommandWrapper {
+							checkpoint: v7::ActorCheckpoint {
+								actor_id: cmd.checkpoint.actor_id,
+								generation: cmd.checkpoint.generation,
+								index: cmd.checkpoint.index,
+							},
+							inner: match cmd.inner {
+								v8::Command::CommandStartActor(start) => {
+									v7::Command::CommandStartActor(v7::CommandStartActor {
+										config: v7::ActorConfig {
+											name: start.config.name,
+											key: start.config.key,
+											create_ts: start.config.create_ts,
+											input: start.config.input,
+										},
+										hibernating_requests: start
+											.hibernating_requests
+											.into_iter()
+											.map(|req| v7::HibernatingRequest {
+												gateway_id: req.gateway_id,
+												request_id: req.request_id,
+											})
+											.collect(),
+									})
+								}
+								v8::Command::CommandStopActor => v7::Command::CommandStopActor,
+							},
+						})
+						.collect(),
+				),
+				v8::ToRunner::ToClientAckEvents(ack) => {
+					v7::ToRunner::ToClientAckEvents(v7::ToClientAckEvents {
+						last_event_checkpoints: ack
+							.last_event_checkpoints
+							.into_iter()
+							.map(|cp| v7::ActorCheckpoint {
+								actor_id: cp.actor_id,
+								generation: cp.generation,
+								index: cp.index,
+							})
+							.collect(),
+					})
+				}
+				v8::ToRunner::ToClientTunnelMessage(msg) => {
+					v7::ToRunner::ToClientTunnelMessage(v7::ToClientTunnelMessage {
+						message_id: v7::MessageId {
+							gateway_id: msg.message_id.gateway_id,
+							request_id: msg.message_id.request_id,
+							message_index: msg.message_id.message_index,
+						},
+						message_kind: convert_to_client_tunnel_message_kind_v8_to_v7(
+							msg.message_kind,
+						),
+					})
+				}
+			};
+
+			Ok(ToRunnerMk2::V7(inner))
 		} else {
 			bail!("unexpected version");
 		}
@@ -1918,19 +2250,20 @@ impl OwnedVersionedData for ToRunner {
 
 pub enum ToGateway {
 	V3(v3::ToGateway),
-	V7(v7::ToGateway),
+	// v4-v8 have the same ToGateway binary format.
+	V8(v8::ToGateway),
 }
 
 impl OwnedVersionedData for ToGateway {
-	type Latest = v7::ToGateway;
+	type Latest = v8::ToGateway;
 
-	fn wrap_latest(latest: v7::ToGateway) -> Self {
-		ToGateway::V7(latest)
+	fn wrap_latest(latest: v8::ToGateway) -> Self {
+		ToGateway::V8(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
 		#[allow(irrefutable_let_patterns)]
-		if let ToGateway::V7(data) = self {
+		if let ToGateway::V8(data) = self {
 			Ok(data)
 		} else {
 			bail!("version not latest");
@@ -1940,7 +2273,8 @@ impl OwnedVersionedData for ToGateway {
 	fn deserialize_version(payload: &[u8], version: u16) -> Result<Self> {
 		match version {
 			1 | 2 | 3 => Ok(ToGateway::V3(serde_bare::from_slice(payload)?)),
-			4 | 5 | 6 | 7 => Ok(ToGateway::V7(serde_bare::from_slice(payload)?)),
+			// v4-v8 have the same ToGateway binary format
+			4 | 5 | 6 | 7 | 8 => Ok(ToGateway::V8(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -1948,59 +2282,59 @@ impl OwnedVersionedData for ToGateway {
 	fn serialize_version(self, _version: u16) -> Result<Vec<u8>> {
 		match self {
 			ToGateway::V3(data) => serde_bare::to_vec(&data).map_err(Into::into),
-			ToGateway::V7(data) => serde_bare::to_vec(&data).map_err(Into::into),
+			ToGateway::V8(data) => serde_bare::to_vec(&data).map_err(Into::into),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Self::v3_to_v7, Ok, Ok, Ok]
+		vec![Ok, Ok, Self::v3_to_v8, Ok, Ok, Ok, Ok]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Self::v7_to_v3, Ok, Ok]
+		vec![Ok, Ok, Ok, Ok, Self::v8_to_v3, Ok, Ok]
 	}
 }
 
 impl ToGateway {
-	pub fn v3_to_v7(self) -> Result<Self> {
+	pub fn v3_to_v8(self) -> Result<Self> {
 		if let ToGateway::V3(x) = self {
 			let inner = match x {
 				v3::ToGateway::ToGatewayPong(pong) => {
-					v7::ToGateway::ToGatewayPong(v7::ToGatewayPong {
+					v8::ToGateway::ToGatewayPong(v8::ToGatewayPong {
 						request_id: pong.request_id,
 						ts: pong.ts,
 					})
 				}
 				v3::ToGateway::ToServerTunnelMessage(msg) => {
-					v7::ToGateway::ToServerTunnelMessage(v7::ToServerTunnelMessage {
-						message_id: v7::MessageId {
+					v8::ToGateway::ToServerTunnelMessage(v8::ToServerTunnelMessage {
+						message_id: v8::MessageId {
 							gateway_id: msg.message_id.gateway_id,
 							request_id: msg.message_id.request_id,
 							message_index: msg.message_id.message_index,
 						},
-						message_kind: convert_to_server_tunnel_message_kind_v6_to_v7(
+						message_kind: convert_to_server_tunnel_message_kind_v6_to_v8(
 							convert_to_server_tunnel_message_kind_v3_to_v4(msg.message_kind),
 						),
 					})
 				}
 			};
 
-			Ok(ToGateway::V7(inner))
+			Ok(ToGateway::V8(inner))
 		} else {
 			bail!("unexpected version");
 		}
 	}
 
-	fn v7_to_v3(self) -> Result<Self> {
-		if let ToGateway::V7(x) = self {
+	fn v8_to_v3(self) -> Result<Self> {
+		if let ToGateway::V8(x) = self {
 			let inner = match x {
-				v7::ToGateway::ToGatewayPong(pong) => {
+				v8::ToGateway::ToGatewayPong(pong) => {
 					v3::ToGateway::ToGatewayPong(v3::ToGatewayPong {
 						request_id: pong.request_id,
 						ts: pong.ts,
 					})
 				}
-				v7::ToGateway::ToServerTunnelMessage(msg) => {
+				v8::ToGateway::ToServerTunnelMessage(msg) => {
 					v3::ToGateway::ToServerTunnelMessage(v3::ToServerTunnelMessage {
 						message_id: v3::MessageId {
 							gateway_id: msg.message_id.gateway_id,
@@ -2008,7 +2342,7 @@ impl ToGateway {
 							message_index: msg.message_id.message_index,
 						},
 						message_kind: convert_to_server_tunnel_message_kind_v4_to_v3(
-							convert_to_server_tunnel_message_kind_v7_to_v6(msg.message_kind),
+							convert_to_server_tunnel_message_kind_v8_to_v6(msg.message_kind),
 						)?,
 					})
 				}
@@ -2023,19 +2357,19 @@ impl ToGateway {
 
 pub enum ToServerlessServer {
 	V3(v3::ToServerlessServer),
-	V7(v7::ToServerlessServer),
+	V8(v8::ToServerlessServer),
 }
 
 impl OwnedVersionedData for ToServerlessServer {
-	type Latest = v7::ToServerlessServer;
+	type Latest = v8::ToServerlessServer;
 
-	fn wrap_latest(latest: v7::ToServerlessServer) -> Self {
-		ToServerlessServer::V7(latest)
+	fn wrap_latest(latest: v8::ToServerlessServer) -> Self {
+		ToServerlessServer::V8(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
 		#[allow(irrefutable_let_patterns)]
-		if let ToServerlessServer::V7(data) = self {
+		if let ToServerlessServer::V8(data) = self {
 			Ok(data)
 		} else {
 			bail!("version not latest");
@@ -2045,7 +2379,8 @@ impl OwnedVersionedData for ToServerlessServer {
 	fn deserialize_version(payload: &[u8], version: u16) -> Result<Self> {
 		match version {
 			1 | 2 | 3 => Ok(ToServerlessServer::V3(serde_bare::from_slice(payload)?)),
-			4 | 5 | 6 | 7 => Ok(ToServerlessServer::V7(serde_bare::from_slice(payload)?)),
+			// v4-v8 have the same ToServerlessServer binary format
+			4 | 5 | 6 | 7 | 8 => Ok(ToServerlessServer::V8(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -2053,41 +2388,41 @@ impl OwnedVersionedData for ToServerlessServer {
 	fn serialize_version(self, _version: u16) -> Result<Vec<u8>> {
 		match self {
 			ToServerlessServer::V3(data) => serde_bare::to_vec(&data).map_err(Into::into),
-			ToServerlessServer::V7(data) => serde_bare::to_vec(&data).map_err(Into::into),
+			ToServerlessServer::V8(data) => serde_bare::to_vec(&data).map_err(Into::into),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Self::v3_to_v7, Ok, Ok, Ok]
+		vec![Ok, Ok, Self::v3_to_v8, Ok, Ok, Ok, Ok]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Self::v7_to_v3, Ok, Ok]
+		vec![Ok, Ok, Ok, Ok, Self::v8_to_v3, Ok, Ok]
 	}
 }
 
 impl ToServerlessServer {
-	fn v3_to_v7(self) -> Result<Self> {
+	fn v3_to_v8(self) -> Result<Self> {
 		if let ToServerlessServer::V3(x) = self {
 			let inner = match x {
 				v3::ToServerlessServer::ToServerlessServerInit(init) => {
-					v7::ToServerlessServer::ToServerlessServerInit(v7::ToServerlessServerInit {
+					v8::ToServerlessServer::ToServerlessServerInit(v8::ToServerlessServerInit {
 						runner_id: init.runner_id,
 						runner_protocol_version: PROTOCOL_MK1_VERSION,
 					})
 				}
 			};
 
-			Ok(ToServerlessServer::V7(inner))
+			Ok(ToServerlessServer::V8(inner))
 		} else {
 			bail!("unexpected version");
 		}
 	}
 
-	fn v7_to_v3(self) -> Result<Self> {
-		if let ToServerlessServer::V7(x) = self {
+	fn v8_to_v3(self) -> Result<Self> {
+		if let ToServerlessServer::V8(x) = self {
 			let inner = match x {
-				v7::ToServerlessServer::ToServerlessServerInit(init) => {
+				v8::ToServerlessServer::ToServerlessServerInit(init) => {
 					v3::ToServerlessServer::ToServerlessServerInit(v3::ToServerlessServerInit {
 						runner_id: init.runner_id,
 					})
@@ -2104,17 +2439,18 @@ impl ToServerlessServer {
 pub enum ActorCommandKeyData {
 	V4(v4::ActorCommandKeyData),
 	V7(v7::ActorCommandKeyData),
+	V8(v8::ActorCommandKeyData),
 }
 
 impl OwnedVersionedData for ActorCommandKeyData {
-	type Latest = v7::ActorCommandKeyData;
+	type Latest = v8::ActorCommandKeyData;
 
-	fn wrap_latest(latest: v7::ActorCommandKeyData) -> Self {
-		ActorCommandKeyData::V7(latest)
+	fn wrap_latest(latest: v8::ActorCommandKeyData) -> Self {
+		ActorCommandKeyData::V8(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
-		if let ActorCommandKeyData::V7(data) = self {
+		if let ActorCommandKeyData::V8(data) = self {
 			Ok(data)
 		} else {
 			bail!("version not latest");
@@ -2125,6 +2461,7 @@ impl OwnedVersionedData for ActorCommandKeyData {
 		match version {
 			4 => Ok(ActorCommandKeyData::V4(serde_bare::from_slice(payload)?)),
 			5 | 6 | 7 => Ok(ActorCommandKeyData::V7(serde_bare::from_slice(payload)?)),
+			8 => Ok(ActorCommandKeyData::V8(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -2133,15 +2470,16 @@ impl OwnedVersionedData for ActorCommandKeyData {
 		match self {
 			ActorCommandKeyData::V4(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ActorCommandKeyData::V7(data) => serde_bare::to_vec(&data).map_err(Into::into),
+			ActorCommandKeyData::V8(data) => serde_bare::to_vec(&data).map_err(Into::into),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Self::v4_to_v7, Ok, Ok]
+		vec![Ok, Ok, Ok, Self::v4_to_v7, Ok, Ok, Self::v7_to_v8]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Self::v7_to_v4, Ok, Ok, Ok]
+		vec![Self::v8_to_v7, Ok, Ok, Self::v7_to_v4, Ok, Ok, Ok]
 	}
 }
 
@@ -2209,6 +2547,71 @@ impl ActorCommandKeyData {
 			};
 
 			Ok(ActorCommandKeyData::V4(inner))
+		} else {
+			bail!("unexpected version");
+		}
+	}
+
+	fn v7_to_v8(self) -> Result<Self> {
+		if let ActorCommandKeyData::V7(x) = self {
+			let inner = match x {
+				v7::ActorCommandKeyData::CommandStartActor(start) => {
+					v8::ActorCommandKeyData::CommandStartActor(v8::CommandStartActor {
+						config: v8::ActorConfig {
+							name: start.config.name,
+							key: start.config.key,
+							create_ts: start.config.create_ts,
+							input: start.config.input,
+						},
+						hibernating_requests: start
+							.hibernating_requests
+							.into_iter()
+							.map(|req| v8::HibernatingRequest {
+								gateway_id: req.gateway_id,
+								request_id: req.request_id,
+							})
+							.collect(),
+						preloaded_kv: None,
+					})
+				}
+				v7::ActorCommandKeyData::CommandStopActor => {
+					v8::ActorCommandKeyData::CommandStopActor
+				}
+			};
+
+			Ok(ActorCommandKeyData::V8(inner))
+		} else {
+			bail!("unexpected version");
+		}
+	}
+
+	fn v8_to_v7(self) -> Result<Self> {
+		if let ActorCommandKeyData::V8(x) = self {
+			let inner = match x {
+				v8::ActorCommandKeyData::CommandStartActor(start) => {
+					v7::ActorCommandKeyData::CommandStartActor(v7::CommandStartActor {
+						config: v7::ActorConfig {
+							name: start.config.name,
+							key: start.config.key,
+							create_ts: start.config.create_ts,
+							input: start.config.input,
+						},
+						hibernating_requests: start
+							.hibernating_requests
+							.into_iter()
+							.map(|req| v7::HibernatingRequest {
+								gateway_id: req.gateway_id,
+								request_id: req.request_id,
+							})
+							.collect(),
+					})
+				}
+				v8::ActorCommandKeyData::CommandStopActor => {
+					v7::ActorCommandKeyData::CommandStopActor
+				}
+			};
+
+			Ok(ActorCommandKeyData::V7(inner))
 		} else {
 			bail!("unexpected version");
 		}
@@ -3676,6 +4079,96 @@ fn convert_kv_list_query_v7_to_v6(query: v7::KvListQuery) -> v6::KvListQuery {
 	}
 }
 
+// v8 KvRequestData and KvListQuery are identical to v7.
+fn convert_kv_request_data_v6_to_v8(data: v6::KvRequestData) -> v8::KvRequestData {
+	match data {
+		v6::KvRequestData::KvGetRequest(req) => {
+			v8::KvRequestData::KvGetRequest(v8::KvGetRequest { keys: req.keys })
+		}
+		v6::KvRequestData::KvListRequest(req) => {
+			v8::KvRequestData::KvListRequest(v8::KvListRequest {
+				query: convert_kv_list_query_v6_to_v8(req.query),
+				reverse: req.reverse,
+				limit: req.limit,
+			})
+		}
+		v6::KvRequestData::KvPutRequest(req) => {
+			v8::KvRequestData::KvPutRequest(v8::KvPutRequest {
+				keys: req.keys,
+				values: req.values,
+			})
+		}
+		v6::KvRequestData::KvDeleteRequest(req) => {
+			v8::KvRequestData::KvDeleteRequest(v8::KvDeleteRequest { keys: req.keys })
+		}
+		v6::KvRequestData::KvDropRequest => v8::KvRequestData::KvDropRequest,
+	}
+}
+
+fn convert_kv_request_data_v8_to_v6(data: v8::KvRequestData) -> Result<v6::KvRequestData> {
+	match data {
+		v8::KvRequestData::KvGetRequest(req) => {
+			Ok(v6::KvRequestData::KvGetRequest(v6::KvGetRequest {
+				keys: req.keys,
+			}))
+		}
+		v8::KvRequestData::KvListRequest(req) => {
+			Ok(v6::KvRequestData::KvListRequest(v6::KvListRequest {
+				query: convert_kv_list_query_v8_to_v6(req.query),
+				reverse: req.reverse,
+				limit: req.limit,
+			}))
+		}
+		v8::KvRequestData::KvPutRequest(req) => {
+			Ok(v6::KvRequestData::KvPutRequest(v6::KvPutRequest {
+				keys: req.keys,
+				values: req.values,
+			}))
+		}
+		v8::KvRequestData::KvDeleteRequest(req) => {
+			Ok(v6::KvRequestData::KvDeleteRequest(v6::KvDeleteRequest {
+				keys: req.keys,
+			}))
+		}
+		v8::KvRequestData::KvDeleteRangeRequest(_) => {
+			bail!("KvDeleteRangeRequest requires runner protocol v7")
+		}
+		v8::KvRequestData::KvDropRequest => Ok(v6::KvRequestData::KvDropRequest),
+	}
+}
+
+fn convert_kv_list_query_v6_to_v8(query: v6::KvListQuery) -> v8::KvListQuery {
+	match query {
+		v6::KvListQuery::KvListAllQuery => v8::KvListQuery::KvListAllQuery,
+		v6::KvListQuery::KvListRangeQuery(range) => {
+			v8::KvListQuery::KvListRangeQuery(v8::KvListRangeQuery {
+				start: range.start,
+				end: range.end,
+				exclusive: range.exclusive,
+			})
+		}
+		v6::KvListQuery::KvListPrefixQuery(prefix) => {
+			v8::KvListQuery::KvListPrefixQuery(v8::KvListPrefixQuery { key: prefix.key })
+		}
+	}
+}
+
+fn convert_kv_list_query_v8_to_v6(query: v8::KvListQuery) -> v6::KvListQuery {
+	match query {
+		v8::KvListQuery::KvListAllQuery => v6::KvListQuery::KvListAllQuery,
+		v8::KvListQuery::KvListRangeQuery(range) => {
+			v6::KvListQuery::KvListRangeQuery(v6::KvListRangeQuery {
+				start: range.start,
+				end: range.end,
+				exclusive: range.exclusive,
+			})
+		}
+		v8::KvListQuery::KvListPrefixQuery(prefix) => {
+			v6::KvListQuery::KvListPrefixQuery(v6::KvListPrefixQuery { key: prefix.key })
+		}
+	}
+}
+
 fn convert_to_client_tunnel_message_kind_v4_to_v6(
 	kind: v4::ToClientTunnelMessageKind,
 ) -> v6::ToClientTunnelMessageKind {
@@ -4339,6 +4832,276 @@ fn convert_to_server_tunnel_message_kind_v7_to_v6(
 				code: close.code,
 				reason: close.reason,
 				hibernate: close.hibernate,
+			})
+		}
+	}
+}
+
+// v8 ToServerTunnelMessageKind is identical to v7.
+fn convert_to_server_tunnel_message_kind_v6_to_v8(
+	kind: v6::ToServerTunnelMessageKind,
+) -> v8::ToServerTunnelMessageKind {
+	match kind {
+		v6::ToServerTunnelMessageKind::ToServerResponseStart(resp) => {
+			v8::ToServerTunnelMessageKind::ToServerResponseStart(v8::ToServerResponseStart {
+				status: resp.status,
+				headers: resp.headers,
+				body: resp.body,
+				stream: resp.stream,
+			})
+		}
+		v6::ToServerTunnelMessageKind::ToServerResponseChunk(chunk) => {
+			v8::ToServerTunnelMessageKind::ToServerResponseChunk(v8::ToServerResponseChunk {
+				body: chunk.body,
+				finish: chunk.finish,
+			})
+		}
+		v6::ToServerTunnelMessageKind::ToServerResponseAbort => {
+			v8::ToServerTunnelMessageKind::ToServerResponseAbort
+		}
+		v6::ToServerTunnelMessageKind::ToServerWebSocketOpen(open) => {
+			v8::ToServerTunnelMessageKind::ToServerWebSocketOpen(v8::ToServerWebSocketOpen {
+				can_hibernate: open.can_hibernate,
+			})
+		}
+		v6::ToServerTunnelMessageKind::ToServerWebSocketMessage(msg) => {
+			v8::ToServerTunnelMessageKind::ToServerWebSocketMessage(v8::ToServerWebSocketMessage {
+				data: msg.data,
+				binary: msg.binary,
+			})
+		}
+		v6::ToServerTunnelMessageKind::ToServerWebSocketMessageAck(ack) => {
+			v8::ToServerTunnelMessageKind::ToServerWebSocketMessageAck(
+				v8::ToServerWebSocketMessageAck { index: ack.index },
+			)
+		}
+		v6::ToServerTunnelMessageKind::ToServerWebSocketClose(close) => {
+			v8::ToServerTunnelMessageKind::ToServerWebSocketClose(v8::ToServerWebSocketClose {
+				code: close.code,
+				reason: close.reason,
+				hibernate: close.hibernate,
+			})
+		}
+	}
+}
+
+fn convert_to_server_tunnel_message_kind_v8_to_v6(
+	kind: v8::ToServerTunnelMessageKind,
+) -> v6::ToServerTunnelMessageKind {
+	match kind {
+		v8::ToServerTunnelMessageKind::ToServerResponseStart(resp) => {
+			v6::ToServerTunnelMessageKind::ToServerResponseStart(v6::ToServerResponseStart {
+				status: resp.status,
+				headers: resp.headers,
+				body: resp.body,
+				stream: resp.stream,
+			})
+		}
+		v8::ToServerTunnelMessageKind::ToServerResponseChunk(chunk) => {
+			v6::ToServerTunnelMessageKind::ToServerResponseChunk(v6::ToServerResponseChunk {
+				body: chunk.body,
+				finish: chunk.finish,
+			})
+		}
+		v8::ToServerTunnelMessageKind::ToServerResponseAbort => {
+			v6::ToServerTunnelMessageKind::ToServerResponseAbort
+		}
+		v8::ToServerTunnelMessageKind::ToServerWebSocketOpen(open) => {
+			v6::ToServerTunnelMessageKind::ToServerWebSocketOpen(v6::ToServerWebSocketOpen {
+				can_hibernate: open.can_hibernate,
+			})
+		}
+		v8::ToServerTunnelMessageKind::ToServerWebSocketMessage(msg) => {
+			v6::ToServerTunnelMessageKind::ToServerWebSocketMessage(v6::ToServerWebSocketMessage {
+				data: msg.data,
+				binary: msg.binary,
+			})
+		}
+		v8::ToServerTunnelMessageKind::ToServerWebSocketMessageAck(ack) => {
+			v6::ToServerTunnelMessageKind::ToServerWebSocketMessageAck(
+				v6::ToServerWebSocketMessageAck { index: ack.index },
+			)
+		}
+		v8::ToServerTunnelMessageKind::ToServerWebSocketClose(close) => {
+			v6::ToServerTunnelMessageKind::ToServerWebSocketClose(v6::ToServerWebSocketClose {
+				code: close.code,
+				reason: close.reason,
+				hibernate: close.hibernate,
+			})
+		}
+	}
+}
+
+// v7 and v8 have identical KvResponseData and ToClientTunnelMessageKind types.
+// These converters are field-by-field identity maps.
+
+fn convert_kv_response_data_v7_to_v8(data: v7::KvResponseData) -> v8::KvResponseData {
+	match data {
+		v7::KvResponseData::KvErrorResponse(err) => {
+			v8::KvResponseData::KvErrorResponse(v8::KvErrorResponse {
+				message: err.message,
+			})
+		}
+		v7::KvResponseData::KvGetResponse(resp) => {
+			v8::KvResponseData::KvGetResponse(v8::KvGetResponse {
+				keys: resp.keys,
+				values: resp.values,
+				metadata: resp
+					.metadata
+					.into_iter()
+					.map(|m| v8::KvMetadata {
+						version: m.version,
+						update_ts: m.update_ts,
+					})
+					.collect(),
+			})
+		}
+		v7::KvResponseData::KvListResponse(resp) => {
+			v8::KvResponseData::KvListResponse(v8::KvListResponse {
+				keys: resp.keys,
+				values: resp.values,
+				metadata: resp
+					.metadata
+					.into_iter()
+					.map(|m| v8::KvMetadata {
+						version: m.version,
+						update_ts: m.update_ts,
+					})
+					.collect(),
+			})
+		}
+		v7::KvResponseData::KvPutResponse => v8::KvResponseData::KvPutResponse,
+		v7::KvResponseData::KvDeleteResponse => v8::KvResponseData::KvDeleteResponse,
+		v7::KvResponseData::KvDropResponse => v8::KvResponseData::KvDropResponse,
+	}
+}
+
+fn convert_kv_response_data_v8_to_v7(data: v8::KvResponseData) -> v7::KvResponseData {
+	match data {
+		v8::KvResponseData::KvErrorResponse(err) => {
+			v7::KvResponseData::KvErrorResponse(v7::KvErrorResponse {
+				message: err.message,
+			})
+		}
+		v8::KvResponseData::KvGetResponse(resp) => {
+			v7::KvResponseData::KvGetResponse(v7::KvGetResponse {
+				keys: resp.keys,
+				values: resp.values,
+				metadata: resp
+					.metadata
+					.into_iter()
+					.map(|m| v7::KvMetadata {
+						version: m.version,
+						update_ts: m.update_ts,
+					})
+					.collect(),
+			})
+		}
+		v8::KvResponseData::KvListResponse(resp) => {
+			v7::KvResponseData::KvListResponse(v7::KvListResponse {
+				keys: resp.keys,
+				values: resp.values,
+				metadata: resp
+					.metadata
+					.into_iter()
+					.map(|m| v7::KvMetadata {
+						version: m.version,
+						update_ts: m.update_ts,
+					})
+					.collect(),
+			})
+		}
+		v8::KvResponseData::KvPutResponse => v7::KvResponseData::KvPutResponse,
+		v8::KvResponseData::KvDeleteResponse => v7::KvResponseData::KvDeleteResponse,
+		v8::KvResponseData::KvDropResponse => v7::KvResponseData::KvDropResponse,
+	}
+}
+
+fn convert_to_client_tunnel_message_kind_v7_to_v8(
+	kind: v7::ToClientTunnelMessageKind,
+) -> v8::ToClientTunnelMessageKind {
+	match kind {
+		v7::ToClientTunnelMessageKind::ToClientRequestStart(req) => {
+			v8::ToClientTunnelMessageKind::ToClientRequestStart(v8::ToClientRequestStart {
+				actor_id: req.actor_id,
+				method: req.method,
+				path: req.path,
+				headers: req.headers,
+				body: req.body,
+				stream: req.stream,
+			})
+		}
+		v7::ToClientTunnelMessageKind::ToClientRequestChunk(chunk) => {
+			v8::ToClientTunnelMessageKind::ToClientRequestChunk(v8::ToClientRequestChunk {
+				body: chunk.body,
+				finish: chunk.finish,
+			})
+		}
+		v7::ToClientTunnelMessageKind::ToClientRequestAbort => {
+			v8::ToClientTunnelMessageKind::ToClientRequestAbort
+		}
+		v7::ToClientTunnelMessageKind::ToClientWebSocketOpen(ws) => {
+			v8::ToClientTunnelMessageKind::ToClientWebSocketOpen(v8::ToClientWebSocketOpen {
+				actor_id: ws.actor_id,
+				path: ws.path,
+				headers: ws.headers,
+			})
+		}
+		v7::ToClientTunnelMessageKind::ToClientWebSocketMessage(msg) => {
+			v8::ToClientTunnelMessageKind::ToClientWebSocketMessage(v8::ToClientWebSocketMessage {
+				data: msg.data,
+				binary: msg.binary,
+			})
+		}
+		v7::ToClientTunnelMessageKind::ToClientWebSocketClose(close) => {
+			v8::ToClientTunnelMessageKind::ToClientWebSocketClose(v8::ToClientWebSocketClose {
+				code: close.code,
+				reason: close.reason,
+			})
+		}
+	}
+}
+
+fn convert_to_client_tunnel_message_kind_v8_to_v7(
+	kind: v8::ToClientTunnelMessageKind,
+) -> v7::ToClientTunnelMessageKind {
+	match kind {
+		v8::ToClientTunnelMessageKind::ToClientRequestStart(req) => {
+			v7::ToClientTunnelMessageKind::ToClientRequestStart(v7::ToClientRequestStart {
+				actor_id: req.actor_id,
+				method: req.method,
+				path: req.path,
+				headers: req.headers,
+				body: req.body,
+				stream: req.stream,
+			})
+		}
+		v8::ToClientTunnelMessageKind::ToClientRequestChunk(chunk) => {
+			v7::ToClientTunnelMessageKind::ToClientRequestChunk(v7::ToClientRequestChunk {
+				body: chunk.body,
+				finish: chunk.finish,
+			})
+		}
+		v8::ToClientTunnelMessageKind::ToClientRequestAbort => {
+			v7::ToClientTunnelMessageKind::ToClientRequestAbort
+		}
+		v8::ToClientTunnelMessageKind::ToClientWebSocketOpen(ws) => {
+			v7::ToClientTunnelMessageKind::ToClientWebSocketOpen(v7::ToClientWebSocketOpen {
+				actor_id: ws.actor_id,
+				path: ws.path,
+				headers: ws.headers,
+			})
+		}
+		v8::ToClientTunnelMessageKind::ToClientWebSocketMessage(msg) => {
+			v7::ToClientTunnelMessageKind::ToClientWebSocketMessage(v7::ToClientWebSocketMessage {
+				data: msg.data,
+				binary: msg.binary,
+			})
+		}
+		v8::ToClientTunnelMessageKind::ToClientWebSocketClose(close) => {
+			v7::ToClientTunnelMessageKind::ToClientWebSocketClose(v7::ToClientWebSocketClose {
+				code: close.code,
+				reason: close.reason,
 			})
 		}
 	}

--- a/engine/sdks/schemas/runner-protocol/v8.bare
+++ b/engine/sdks/schemas/runner-protocol/v8.bare
@@ -1,0 +1,453 @@
+# Runner Protocol v1
+
+# MARK: Core Primitives
+
+type Id str
+type Json str
+
+type GatewayId data[4]
+type RequestId data[4]
+type MessageIndex u16
+
+# MARK: KV
+
+# Basic types
+type KvKey data
+type KvValue data
+type KvMetadata struct {
+	version: data
+	updateTs: i64
+}
+
+# Query types
+type KvListAllQuery void
+type KvListRangeQuery struct {
+	start: KvKey
+	end: KvKey
+	exclusive: bool
+}
+
+type KvListPrefixQuery struct {
+	key: KvKey
+}
+
+type KvListQuery union {
+	KvListAllQuery |
+	KvListRangeQuery |
+	KvListPrefixQuery
+}
+
+# Request types
+type KvGetRequest struct {
+	keys: list<KvKey>
+}
+
+type KvListRequest struct {
+	query: KvListQuery
+	reverse: optional<bool>
+	limit: optional<u64>
+}
+
+type KvPutRequest struct {
+	keys: list<KvKey>
+	values: list<KvValue>
+}
+
+type KvDeleteRequest struct {
+	keys: list<KvKey>
+}
+
+type KvDeleteRangeRequest struct {
+	start: KvKey
+	end: KvKey
+}
+
+type KvDropRequest void
+
+# Response types
+type KvErrorResponse struct {
+	message: str
+}
+
+type KvGetResponse struct {
+	keys: list<KvKey>
+	values: list<KvValue>
+	metadata: list<KvMetadata>
+}
+
+type KvListResponse struct {
+	keys: list<KvKey>
+	values: list<KvValue>
+	metadata: list<KvMetadata>
+}
+
+type KvPutResponse void
+type KvDeleteResponse void
+type KvDropResponse void
+
+# Request/Response unions
+type KvRequestData union {
+	KvGetRequest |
+	KvListRequest |
+	KvPutRequest |
+	KvDeleteRequest |
+	KvDeleteRangeRequest |
+	KvDropRequest
+}
+
+type KvResponseData union {
+	KvErrorResponse |
+	KvGetResponse |
+	KvListResponse |
+	KvPutResponse |
+	KvDeleteResponse |
+	KvDropResponse
+}
+
+# MARK: Actor
+
+# Core
+type StopCode enum {
+	OK
+	ERROR
+}
+
+type ActorName struct {
+	metadata: Json
+}
+
+type ActorConfig struct {
+	name: str
+	key: optional<str>
+	createTs: i64
+	input: optional<data>
+}
+
+type ActorCheckpoint struct {
+	actorId: Id
+	generation: u32
+	index: i64
+}
+
+# Intent
+type ActorIntentSleep void
+
+type ActorIntentStop void
+
+type ActorIntent union {
+	ActorIntentSleep |
+	ActorIntentStop
+}
+
+# State
+type ActorStateRunning void
+
+type ActorStateStopped struct {
+	code: StopCode
+	message: optional<str>
+}
+
+type ActorState union {
+	ActorStateRunning |
+	ActorStateStopped
+}
+
+# MARK: Events
+type EventActorIntent struct {
+	intent: ActorIntent
+}
+
+type EventActorStateUpdate struct {
+	state: ActorState
+}
+
+type EventActorSetAlarm struct {
+	alarmTs: optional<i64>
+}
+
+type Event union {
+	EventActorIntent |
+	EventActorStateUpdate |
+	EventActorSetAlarm
+}
+
+type EventWrapper struct {
+	checkpoint: ActorCheckpoint
+	inner: Event
+}
+
+# MARK: Preloaded KV
+
+type PreloadedKvEntry struct {
+	key: KvKey
+	value: KvValue
+	metadata: KvMetadata
+}
+
+type PreloadedKv struct {
+	entries: list<PreloadedKvEntry>
+	requestedGetKeys: list<KvKey>
+	requestedPrefixes: list<KvKey>
+}
+
+# MARK: Commands
+
+type HibernatingRequest struct {
+	gatewayId: GatewayId
+	requestId: RequestId
+}
+
+type CommandStartActor struct {
+	config: ActorConfig
+	hibernatingRequests: list<HibernatingRequest>
+	preloadedKv: optional<PreloadedKv>
+}
+
+type CommandStopActor void
+
+type Command union {
+	CommandStartActor |
+	CommandStopActor
+}
+
+type CommandWrapper struct {
+	checkpoint: ActorCheckpoint
+	inner: Command
+}
+
+# We redeclare this so its top level
+type ActorCommandKeyData union {
+	CommandStartActor |
+	CommandStopActor
+}
+
+# MARK: Tunnel
+
+# Message ID
+
+type MessageId struct {
+	# Globally unique ID
+	gatewayId: GatewayId
+	# Unique ID to the gateway
+	requestId: RequestId
+	# Unique ID to the request
+	messageIndex: MessageIndex
+}
+
+
+# HTTP
+type ToClientRequestStart struct {
+	actorId: Id
+	method: str
+	path: str
+	headers: map<str><str>
+	body: optional<data>
+	stream: bool
+}
+
+type ToClientRequestChunk struct {
+	body: data
+	finish: bool
+}
+
+type ToClientRequestAbort void
+
+type ToServerResponseStart struct {
+	status: u16
+	headers: map<str><str>
+	body: optional<data>
+	stream: bool
+}
+
+type ToServerResponseChunk struct {
+	body: data
+	finish: bool
+}
+
+type ToServerResponseAbort void
+
+# WebSocket
+type ToClientWebSocketOpen struct {
+	actorId: Id
+	path: str
+	headers: map<str><str>
+}
+
+type ToClientWebSocketMessage struct {
+	data: data
+	binary: bool
+}
+
+type ToClientWebSocketClose struct {
+	code: optional<u16>
+	reason: optional<str>
+}
+
+type ToServerWebSocketOpen struct {
+	canHibernate: bool
+}
+
+type ToServerWebSocketMessage struct {
+	data: data
+	binary: bool
+}
+
+type ToServerWebSocketMessageAck struct {
+	index: MessageIndex
+}
+
+type ToServerWebSocketClose struct {
+	code: optional<u16>
+	reason: optional<str>
+	hibernate: bool
+}
+
+# To Server
+type ToServerTunnelMessageKind union {
+	# HTTP
+	ToServerResponseStart |
+	ToServerResponseChunk |
+	ToServerResponseAbort |
+
+	# WebSocket
+	ToServerWebSocketOpen |
+	ToServerWebSocketMessage |
+	ToServerWebSocketMessageAck |
+	ToServerWebSocketClose
+}
+
+type ToServerTunnelMessage struct {
+	messageId: MessageId
+	messageKind: ToServerTunnelMessageKind
+}
+
+# To Client
+type ToClientTunnelMessageKind union {
+	# HTTP
+	ToClientRequestStart |
+	ToClientRequestChunk |
+	ToClientRequestAbort |
+
+	# WebSocket
+	ToClientWebSocketOpen |
+	ToClientWebSocketMessage |
+	ToClientWebSocketClose
+}
+
+type ToClientTunnelMessage struct {
+	messageId: MessageId
+	messageKind: ToClientTunnelMessageKind
+}
+
+type ToClientPing struct {
+	ts: i64
+}
+
+# MARK: To Server
+type ToServerInit struct {
+	name: str
+	version: u32
+	totalSlots: u32
+	prepopulateActorNames: optional<map<str><ActorName>>
+	metadata: optional<Json>
+}
+
+type ToServerEvents list<EventWrapper>
+
+type ToServerAckCommands struct {
+	lastCommandCheckpoints: list<ActorCheckpoint>
+}
+
+type ToServerStopping void
+
+type ToServerPong struct {
+	ts: i64
+}
+
+type ToServerKvRequest struct {
+	actorId: Id
+	requestId: u32
+	data: KvRequestData
+}
+
+type ToServer union {
+	ToServerInit |
+	ToServerEvents |
+	ToServerAckCommands |
+	ToServerStopping |
+	ToServerPong |
+	ToServerKvRequest |
+	ToServerTunnelMessage
+}
+
+# MARK: To Client
+type ProtocolMetadata struct {
+	runnerLostThreshold: i64
+	actorStopThreshold: i64
+	serverlessDrainGracePeriod: optional<i64>
+}
+
+type ToClientInit struct {
+	runnerId: Id
+	metadata: ProtocolMetadata
+}
+
+type ToClientCommands list<CommandWrapper>
+
+type ToClientAckEvents struct {
+	lastEventCheckpoints: list<ActorCheckpoint>
+}
+
+type ToClientKvResponse struct {
+	requestId: u32
+	data: KvResponseData
+}
+
+type ToClient union {
+	ToClientInit |
+	ToClientCommands |
+	ToClientAckEvents |
+	ToClientKvResponse |
+	ToClientTunnelMessage |
+	ToClientPing
+}
+
+# MARK: To Runner
+type ToRunnerPing struct {
+	gatewayId: GatewayId
+	requestId: RequestId
+	ts: i64
+}
+
+type ToRunnerClose void
+
+# We have to re-declare the entire union since BARE will not generate the
+# ser/de for ToClient if it's not a top-level type
+type ToRunner union {
+	ToRunnerPing |
+	ToRunnerClose |
+	ToClientCommands |
+	ToClientAckEvents |
+	ToClientTunnelMessage
+}
+
+# MARK: To Gateway
+type ToGatewayPong struct {
+	requestId: RequestId
+	ts: i64
+}
+
+type ToGateway union {
+	ToGatewayPong |
+	ToServerTunnelMessage
+}
+
+# MARK: Serverless
+type ToServerlessServerInit struct {
+	runnerId: Id
+	runnerProtocolVersion: u16
+}
+
+type ToServerlessServer union {
+	ToServerlessServerInit
+}

--- a/engine/sdks/typescript/runner-protocol/src/index.ts
+++ b/engine/sdks/typescript/runner-protocol/src/index.ts
@@ -865,6 +865,65 @@ export function writeEventWrapper(bc: bare.ByteCursor, x: EventWrapper): void {
     writeEvent(bc, x.inner)
 }
 
+export type PreloadedKvEntry = {
+    readonly key: KvKey
+    readonly value: KvValue
+    readonly metadata: KvMetadata
+}
+
+export function readPreloadedKvEntry(bc: bare.ByteCursor): PreloadedKvEntry {
+    return {
+        key: readKvKey(bc),
+        value: readKvValue(bc),
+        metadata: readKvMetadata(bc),
+    }
+}
+
+export function writePreloadedKvEntry(bc: bare.ByteCursor, x: PreloadedKvEntry): void {
+    writeKvKey(bc, x.key)
+    writeKvValue(bc, x.value)
+    writeKvMetadata(bc, x.metadata)
+}
+
+function read8(bc: bare.ByteCursor): readonly PreloadedKvEntry[] {
+    const len = bare.readUintSafe(bc)
+    if (len === 0) {
+        return []
+    }
+    const result = [readPreloadedKvEntry(bc)]
+    for (let i = 1; i < len; i++) {
+        result[i] = readPreloadedKvEntry(bc)
+    }
+    return result
+}
+
+function write8(bc: bare.ByteCursor, x: readonly PreloadedKvEntry[]): void {
+    bare.writeUintSafe(bc, x.length)
+    for (let i = 0; i < x.length; i++) {
+        writePreloadedKvEntry(bc, x[i])
+    }
+}
+
+export type PreloadedKv = {
+    readonly entries: readonly PreloadedKvEntry[]
+    readonly requestedGetKeys: readonly KvKey[]
+    readonly requestedPrefixes: readonly KvKey[]
+}
+
+export function readPreloadedKv(bc: bare.ByteCursor): PreloadedKv {
+    return {
+        entries: read8(bc),
+        requestedGetKeys: read0(bc),
+        requestedPrefixes: read0(bc),
+    }
+}
+
+export function writePreloadedKv(bc: bare.ByteCursor, x: PreloadedKv): void {
+    write8(bc, x.entries)
+    write0(bc, x.requestedGetKeys)
+    write0(bc, x.requestedPrefixes)
+}
+
 export type HibernatingRequest = {
     readonly gatewayId: GatewayId
     readonly requestId: RequestId
@@ -882,7 +941,7 @@ export function writeHibernatingRequest(bc: bare.ByteCursor, x: HibernatingReque
     writeRequestId(bc, x.requestId)
 }
 
-function read8(bc: bare.ByteCursor): readonly HibernatingRequest[] {
+function read9(bc: bare.ByteCursor): readonly HibernatingRequest[] {
     const len = bare.readUintSafe(bc)
     if (len === 0) {
         return []
@@ -894,28 +953,42 @@ function read8(bc: bare.ByteCursor): readonly HibernatingRequest[] {
     return result
 }
 
-function write8(bc: bare.ByteCursor, x: readonly HibernatingRequest[]): void {
+function write9(bc: bare.ByteCursor, x: readonly HibernatingRequest[]): void {
     bare.writeUintSafe(bc, x.length)
     for (let i = 0; i < x.length; i++) {
         writeHibernatingRequest(bc, x[i])
     }
 }
 
+function read10(bc: bare.ByteCursor): PreloadedKv | null {
+    return bare.readBool(bc) ? readPreloadedKv(bc) : null
+}
+
+function write10(bc: bare.ByteCursor, x: PreloadedKv | null): void {
+    bare.writeBool(bc, x != null)
+    if (x != null) {
+        writePreloadedKv(bc, x)
+    }
+}
+
 export type CommandStartActor = {
     readonly config: ActorConfig
     readonly hibernatingRequests: readonly HibernatingRequest[]
+    readonly preloadedKv: PreloadedKv | null
 }
 
 export function readCommandStartActor(bc: bare.ByteCursor): CommandStartActor {
     return {
         config: readActorConfig(bc),
-        hibernatingRequests: read8(bc),
+        hibernatingRequests: read9(bc),
+        preloadedKv: read10(bc),
     }
 }
 
 export function writeCommandStartActor(bc: bare.ByteCursor, x: CommandStartActor): void {
     writeActorConfig(bc, x.config)
-    write8(bc, x.hibernatingRequests)
+    write9(bc, x.hibernatingRequests)
+    write10(bc, x.preloadedKv)
 }
 
 export type CommandStopActor = null
@@ -1054,7 +1127,7 @@ export function writeMessageId(bc: bare.ByteCursor, x: MessageId): void {
     writeMessageIndex(bc, x.messageIndex)
 }
 
-function read9(bc: bare.ByteCursor): ReadonlyMap<string, string> {
+function read11(bc: bare.ByteCursor): ReadonlyMap<string, string> {
     const len = bare.readUintSafe(bc)
     const result = new Map<string, string>()
     for (let i = 0; i < len; i++) {
@@ -1069,7 +1142,7 @@ function read9(bc: bare.ByteCursor): ReadonlyMap<string, string> {
     return result
 }
 
-function write9(bc: bare.ByteCursor, x: ReadonlyMap<string, string>): void {
+function write11(bc: bare.ByteCursor, x: ReadonlyMap<string, string>): void {
     bare.writeUintSafe(bc, x.size)
     for (const kv of x) {
         bare.writeString(bc, kv[0])
@@ -1094,7 +1167,7 @@ export function readToClientRequestStart(bc: bare.ByteCursor): ToClientRequestSt
         actorId: readId(bc),
         method: bare.readString(bc),
         path: bare.readString(bc),
-        headers: read9(bc),
+        headers: read11(bc),
         body: read6(bc),
         stream: bare.readBool(bc),
     }
@@ -1104,7 +1177,7 @@ export function writeToClientRequestStart(bc: bare.ByteCursor, x: ToClientReques
     writeId(bc, x.actorId)
     bare.writeString(bc, x.method)
     bare.writeString(bc, x.path)
-    write9(bc, x.headers)
+    write11(bc, x.headers)
     write6(bc, x.body)
     bare.writeBool(bc, x.stream)
 }
@@ -1138,7 +1211,7 @@ export type ToServerResponseStart = {
 export function readToServerResponseStart(bc: bare.ByteCursor): ToServerResponseStart {
     return {
         status: bare.readU16(bc),
-        headers: read9(bc),
+        headers: read11(bc),
         body: read6(bc),
         stream: bare.readBool(bc),
     }
@@ -1146,7 +1219,7 @@ export function readToServerResponseStart(bc: bare.ByteCursor): ToServerResponse
 
 export function writeToServerResponseStart(bc: bare.ByteCursor, x: ToServerResponseStart): void {
     bare.writeU16(bc, x.status)
-    write9(bc, x.headers)
+    write11(bc, x.headers)
     write6(bc, x.body)
     bare.writeBool(bc, x.stream)
 }
@@ -1183,14 +1256,14 @@ export function readToClientWebSocketOpen(bc: bare.ByteCursor): ToClientWebSocke
     return {
         actorId: readId(bc),
         path: bare.readString(bc),
-        headers: read9(bc),
+        headers: read11(bc),
     }
 }
 
 export function writeToClientWebSocketOpen(bc: bare.ByteCursor, x: ToClientWebSocketOpen): void {
     writeId(bc, x.actorId)
     bare.writeString(bc, x.path)
-    write9(bc, x.headers)
+    write11(bc, x.headers)
 }
 
 export type ToClientWebSocketMessage = {
@@ -1210,11 +1283,11 @@ export function writeToClientWebSocketMessage(bc: bare.ByteCursor, x: ToClientWe
     bare.writeBool(bc, x.binary)
 }
 
-function read10(bc: bare.ByteCursor): u16 | null {
+function read12(bc: bare.ByteCursor): u16 | null {
     return bare.readBool(bc) ? bare.readU16(bc) : null
 }
 
-function write10(bc: bare.ByteCursor, x: u16 | null): void {
+function write12(bc: bare.ByteCursor, x: u16 | null): void {
     bare.writeBool(bc, x != null)
     if (x != null) {
         bare.writeU16(bc, x)
@@ -1228,13 +1301,13 @@ export type ToClientWebSocketClose = {
 
 export function readToClientWebSocketClose(bc: bare.ByteCursor): ToClientWebSocketClose {
     return {
-        code: read10(bc),
+        code: read12(bc),
         reason: read5(bc),
     }
 }
 
 export function writeToClientWebSocketClose(bc: bare.ByteCursor, x: ToClientWebSocketClose): void {
-    write10(bc, x.code)
+    write12(bc, x.code)
     write5(bc, x.reason)
 }
 
@@ -1291,14 +1364,14 @@ export type ToServerWebSocketClose = {
 
 export function readToServerWebSocketClose(bc: bare.ByteCursor): ToServerWebSocketClose {
     return {
-        code: read10(bc),
+        code: read12(bc),
         reason: read5(bc),
         hibernate: bare.readBool(bc),
     }
 }
 
 export function writeToServerWebSocketClose(bc: bare.ByteCursor, x: ToServerWebSocketClose): void {
-    write10(bc, x.code)
+    write12(bc, x.code)
     write5(bc, x.reason)
     bare.writeBool(bc, x.hibernate)
 }
@@ -1507,7 +1580,7 @@ export function writeToClientPing(bc: bare.ByteCursor, x: ToClientPing): void {
     bare.writeI64(bc, x.ts)
 }
 
-function read11(bc: bare.ByteCursor): ReadonlyMap<string, ActorName> {
+function read13(bc: bare.ByteCursor): ReadonlyMap<string, ActorName> {
     const len = bare.readUintSafe(bc)
     const result = new Map<string, ActorName>()
     for (let i = 0; i < len; i++) {
@@ -1522,7 +1595,7 @@ function read11(bc: bare.ByteCursor): ReadonlyMap<string, ActorName> {
     return result
 }
 
-function write11(bc: bare.ByteCursor, x: ReadonlyMap<string, ActorName>): void {
+function write13(bc: bare.ByteCursor, x: ReadonlyMap<string, ActorName>): void {
     bare.writeUintSafe(bc, x.size)
     for (const kv of x) {
         bare.writeString(bc, kv[0])
@@ -1530,22 +1603,22 @@ function write11(bc: bare.ByteCursor, x: ReadonlyMap<string, ActorName>): void {
     }
 }
 
-function read12(bc: bare.ByteCursor): ReadonlyMap<string, ActorName> | null {
-    return bare.readBool(bc) ? read11(bc) : null
+function read14(bc: bare.ByteCursor): ReadonlyMap<string, ActorName> | null {
+    return bare.readBool(bc) ? read13(bc) : null
 }
 
-function write12(bc: bare.ByteCursor, x: ReadonlyMap<string, ActorName> | null): void {
+function write14(bc: bare.ByteCursor, x: ReadonlyMap<string, ActorName> | null): void {
     bare.writeBool(bc, x != null)
     if (x != null) {
-        write11(bc, x)
+        write13(bc, x)
     }
 }
 
-function read13(bc: bare.ByteCursor): Json | null {
+function read15(bc: bare.ByteCursor): Json | null {
     return bare.readBool(bc) ? readJson(bc) : null
 }
 
-function write13(bc: bare.ByteCursor, x: Json | null): void {
+function write15(bc: bare.ByteCursor, x: Json | null): void {
     bare.writeBool(bc, x != null)
     if (x != null) {
         writeJson(bc, x)
@@ -1568,8 +1641,8 @@ export function readToServerInit(bc: bare.ByteCursor): ToServerInit {
         name: bare.readString(bc),
         version: bare.readU32(bc),
         totalSlots: bare.readU32(bc),
-        prepopulateActorNames: read12(bc),
-        metadata: read13(bc),
+        prepopulateActorNames: read14(bc),
+        metadata: read15(bc),
     }
 }
 
@@ -1577,8 +1650,8 @@ export function writeToServerInit(bc: bare.ByteCursor, x: ToServerInit): void {
     bare.writeString(bc, x.name)
     bare.writeU32(bc, x.version)
     bare.writeU32(bc, x.totalSlots)
-    write12(bc, x.prepopulateActorNames)
-    write13(bc, x.metadata)
+    write14(bc, x.prepopulateActorNames)
+    write15(bc, x.metadata)
 }
 
 export type ToServerEvents = readonly EventWrapper[]
@@ -1602,7 +1675,7 @@ export function writeToServerEvents(bc: bare.ByteCursor, x: ToServerEvents): voi
     }
 }
 
-function read14(bc: bare.ByteCursor): readonly ActorCheckpoint[] {
+function read16(bc: bare.ByteCursor): readonly ActorCheckpoint[] {
     const len = bare.readUintSafe(bc)
     if (len === 0) {
         return []
@@ -1614,7 +1687,7 @@ function read14(bc: bare.ByteCursor): readonly ActorCheckpoint[] {
     return result
 }
 
-function write14(bc: bare.ByteCursor, x: readonly ActorCheckpoint[]): void {
+function write16(bc: bare.ByteCursor, x: readonly ActorCheckpoint[]): void {
     bare.writeUintSafe(bc, x.length)
     for (let i = 0; i < x.length; i++) {
         writeActorCheckpoint(bc, x[i])
@@ -1627,12 +1700,12 @@ export type ToServerAckCommands = {
 
 export function readToServerAckCommands(bc: bare.ByteCursor): ToServerAckCommands {
     return {
-        lastCommandCheckpoints: read14(bc),
+        lastCommandCheckpoints: read16(bc),
     }
 }
 
 export function writeToServerAckCommands(bc: bare.ByteCursor, x: ToServerAckCommands): void {
-    write14(bc, x.lastCommandCheckpoints)
+    write16(bc, x.lastCommandCheckpoints)
 }
 
 export type ToServerStopping = null
@@ -1830,12 +1903,12 @@ export type ToClientAckEvents = {
 
 export function readToClientAckEvents(bc: bare.ByteCursor): ToClientAckEvents {
     return {
-        lastEventCheckpoints: read14(bc),
+        lastEventCheckpoints: read16(bc),
     }
 }
 
 export function writeToClientAckEvents(bc: bare.ByteCursor, x: ToClientAckEvents): void {
-    write14(bc, x.lastEventCheckpoints)
+    write16(bc, x.lastEventCheckpoints)
 }
 
 export type ToClientKvResponse = {

--- a/engine/sdks/typescript/runner/src/actor.ts
+++ b/engine/sdks/typescript/runner/src/actor.ts
@@ -9,6 +9,7 @@ export interface ActorConfig {
 	key: string | null;
 	createTs: bigint;
 	input: Uint8Array | null;
+	preloadedKv: protocol.PreloadedKv | undefined;
 }
 
 export class RunnerActor {

--- a/engine/sdks/typescript/runner/src/mod.ts
+++ b/engine/sdks/typescript/runner/src/mod.ts
@@ -21,7 +21,7 @@ export { RunnerActor, type ActorConfig };
 export { idToStr } from "./utils";
 
 const KV_EXPIRE: number = 30_000;
-const PROTOCOL_VERSION: number = 7;
+const PROTOCOL_VERSION: number = 8;
 
 /** Warn once the backlog significantly exceeds the server's ack batch size. */
 const EVENT_BACKLOG_WARN_THRESHOLD = 10_000;
@@ -1094,6 +1094,7 @@ export class Runner {
 			key: config.key,
 			createTs: config.createTs,
 			input: config.input ? new Uint8Array(config.input) : null,
+			preloadedKv: startCommand.preloadedKv ?? undefined,
 		};
 
 		const instance = new RunnerActor(
@@ -1132,6 +1133,7 @@ export class Runner {
 			key: config.key,
 			generation,
 			hibernatingRequests: startCommand.hibernatingRequests.length,
+			preloadedKvEntries: startCommand.preloadedKv?.entries.length ?? 0,
 		});
 
 		this.#sendActorStateUpdate(actorId, generation, "running");

--- a/engine/sdks/typescript/runner/src/stringify.ts
+++ b/engine/sdks/typescript/runner/src/stringify.ts
@@ -115,7 +115,7 @@ export function stringifyToClientTunnelMessageKind(
 export function stringifyCommand(command: protocol.Command): string {
 	switch (command.tag) {
 		case "CommandStartActor": {
-			const { config, hibernatingRequests } = command.val;
+			const { config, hibernatingRequests, preloadedKv } = command.val;
 			const keyStr = config.key === null ? "null" : `"${config.key}"`;
 			const inputStr =
 				config.input === null
@@ -125,7 +125,10 @@ export function stringifyCommand(command: protocol.Command): string {
 				hibernatingRequests.length > 0
 					? `[${hibernatingRequests.map((hr) => `{gatewayId: ${idToStr(hr.gatewayId)}, requestId: ${idToStr(hr.requestId)}}`).join(", ")}]`
 					: "[]";
-			return `CommandStartActor{config: {name: "${config.name}", key: ${keyStr}, createTs: ${stringifyBigInt(config.createTs)}, input: ${inputStr}}, hibernatingRequests: ${hibernatingRequestsStr}}`;
+			const preloadedKvStr = preloadedKv === null
+				? "null"
+				: `{entries: ${preloadedKv.entries.length}, getKeys: ${preloadedKv.requestedGetKeys.length}, prefixes: ${preloadedKv.requestedPrefixes.length}}`;
+			return `CommandStartActor{config: {name: "${config.name}", key: ${keyStr}, createTs: ${stringifyBigInt(config.createTs)}, input: ${inputStr}}, hibernatingRequests: ${hibernatingRequestsStr}, preloadedKv: ${preloadedKvStr}}`;
 		}
 		case "CommandStopActor": {
 			return `CommandStopActor`;

--- a/rivetkit-typescript/packages/rivetkit/src/actor/config.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/config.ts
@@ -239,6 +239,12 @@ export const ActorConfigSchema = z
 						zFunction<(request: Request) => boolean>(),
 					])
 					.default(false),
+				/** Override the engine default for maximum SQLite preload bytes. Set to 0 to disable SQLite preloading. */
+				preloadMaxSqliteBytes: z.number().nonnegative().optional(),
+				/** Override the engine default for maximum workflow preload bytes. Set to 0 to disable workflow preloading. */
+				preloadMaxWorkflowBytes: z.number().nonnegative().optional(),
+				/** Override the engine default for maximum connections preload bytes. Set to 0 to disable connections preloading. */
+				preloadMaxConnectionsBytes: z.number().nonnegative().optional(),
 			})
 			.strict()
 			.prefault(() => ({})),
@@ -1094,6 +1100,24 @@ export const DocActorOptionsSchema = z
 			.optional()
 			.describe(
 				"Whether WebSockets using onWebSocket can be hibernated. WebSockets using actions/events are hibernatable by default. Default: false",
+			),
+		preloadMaxSqliteBytes: z
+			.number()
+			.optional()
+			.describe(
+				"Override the engine default for maximum SQLite preload bytes. Set to 0 to disable SQLite preloading.",
+			),
+		preloadMaxWorkflowBytes: z
+			.number()
+			.optional()
+			.describe(
+				"Override the engine default for maximum workflow preload bytes. Set to 0 to disable workflow preloading.",
+			),
+		preloadMaxConnectionsBytes: z
+			.number()
+			.optional()
+			.describe(
+				"Override the engine default for maximum connections preload bytes. Set to 0 to disable connections preloading.",
 			),
 	})
 	.describe("Actor options for timeouts and behavior configuration.");

--- a/rivetkit-typescript/packages/rivetkit/src/actor/instance/KV_PRELOADING.md
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/instance/KV_PRELOADING.md
@@ -1,0 +1,151 @@
+# Actor KV Preloading
+
+Internal reference for the actor startup KV preloading system. For the full design spec, see `/.agent/notes/actor-startup-kv-preload-spec.md`.
+
+## Overview
+
+Actor startup preloads KV data from the engine in a single FoundationDB transaction and delivers it alongside the `CommandStartActor` protocol message. Each subsystem receives its data from a `PreloadMap` instead of performing individual KV round-trips.
+
+This is a one-shot data injection, not a cache. After startup completes, the preload map is discarded. Preloaded KV is NOT persisted in the command queue or workflow history. It is fetched fresh from FDB at send time.
+
+## Key Prefixes
+
+All internal KV keys are defined in `keys.ts`. Each subsystem owns a reserved prefix:
+
+| Prefix | Subsystem | Preload Type | Default Max | Engine Config Key | Notes |
+|--------|-----------|-------------|------------|-------------------|-------|
+| `[1]` | Persist data (state) | get | n/a | n/a | Single key, always preloaded |
+| `[2]` | Connections | list prefix | 64 KB | `preload_max_connections_bytes` | Bounded |
+| `[3]` | Inspector token | get | n/a | n/a | Single key, always preloaded |
+| `[4]` | User KV | (not preloaded) | n/a | n/a | Deferred to v2 |
+| `[5,1,1]` | Queue metadata | get | n/a | n/a | Single key, always preloaded |
+| `[6]` | Workflows | list prefix | 128 KB | `preload_max_workflow_bytes` | Released after startup; fallback to KV on miss |
+| `[7]` | Traces | (not preloaded) | n/a | n/a | Write-only during normal operation |
+| `[8]` | SQLite VFS | list prefix | 768 KB | `preload_max_sqlite_bytes` | Partial preload with KV fallback |
+
+Global hard cap across all prefixes: 1 MB (`preload_max_total_bytes` in engine config). All limits are configurable in `engine/packages/config/src/config/pegboard.rs`.
+
+## PreloadMap Interface
+
+```typescript
+interface PreloadMap {
+    // Returns value if preloaded, null if preloaded-but-missing, undefined if not preloaded.
+    get(key: Uint8Array): Uint8Array | null | undefined;
+
+    // Returns entries if prefix was preloaded, undefined if not preloaded.
+    listPrefix(prefix: Uint8Array): [Uint8Array, Uint8Array][] | undefined;
+}
+```
+
+The three-way return on `get()` is important:
+- `Uint8Array` = key exists, here is the value.
+- `null` = key was requested but does not exist in storage. Subsystem should treat as "not found" without issuing a KV read.
+- `undefined` = key was not part of the preload request. Subsystem must fall back to a normal KV read.
+
+Each prefix scan has a `partial` flag that controls truncation behavior:
+
+- **`partial: true` (SQLite `[8]`):** If data exceeds `max_bytes`, return whatever fits. The VFS does per-key lookups and falls back to KV on miss. Partial data is still useful.
+- **`partial: false` (connections `[2]`, workflows `[6]`):** If data exceeds `max_bytes`, return nothing. These subsystems call `listPrefix` expecting the complete set. Partial data would drop entries.
+
+Only the fixed keys (`[1]`, `[3]`, `[5,1,1]`) use the "requested but not found = doesn't exist" semantic.
+
+## Preload Data Lifecycle
+
+| Prefix | Consumed By | Discarded When |
+|--------|------------|----------------|
+| `[1]` persist data | `#loadState()` | After `#loadState()` returns |
+| `[2]` connections | `#restoreExistingActor()` | After `#loadState()` returns |
+| `[3]` inspector token | `#initializeInspectorToken()` | After init returns |
+| `[5,1,1]` queue metadata | `queueManager.initialize()` | After init returns |
+| `[8]` SQLite | `#setupDatabase()` via VFS wrapper | After `#setupDatabase()` completes |
+| `[6]` workflows | Workflow engine `loadStorage()` | After startup completes (`#started = true`) |
+
+Preloading is NOT part of the core KV engine. Each subsystem receives data from the `PreloadMap` directly. The core KV layer is unaware of preloading.
+
+## Subsystem Integration Pattern
+
+Every subsystem that reads KV during startup follows the same pattern:
+
+```typescript
+async initialize(preload?: PreloadMap) {
+    const preloaded = preload?.get(MY_KEY);
+    let value: Uint8Array | null;
+    if (preloaded !== undefined) {
+        // Hit or confirmed-missing from preload
+        value = preloaded;
+    } else {
+        // Not preloaded, fall back to KV
+        value = await this.driver.kvBatchGet(this.actorId, [MY_KEY]);
+    }
+    // ... use value
+}
+```
+
+For list operations (connections, SQLite, workflows):
+
+```typescript
+const preloaded = preload?.listPrefix(MY_PREFIX);
+let entries: [Uint8Array, Uint8Array][];
+if (preloaded !== undefined) {
+    entries = preloaded;
+} else {
+    entries = await this.driver.kvListPrefix(this.actorId, MY_PREFIX);
+}
+```
+
+## SQLite Preloading
+
+SQLite data lives under the `[8]` prefix as 4096-byte chunks. The preload is partial: the engine sends up to `preload_max_sqlite_bytes` (default 768 KB, ~192 pages) of data. The VFS wrapper uses a sorted array with binary search for lookups, falling back to KV on miss.
+
+Key points:
+- **Partial preload is safe.** A miss in the preload map falls back to KV. The VFS wrapper does NOT use "prefix was fully preloaded" semantics.
+- **Write consistency is handled by SQLite.** SQLite's internal page cache ensures that pages written via `xWrite` are served from memory on subsequent reads. The preload map does not need write-through.
+- **Preload map is cleared after onMigrate.** After database setup completes, the preload map is discarded. All subsequent VFS operations go through normal KV.
+- **No hex string keys.** The preload data is stored as a sorted `[Uint8Array, Uint8Array][]` array with binary search, avoiding string conversion overhead.
+
+## Workflow Preloading
+
+Workflow data lives under the `[6]` prefix. For actors that use workflows, the engine preloads up to `preload_max_workflow_bytes` (default 128 KB). Typical workflow data is 2-15 KB for simple workflows.
+
+Workflow preload data is released eagerly after startup completes (`#started = true`). If the workflow engine hasn't consumed it by then, the data is discarded and the workflow engine falls back to normal KV reads. This bounds memory lifetime to the startup window.
+
+## Unexpected Round-Trip Detection
+
+The `#expectNoKvRoundTrips` flag on `ActorInstance` warns when KV reads happen during startup that should have been preloaded:
+
+1. Set to `true` after preload data is consumed, before subsystem init.
+2. Paused (`false`) during user code callbacks (`onWake`, `createVars`, `createState`).
+3. Restored after user code returns.
+4. Cleared after startup completes (`#started = true`).
+
+Any KV read while the flag is `true` logs a structured warning via `this.#rLog.warn`. The flag flips to `false` after the first warning to avoid log spam.
+
+## Write Batching (New Actors)
+
+New actors batch their initialization writes into a single `kvBatchPut`:
+
+| Write | Key | Previously |
+|-------|-----|-----------|
+| Persist data | `[1]` | Separate write after `createState()` |
+| Queue metadata | `[5,1,1]` | Separate write in `queueManager.initialize()` |
+| Inspector token | `[3]` | Separate write in `#initializeInspectorToken()` |
+
+The `WriteCollector` interface collects writes from each subsystem and flushes them in a single round-trip after all subsystem initialization completes.
+
+## Protocol
+
+Preloaded data is delivered alongside `CommandStartActor` (protocol v8). The preloaded KV is populated at send time (not persisted in workflow history or command queue) to avoid storage bloat.
+
+The engine determines what to preload from the actor name metadata sent during runner init (`prepopulateActorNames`). This metadata is refreshed on every WebSocket connection/reconnection.
+
+If the FDB transaction to fetch preloaded data fails, the actor start fails (no silent fallback).
+
+## Adding New KV Reads to Startup
+
+When adding a new KV read to the actor startup path:
+
+1. Add the key/prefix to the automatic preload list in the engine.
+2. Update the subsystem to accept a `PreloadMap` parameter and check it before issuing a KV read.
+3. Verify the `#expectNoKvRoundTrips` flag does not fire warnings for the new key.
+4. If the key uses a new prefix, reserve a slot in `keys.ts` and document it in this file.
+5. If the prefix is unbounded, add a `preload_max_*_bytes` limit in the engine config (`engine/packages/config/src/config/pegboard.rs`) with a per-actor override in actor options. Do not hard-code constants.

--- a/rivetkit-typescript/packages/rivetkit/src/actor/instance/mod.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/instance/mod.ts
@@ -62,7 +62,11 @@ import {
 } from "../utils";
 import { ConnectionManager } from "./connection-manager";
 import { EventManager } from "./event-manager";
-import { KEYS } from "./keys";
+import { KEYS, sqliteStoragePrefix, workflowStoragePrefix } from "./keys";
+import {
+	type PreloadedEntries,
+	type PreloadMap,
+} from "./preload-map";
 import {
 	convertActorFromBarePersisted,
 	type PersistedActor,
@@ -71,8 +75,15 @@ import { QueueManager } from "./queue-manager";
 import { ScheduleManager } from "./schedule-manager";
 import { type SaveStateOptions, StateManager } from "./state-manager";
 import { ActorTracesDriver } from "./traces-driver";
+import { WriteCollector } from "./write-collector";
 
 export type { SaveStateOptions };
+
+/**
+ * Symbol used by subsystems (e.g., queue-manager) to access the
+ * unexpected KV round-trip warning without exposing it as a public method.
+ */
+export const WARN_UNEXPECTED_KV_ROUND_TRIP = Symbol("warnUnexpectedKvRoundTrip");
 
 enum CanSleep {
 	Yes,
@@ -174,6 +185,10 @@ export class ActorInstance<
 	#db?: InferDatabaseClient<DB>;
 	#sqliteVfs?: ISqliteVfs;
 	#metrics = new ActorMetrics();
+
+	// MARK: - Preload
+	#workflowPreloadEntries?: PreloadedEntries;
+	#expectNoKvRoundTrips = false;
 
 	// MARK: - Background Tasks
 	#backgroundPromises: Promise<void>[] = [];
@@ -325,6 +340,28 @@ export class ActorInstance<
 		});
 	}
 
+	get workflowPreloadEntries(): PreloadedEntries | undefined {
+		return this.#workflowPreloadEntries;
+	}
+
+	/**
+	 * Log a structured warning if a KV read happens during startup when
+	 * preloaded data should have covered it. Flips the flag to false after
+	 * the first warning to avoid log spam.
+	 *
+	 * Accessed via symbol to keep it internal. Used by subsystems like
+	 * queue-manager that live in separate files.
+	 */
+	[WARN_UNEXPECTED_KV_ROUND_TRIP](method: string): void {
+		if (this.#expectNoKvRoundTrips) {
+			this.#rLog.warn({
+				msg: "unexpected KV round-trip during startup",
+				method,
+			});
+			this.#expectNoKvRoundTrips = false;
+		}
+	}
+
 	get conns(): Map<ConnId, Conn<S, CP, CS, V, I, DB, E, Q>> {
 		return this.connectionManager.connections;
 	}
@@ -392,6 +429,7 @@ export class ActorInstance<
 		name: string,
 		key: ActorKey,
 		region: string,
+		preload?: PreloadMap,
 	) {
 		// Initialize properties
 		this.driver = actorDriver;
@@ -422,24 +460,59 @@ export class ActorInstance<
 		// Legacy schedule object (for compatibility)
 		this.#schedule = new Schedule(this);
 
-		// Load state
-		await this.#loadState();
-
-		await this.queueManager.initialize();
-
-		// Generate or load inspector token
-		await this.#initializeInspectorToken();
-
-		// Initialize variables
-		if (this.#varsEnabled) {
-			await this.#initializeVars();
+		// Enable unexpected KV round-trip detection when preload data was
+		// provided. Any KV read that bypasses the preload during subsystem
+		// init is a regression.
+		if (preload) {
+			this.#expectNoKvRoundTrips = true;
 		}
 
-		// Call onStart lifecycle
-		await this.#callOnStart();
+		// Extract workflow preload data for lazy consumption by workflow engine.
+		if (preload) {
+			const workflowEntries = preload.listPrefix(workflowStoragePrefix());
+			if (workflowEntries !== undefined) {
+				this.#workflowPreloadEntries = workflowEntries;
+			}
+		}
 
-		// Setup database
-		await this.#setupDatabase();
+		// Create a write collector to batch new-actor init writes (persist
+		// data, queue metadata, inspector token) into a single kvBatchPut.
+		const writeCollector = new WriteCollector(actorDriver, actorId);
+
+		// Load state
+		await this.#loadState(preload, writeCollector);
+
+		await this.queueManager.initialize(preload, writeCollector);
+
+		// Generate or load inspector token
+		await this.#initializeInspectorToken(preload, writeCollector);
+
+		// Flush any batched writes from new actor initialization.
+		await writeCollector.flush();
+
+		// Initialize variables. Pause the KV round-trip guard during
+		// user code callbacks (createVars).
+		{
+			const savedGuard = this.#expectNoKvRoundTrips;
+			this.#expectNoKvRoundTrips = false;
+			if (this.#varsEnabled) {
+				await this.#initializeVars();
+			}
+			this.#expectNoKvRoundTrips = savedGuard;
+		}
+
+		// Call onStart lifecycle. Pause the KV round-trip guard during
+		// user code callbacks (onWake).
+		{
+			const savedGuard = this.#expectNoKvRoundTrips;
+			this.#expectNoKvRoundTrips = false;
+			await this.#callOnStart();
+			this.#expectNoKvRoundTrips = savedGuard;
+		}
+
+		// Setup database. This is the last subsystem to consume preload data
+		// during startup, so the PreloadMap can be released after this returns.
+		await this.#setupDatabase(preload);
 
 		// Initialize alarms
 		await this.#scheduleManager.initializeAlarms();
@@ -458,6 +531,13 @@ export class ActorInstance<
 		// We do this after onBeforeActorStart to prevent the actor from going
 		// to sleep before finishing setup
 		this.#started = true;
+
+		// Clear KV round-trip detection after startup completes.
+		this.#expectNoKvRoundTrips = false;
+
+		// Release workflow preload data after startup completes.
+		this.#workflowPreloadEntries = undefined;
+
 		this.#rLog.info({ msg: "actor started" });
 
 		// Start sleep timer after setting #started since this affects the
@@ -1163,12 +1243,23 @@ export class ActorInstance<
 		this.#patchLoggerForTraces(this.#rLog);
 	}
 
-	async #loadState() {
-		// Read initial state from KV
-		const [persistDataBuffer] = await this.driver.kvBatchGet(
-			this.#actorId,
-			[KEYS.PERSIST_DATA],
-		);
+	async #loadState(preload?: PreloadMap, writeCollector?: WriteCollector) {
+		// Check preload for persist data before issuing a KV read.
+		let persistDataBuffer: Uint8Array | null;
+		const preloaded = preload?.get(KEYS.PERSIST_DATA);
+		if (preloaded !== undefined) {
+			// Preload returned a value or null (not-found).
+			persistDataBuffer = preloaded;
+		} else {
+			// Not preloaded, fall back to KV read.
+			this[WARN_UNEXPECTED_KV_ROUND_TRIP]("kvBatchGet");
+			const [buf] = await this.driver.kvBatchGet(
+				this.#actorId,
+				[KEYS.PERSIST_DATA],
+			);
+			persistDataBuffer = buf;
+		}
+
 		invariant(
 			persistDataBuffer !== null,
 			"persist data has not been set, it should be set when initialized",
@@ -1180,21 +1271,25 @@ export class ActorInstance<
 
 		if (persistData.hasInitialized) {
 			// Restore existing actor
-			await this.#restoreExistingActor(persistData);
+			await this.#restoreExistingActor(persistData, preload);
 		} else {
-			// Create new actor
-			await this.#createNewActor(persistData);
+			// Create new actor. Pause the KV round-trip guard during user
+			// code callbacks (createState, onCreate).
+			const savedGuard = this.#expectNoKvRoundTrips;
+			this.#expectNoKvRoundTrips = false;
+			await this.#createNewActor(persistData, writeCollector);
+			this.#expectNoKvRoundTrips = savedGuard;
 		}
 
 		// Pass persist reference to schedule manager
 		this.#scheduleManager.setPersist(this.stateManager.persist);
 	}
 
-	async #createNewActor(persistData: PersistedActor<S, I>) {
+	async #createNewActor(persistData: PersistedActor<S, I>, writeCollector?: WriteCollector) {
 		this.#rLog.info({ msg: "actor creating" });
 
 		// Initialize state
-		await this.stateManager.initializeState(persistData);
+		await this.stateManager.initializeState(persistData, writeCollector);
 
 		// Call onCreate lifecycle
 		if (this.#config.onCreate) {
@@ -1205,12 +1300,19 @@ export class ActorInstance<
 		}
 	}
 
-	async #restoreExistingActor(persistData: PersistedActor<S, I>) {
-		// List all connection keys
-		const connEntries = await this.driver.kvListPrefix(
-			this.#actorId,
-			KEYS.CONN_PREFIX,
-		);
+	async #restoreExistingActor(persistData: PersistedActor<S, I>, preload?: PreloadMap) {
+		// Check preload for connection entries before issuing a KV list.
+		let connEntries: [Uint8Array, Uint8Array][];
+		const preloadedConns = preload?.listPrefix(KEYS.CONN_PREFIX);
+		if (preloadedConns !== undefined) {
+			connEntries = preloadedConns;
+		} else {
+			this[WARN_UNEXPECTED_KV_ROUND_TRIP]("kvListPrefix");
+			connEntries = await this.driver.kvListPrefix(
+				this.#actorId,
+				KEYS.CONN_PREFIX,
+			);
+		}
 
 		// Decode connections
 		const connections: PersistedConn<CP, CS>[] = [];
@@ -1241,11 +1343,19 @@ export class ActorInstance<
 		this.connectionManager.restoreConnections(connections);
 	}
 
-	async #initializeInspectorToken() {
-		// Try to load existing token
-		const [tokenBuffer] = await this.driver.kvBatchGet(this.#actorId, [
-			KEYS.INSPECTOR_TOKEN,
-		]);
+	async #initializeInspectorToken(preload?: PreloadMap, writeCollector?: WriteCollector) {
+		// Check preload for inspector token before issuing a KV read.
+		let tokenBuffer: Uint8Array | null;
+		const preloaded = preload?.get(KEYS.INSPECTOR_TOKEN);
+		if (preloaded !== undefined) {
+			tokenBuffer = preloaded;
+		} else {
+			this[WARN_UNEXPECTED_KV_ROUND_TRIP]("kvBatchGet");
+			const [buf] = await this.driver.kvBatchGet(this.#actorId, [
+				KEYS.INSPECTOR_TOKEN,
+			]);
+			tokenBuffer = buf;
+		}
 
 		if (tokenBuffer !== null) {
 			// Token exists, decode it
@@ -1256,9 +1366,13 @@ export class ActorInstance<
 			// Generate new token
 			this.#inspectorToken = generateSecureToken();
 			const tokenBytes = new TextEncoder().encode(this.#inspectorToken);
-			await this.driver.kvBatchPut(this.#actorId, [
-				[KEYS.INSPECTOR_TOKEN, tokenBytes],
-			]);
+			if (writeCollector) {
+				writeCollector.add(KEYS.INSPECTOR_TOKEN, tokenBytes);
+			} else {
+				await this.driver.kvBatchPut(this.#actorId, [
+					[KEYS.INSPECTOR_TOKEN, tokenBytes],
+				]);
+			}
 			this.#rLog.debug({ msg: "generated new inspector token" });
 		}
 	}
@@ -1474,10 +1588,13 @@ export class ActorInstance<
 		}
 	}
 
-	async #setupDatabase() {
+	async #setupDatabase(preload?: PreloadMap) {
 		if (!("db" in this.#config) || !this.#config.db) {
 			return;
 		}
+
+		// Extract SQLite preload entries for VFS read optimization.
+		const sqlitePreloadEntries = preload?.listPrefix(sqliteStoragePrefix());
 
 		let client: InferDatabaseClient<DB> | undefined;
 		try {
@@ -1512,6 +1629,7 @@ export class ActorInstance<
 				},
 				sqliteVfs: this.#sqliteVfs,
 				metrics: this.#metrics,
+				preloadedEntries: sqlitePreloadEntries,
 			});
 			this.#rLog.info({ msg: "database migration starting" });
 			await this.#config.db.onMigrate?.(client);

--- a/rivetkit-typescript/packages/rivetkit/src/actor/instance/preload-map.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/instance/preload-map.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect } from "vitest";
+import {
+	compareBytes,
+	binarySearch,
+	buildPreloadMap,
+	type PreloadedEntries,
+	type PreloadedKvInput,
+} from "./preload-map";
+
+// Helper to create Uint8Array from a list of byte values.
+function bytes(...values: number[]): Uint8Array {
+	return new Uint8Array(values);
+}
+
+describe("compareBytes", () => {
+	it("returns 0 for equal arrays", () => {
+		expect(compareBytes(bytes(1, 2, 3), bytes(1, 2, 3))).toBe(0);
+	});
+
+	it("returns 0 for two empty arrays", () => {
+		expect(compareBytes(bytes(), bytes())).toBe(0);
+	});
+
+	it("returns negative when first array is shorter", () => {
+		expect(compareBytes(bytes(1, 2), bytes(1, 2, 3))).toBeLessThan(0);
+	});
+
+	it("returns positive when first array is longer", () => {
+		expect(compareBytes(bytes(1, 2, 3), bytes(1, 2))).toBeGreaterThan(0);
+	});
+
+	it("compares lexicographically when bytes differ", () => {
+		expect(compareBytes(bytes(1, 2), bytes(1, 3))).toBeLessThan(0);
+		expect(compareBytes(bytes(1, 3), bytes(1, 2))).toBeGreaterThan(0);
+	});
+
+	it("compares first differing byte", () => {
+		expect(compareBytes(bytes(5, 0, 0), bytes(3, 9, 9))).toBeGreaterThan(0);
+	});
+
+	it("handles single-byte arrays", () => {
+		expect(compareBytes(bytes(0), bytes(0))).toBe(0);
+		expect(compareBytes(bytes(0), bytes(1))).toBeLessThan(0);
+		expect(compareBytes(bytes(255), bytes(0))).toBeGreaterThan(0);
+	});
+});
+
+describe("binarySearch", () => {
+	it("finds a key in a sorted entries array", () => {
+		const entries: PreloadedEntries = [
+			[bytes(1), bytes(10)],
+			[bytes(2), bytes(20)],
+			[bytes(3), bytes(30)],
+		];
+		const result = binarySearch(entries, bytes(2));
+		expect(result).toEqual(bytes(20));
+	});
+
+	it("returns undefined when key is not found", () => {
+		const entries: PreloadedEntries = [
+			[bytes(1), bytes(10)],
+			[bytes(3), bytes(30)],
+		];
+		expect(binarySearch(entries, bytes(2))).toBeUndefined();
+	});
+
+	it("returns undefined for an empty array", () => {
+		expect(binarySearch([], bytes(1))).toBeUndefined();
+	});
+
+	it("finds the only element in a single-element array", () => {
+		const entries: PreloadedEntries = [[bytes(5), bytes(50)]];
+		expect(binarySearch(entries, bytes(5))).toEqual(bytes(50));
+	});
+
+	it("returns undefined when key is not in single-element array", () => {
+		const entries: PreloadedEntries = [[bytes(5), bytes(50)]];
+		expect(binarySearch(entries, bytes(3))).toBeUndefined();
+	});
+
+	it("finds the first element", () => {
+		const entries: PreloadedEntries = [
+			[bytes(1), bytes(10)],
+			[bytes(2), bytes(20)],
+			[bytes(3), bytes(30)],
+		];
+		expect(binarySearch(entries, bytes(1))).toEqual(bytes(10));
+	});
+
+	it("finds the last element", () => {
+		const entries: PreloadedEntries = [
+			[bytes(1), bytes(10)],
+			[bytes(2), bytes(20)],
+			[bytes(3), bytes(30)],
+		];
+		expect(binarySearch(entries, bytes(3))).toEqual(bytes(30));
+	});
+
+	it("handles multi-byte keys correctly", () => {
+		const entries: PreloadedEntries = [
+			[bytes(1, 0), bytes(10)],
+			[bytes(1, 1), bytes(11)],
+			[bytes(2, 0), bytes(20)],
+		];
+		expect(binarySearch(entries, bytes(1, 1))).toEqual(bytes(11));
+		expect(binarySearch(entries, bytes(1, 2))).toBeUndefined();
+	});
+});
+
+describe("buildPreloadMap", () => {
+	it("returns undefined for null input", () => {
+		expect(buildPreloadMap(null)).toBeUndefined();
+	});
+
+	it("returns undefined for undefined input", () => {
+		expect(buildPreloadMap(undefined)).toBeUndefined();
+	});
+
+	describe("get()", () => {
+		it("returns Uint8Array when key exists in entries", () => {
+			const input: PreloadedKvInput = {
+				entries: [
+					{ key: bytes(1).buffer, value: bytes(10).buffer },
+					{ key: bytes(2).buffer, value: bytes(20).buffer },
+				],
+				requestedGetKeys: [bytes(1).buffer, bytes(2).buffer],
+				requestedPrefixes: [],
+			};
+			const map = buildPreloadMap(input)!;
+			expect(map).toBeDefined();
+			expect(map.get(bytes(1))).toEqual(bytes(10));
+			expect(map.get(bytes(2))).toEqual(bytes(20));
+		});
+
+		it("returns null when key is in requestedGetKeys but not in entries", () => {
+			const input: PreloadedKvInput = {
+				entries: [],
+				requestedGetKeys: [bytes(1).buffer, bytes(5).buffer],
+				requestedPrefixes: [],
+			};
+			const map = buildPreloadMap(input)!;
+			expect(map.get(bytes(1))).toBeNull();
+			expect(map.get(bytes(5))).toBeNull();
+		});
+
+		it("returns undefined when key is not in requestedGetKeys", () => {
+			const input: PreloadedKvInput = {
+				entries: [{ key: bytes(1).buffer, value: bytes(10).buffer }],
+				requestedGetKeys: [bytes(1).buffer],
+				requestedPrefixes: [],
+			};
+			const map = buildPreloadMap(input)!;
+			// Key 99 was never requested.
+			expect(map.get(bytes(99))).toBeUndefined();
+		});
+
+		it("distinguishes all three return types", () => {
+			const input: PreloadedKvInput = {
+				entries: [{ key: bytes(1).buffer, value: bytes(10).buffer }],
+				requestedGetKeys: [bytes(1).buffer, bytes(2).buffer],
+				requestedPrefixes: [],
+			};
+			const map = buildPreloadMap(input)!;
+
+			// Key exists in entries: returns value.
+			const found = map.get(bytes(1));
+			expect(found).toBeInstanceOf(Uint8Array);
+			expect(found).toEqual(bytes(10));
+
+			// Key requested but not found: returns null.
+			expect(map.get(bytes(2))).toBeNull();
+
+			// Key not requested at all: returns undefined.
+			expect(map.get(bytes(3))).toBeUndefined();
+		});
+
+		it("handles entries provided in unsorted order", () => {
+			const input: PreloadedKvInput = {
+				entries: [
+					{ key: bytes(3).buffer, value: bytes(30).buffer },
+					{ key: bytes(1).buffer, value: bytes(10).buffer },
+					{ key: bytes(2).buffer, value: bytes(20).buffer },
+				],
+				requestedGetKeys: [
+					bytes(3).buffer,
+					bytes(1).buffer,
+					bytes(2).buffer,
+				],
+				requestedPrefixes: [],
+			};
+			const map = buildPreloadMap(input)!;
+			expect(map.get(bytes(1))).toEqual(bytes(10));
+			expect(map.get(bytes(2))).toEqual(bytes(20));
+			expect(map.get(bytes(3))).toEqual(bytes(30));
+		});
+	});
+
+	describe("listPrefix()", () => {
+		it("returns entries matching prefix", () => {
+			const input: PreloadedKvInput = {
+				entries: [
+					{ key: bytes(1, 0).buffer, value: bytes(10).buffer },
+					{ key: bytes(1, 1).buffer, value: bytes(11).buffer },
+					{ key: bytes(2, 0).buffer, value: bytes(20).buffer },
+				],
+				requestedGetKeys: [],
+				requestedPrefixes: [bytes(1).buffer],
+			};
+			const map = buildPreloadMap(input)!;
+			const result = map.listPrefix(bytes(1));
+			expect(result).toBeDefined();
+			expect(result).toHaveLength(2);
+			expect(result![0][0]).toEqual(bytes(1, 0));
+			expect(result![0][1]).toEqual(bytes(10));
+			expect(result![1][0]).toEqual(bytes(1, 1));
+			expect(result![1][1]).toEqual(bytes(11));
+		});
+
+		it("returns empty array when prefix was requested but has no entries", () => {
+			const input: PreloadedKvInput = {
+				entries: [
+					{ key: bytes(2, 0).buffer, value: bytes(20).buffer },
+				],
+				requestedGetKeys: [],
+				requestedPrefixes: [bytes(1).buffer],
+			};
+			const map = buildPreloadMap(input)!;
+			const result = map.listPrefix(bytes(1));
+			expect(result).toBeDefined();
+			expect(result).toEqual([]);
+		});
+
+		it("returns undefined when prefix was not requested", () => {
+			const input: PreloadedKvInput = {
+				entries: [
+					{ key: bytes(1, 0).buffer, value: bytes(10).buffer },
+				],
+				requestedGetKeys: [],
+				requestedPrefixes: [],
+			};
+			const map = buildPreloadMap(input)!;
+			expect(map.listPrefix(bytes(1))).toBeUndefined();
+		});
+
+		it("returns multiple entries with the same prefix", () => {
+			const input: PreloadedKvInput = {
+				entries: [
+					{ key: bytes(5, 0).buffer, value: bytes(50).buffer },
+					{ key: bytes(5, 1).buffer, value: bytes(51).buffer },
+					{ key: bytes(5, 2).buffer, value: bytes(52).buffer },
+					{ key: bytes(5, 3).buffer, value: bytes(53).buffer },
+				],
+				requestedGetKeys: [],
+				requestedPrefixes: [bytes(5).buffer],
+			};
+			const map = buildPreloadMap(input)!;
+			const result = map.listPrefix(bytes(5));
+			expect(result).toHaveLength(4);
+			expect(result![0][1]).toEqual(bytes(50));
+			expect(result![3][1]).toEqual(bytes(53));
+		});
+
+		it("does not match entries that share a byte prefix but belong to a different requested prefix", () => {
+			// Prefix [1] should not match entries with key [1, 5, ...] if
+			// we are listing prefix [1, 5]. And vice versa.
+			const input: PreloadedKvInput = {
+				entries: [
+					{ key: bytes(1, 0).buffer, value: bytes(10).buffer },
+					{ key: bytes(1, 5, 0).buffer, value: bytes(150).buffer },
+					{ key: bytes(1, 5, 1).buffer, value: bytes(151).buffer },
+					{ key: bytes(2, 0).buffer, value: bytes(20).buffer },
+				],
+				requestedGetKeys: [],
+				requestedPrefixes: [bytes(1, 5).buffer],
+			};
+			const map = buildPreloadMap(input)!;
+			const result = map.listPrefix(bytes(1, 5));
+			expect(result).toBeDefined();
+			expect(result).toHaveLength(2);
+			expect(result![0][0]).toEqual(bytes(1, 5, 0));
+			expect(result![1][0]).toEqual(bytes(1, 5, 1));
+		});
+
+		it("an exact key match counts as having that prefix", () => {
+			const input: PreloadedKvInput = {
+				entries: [
+					{ key: bytes(3).buffer, value: bytes(30).buffer },
+				],
+				requestedGetKeys: [],
+				requestedPrefixes: [bytes(3).buffer],
+			};
+			const map = buildPreloadMap(input)!;
+			const result = map.listPrefix(bytes(3));
+			expect(result).toBeDefined();
+			expect(result).toHaveLength(1);
+			expect(result![0][0]).toEqual(bytes(3));
+		});
+
+		it("empty prefix matches all entries", () => {
+			const input: PreloadedKvInput = {
+				entries: [
+					{ key: bytes(1).buffer, value: bytes(10).buffer },
+					{ key: bytes(2).buffer, value: bytes(20).buffer },
+				],
+				requestedGetKeys: [],
+				requestedPrefixes: [bytes().buffer],
+			};
+			const map = buildPreloadMap(input)!;
+			const result = map.listPrefix(bytes());
+			expect(result).toBeDefined();
+			expect(result).toHaveLength(2);
+		});
+	});
+});

--- a/rivetkit-typescript/packages/rivetkit/src/actor/instance/preload-map.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/instance/preload-map.ts
@@ -1,0 +1,169 @@
+/**
+ * Input types matching the runner protocol PreloadedKv structure.
+ * Defined locally to avoid a dependency on the runner-protocol package.
+ */
+export interface PreloadedKvInput {
+	readonly entries: readonly {
+		readonly key: ArrayBufferLike;
+		readonly value: ArrayBufferLike;
+	}[];
+	readonly requestedGetKeys: readonly ArrayBufferLike[];
+	readonly requestedPrefixes: readonly ArrayBufferLike[];
+}
+
+/**
+ * Sorted array of [key, value] pairs for binary search lookups.
+ * Used for prefix-based preloaded data (SQLite, connections, workflows).
+ */
+export type PreloadedEntries = [Uint8Array, Uint8Array][];
+
+/**
+ * Preloaded KV lookup supporting exact key lookup and prefix listing.
+ *
+ * Three-way return on get():
+ * - Uint8Array: key was preloaded and exists with this value
+ * - null: key was requested but does not exist in storage
+ * - undefined: key was not preloaded, caller should fall back to KV read
+ *
+ * listPrefix():
+ * - [Uint8Array, Uint8Array][]: prefix was preloaded, these are the entries
+ * - undefined: prefix was not preloaded, caller should fall back to KV list
+ */
+export interface PreloadMap {
+	get(key: Uint8Array): Uint8Array | null | undefined;
+	listPrefix(prefix: Uint8Array): [Uint8Array, Uint8Array][] | undefined;
+}
+
+/** Lexicographic comparison of two byte arrays. */
+export function compareBytes(a: Uint8Array, b: Uint8Array): number {
+	const len = Math.min(a.length, b.length);
+	for (let i = 0; i < len; i++) {
+		if (a[i] !== b[i]) return a[i] - b[i];
+	}
+	return a.length - b.length;
+}
+
+/** Binary search a sorted [key, value][] array. Returns the value if found, undefined otherwise. */
+export function binarySearch(
+	entries: PreloadedEntries,
+	key: Uint8Array,
+): Uint8Array | undefined {
+	let lo = 0;
+	let hi = entries.length - 1;
+	while (lo <= hi) {
+		const mid = (lo + hi) >>> 1;
+		const cmp = compareBytes(entries[mid][0], key);
+		if (cmp === 0) return entries[mid][1];
+		if (cmp < 0) lo = mid + 1;
+		else hi = mid - 1;
+	}
+	return undefined;
+}
+
+/**
+ * Returns true if `key` starts with `prefix`.
+ */
+function hasPrefix(key: Uint8Array, prefix: Uint8Array): boolean {
+	if (key.length < prefix.length) return false;
+	for (let i = 0; i < prefix.length; i++) {
+		if (key[i] !== prefix[i]) return false;
+	}
+	return true;
+}
+
+/**
+ * Build a PreloadMap from protocol data.
+ *
+ * Returns undefined if the protocol data is undefined/null (no preloading).
+ */
+export function buildPreloadMap(
+	preloadedKv: PreloadedKvInput | null | undefined,
+): PreloadMap | undefined {
+	if (preloadedKv == null) return undefined;
+
+	// Convert ArrayBuffer entries to Uint8Array and sort by key for binary search.
+	const sorted: PreloadedEntries = preloadedKv.entries
+		.map(
+			(entry) =>
+				[
+					new Uint8Array(entry.key),
+					new Uint8Array(entry.value),
+				] as [Uint8Array, Uint8Array],
+		)
+		.sort((a, b) => compareBytes(a[0], b[0]));
+
+	// Build a set of requested get keys for three-way return semantics.
+	// We use sorted array + binary search since Uint8Array can't be used as Map key.
+	const requestedGetKeys: Uint8Array[] = preloadedKv.requestedGetKeys
+		.map((k) => new Uint8Array(k))
+		.sort(compareBytes);
+
+	// Build a set of requested prefixes for listPrefix semantics.
+	const requestedPrefixes: Uint8Array[] = preloadedKv.requestedPrefixes
+		.map((k) => new Uint8Array(k))
+		.sort(compareBytes);
+
+	return {
+		get(key: Uint8Array): Uint8Array | null | undefined {
+			// Check if this key has a value in the preloaded entries.
+			const value = binarySearch(sorted, key);
+			if (value !== undefined) return value;
+
+			// Check if this key was explicitly requested (meaning it was looked up but not found).
+			if (binarySearchExists(requestedGetKeys, key)) return null;
+
+			// Key was not preloaded at all.
+			return undefined;
+		},
+
+		listPrefix(prefix: Uint8Array): [Uint8Array, Uint8Array][] | undefined {
+			// Check if this prefix was requested.
+			if (!binarySearchExists(requestedPrefixes, prefix)) {
+				return undefined;
+			}
+
+			// Collect all entries matching this prefix.
+			// Since entries are sorted, find the first match and scan forward.
+			const result: [Uint8Array, Uint8Array][] = [];
+			let lo = 0;
+			let hi = sorted.length - 1;
+
+			// Binary search to find the first entry >= prefix.
+			while (lo <= hi) {
+				const mid = (lo + hi) >>> 1;
+				if (compareBytes(sorted[mid][0], prefix) < 0) {
+					lo = mid + 1;
+				} else {
+					hi = mid - 1;
+				}
+			}
+
+			// Scan forward from `lo` collecting all entries with the prefix.
+			for (let i = lo; i < sorted.length; i++) {
+				if (!hasPrefix(sorted[i][0], prefix)) break;
+				result.push(sorted[i]);
+			}
+
+			return result;
+		},
+	};
+}
+
+/**
+ * Binary search a sorted Uint8Array[] to check if a key exists.
+ */
+function binarySearchExists(
+	sortedKeys: Uint8Array[],
+	key: Uint8Array,
+): boolean {
+	let lo = 0;
+	let hi = sortedKeys.length - 1;
+	while (lo <= hi) {
+		const mid = (lo + hi) >>> 1;
+		const cmp = compareBytes(sortedKeys[mid], key);
+		if (cmp === 0) return true;
+		if (cmp < 0) lo = mid + 1;
+		else hi = mid - 1;
+	}
+	return false;
+}

--- a/rivetkit-typescript/packages/rivetkit/src/actor/instance/queue-manager.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/instance/queue-manager.ts
@@ -16,7 +16,9 @@ import {
 	queueMessagesPrefix,
 	queueMetadataKey,
 } from "./keys";
-import type { ActorInstance } from "./mod";
+import { type ActorInstance, WARN_UNEXPECTED_KV_ROUND_TRIP } from "./mod";
+import type { PreloadMap } from "./preload-map";
+import type { WriteCollector } from "./write-collector";
 
 export interface QueueMessage {
 	id: bigint;
@@ -95,14 +97,26 @@ export class QueueManager<
 	}
 
 	/** Loads queue metadata from storage and initializes internal state. */
-	async initialize(): Promise<void> {
-		const [metadataBuffer] = await this.#driver.kvBatchGet(this.#actor.id, [
-			QUEUE_METADATA_KEY,
-		]);
-		if (!metadataBuffer) {
-			await this.#driver.kvBatchPut(this.#actor.id, [
-				[QUEUE_METADATA_KEY, this.#serializeMetadata()],
+	async initialize(preload?: PreloadMap, writeCollector?: WriteCollector): Promise<void> {
+		// Check preload for queue metadata before issuing a KV read.
+		let metadataBuffer: Uint8Array | null;
+		const preloaded = preload?.get(QUEUE_METADATA_KEY);
+		if (preloaded !== undefined) {
+			metadataBuffer = preloaded;
+		} else {
+			this.#actor[WARN_UNEXPECTED_KV_ROUND_TRIP]("kvBatchGet");
+			const [buf] = await this.#driver.kvBatchGet(this.#actor.id, [
+				QUEUE_METADATA_KEY,
 			]);
+			metadataBuffer = buf;
+		}
+		if (!metadataBuffer) {
+			const entry: [Uint8Array, Uint8Array] = [QUEUE_METADATA_KEY, this.#serializeMetadata()];
+			if (writeCollector) {
+				writeCollector.add(entry[0], entry[1]);
+			} else {
+				await this.#driver.kvBatchPut(this.#actor.id, [entry]);
+			}
 			this.#actor.inspector.updateQueueSize(this.#metadata.size);
 			return;
 		}

--- a/rivetkit-typescript/packages/rivetkit/src/actor/instance/state-manager.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/instance/state-manager.ts
@@ -17,6 +17,7 @@ import { isConnStatePath, isStatePath } from "../utils";
 import { KEYS, makeConnKey } from "./keys";
 import type { ActorInstance } from "./mod";
 import { convertActorToBarePersisted, type PersistedActor } from "./persisted";
+import type { WriteCollector } from "./write-collector";
 
 export interface SaveStateOptions {
 	/**
@@ -109,7 +110,7 @@ export class StateManager<
 	/**
 	 * Initializes state from persisted data or creates new state.
 	 */
-	async initializeState(persistData: PersistedActor<S, I>): Promise<void> {
+	async initializeState(persistData: PersistedActor<S, I>, writeCollector?: WriteCollector): Promise<void> {
 		if (!persistData.hasInitialized) {
 			// Create initial state
 			let stateData: unknown;
@@ -141,20 +142,21 @@ export class StateManager<
 			persistData.state = stateData as S;
 			persistData.hasInitialized = true;
 
-			// Save initial state
-			//
-			// We don't use #savePersistInner because the actor is not fully
-			// initialized yet
+			// Save initial state. We don't use #savePersistInner because the
+			// actor is not fully initialized yet.
 			const bareData = convertActorToBarePersisted<S, I>(persistData);
-			await this.#actorDriver.kvBatchPut(this.#actor.id, [
-				[
-					KEYS.PERSIST_DATA,
-					ACTOR_VERSIONED.serializeWithEmbeddedVersion(
-						bareData,
-						ACTOR_PERSIST_CURRENT_VERSION,
-					),
-				],
-			]);
+			const entry: [Uint8Array, Uint8Array] = [
+				KEYS.PERSIST_DATA,
+				ACTOR_VERSIONED.serializeWithEmbeddedVersion(
+					bareData,
+					ACTOR_PERSIST_CURRENT_VERSION,
+				),
+			];
+			if (writeCollector) {
+				writeCollector.add(entry[0], entry[1]);
+			} else {
+				await this.#actorDriver.kvBatchPut(this.#actor.id, [entry]);
+			}
 		}
 
 		// Initialize proxy

--- a/rivetkit-typescript/packages/rivetkit/src/actor/instance/write-collector.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/instance/write-collector.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { WriteCollector } from "./write-collector.js";
+
+describe("WriteCollector", () => {
+	function setup() {
+		const calls: [string, [Uint8Array, Uint8Array][]][] = [];
+		const fakeDriver = {
+			kvBatchPut: async (
+				actorId: string,
+				entries: [Uint8Array, Uint8Array][],
+			) => {
+				calls.push([actorId, entries]);
+			},
+		} as any;
+		const actorId = "test-actor-id";
+		const collector = new WriteCollector(fakeDriver, actorId);
+		return { calls, collector, actorId };
+	}
+
+	it("flush() with no entries does nothing", async () => {
+		const { calls, collector } = setup();
+		await collector.flush();
+		expect(calls).toHaveLength(0);
+	});
+
+	it("flush() with entries calls kvBatchPut with all collected entries", async () => {
+		const { calls, collector, actorId } = setup();
+
+		const key1 = new Uint8Array([1, 2, 3]);
+		const val1 = new Uint8Array([4, 5, 6]);
+		const key2 = new Uint8Array([7, 8]);
+		const val2 = new Uint8Array([9, 10]);
+
+		collector.add(key1, val1);
+		collector.add(key2, val2);
+		await collector.flush();
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]![0]).toBe(actorId);
+		expect(calls[0]![1]).toHaveLength(2);
+		expect(calls[0]![1]![0]).toEqual([key1, val1]);
+		expect(calls[0]![1]![1]).toEqual([key2, val2]);
+	});
+
+	it("multiple add() calls accumulate entries", async () => {
+		const { calls, collector } = setup();
+
+		collector.add(new Uint8Array([1]), new Uint8Array([2]));
+		collector.add(new Uint8Array([3]), new Uint8Array([4]));
+		collector.add(new Uint8Array([5]), new Uint8Array([6]));
+
+		await collector.flush();
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]![1]).toHaveLength(3);
+	});
+
+	it("after flush(), entries are cleared and second flush is a no-op", async () => {
+		const { calls, collector } = setup();
+
+		collector.add(new Uint8Array([1]), new Uint8Array([2]));
+		await collector.flush();
+		expect(calls).toHaveLength(1);
+
+		await collector.flush();
+		expect(calls).toHaveLength(1);
+	});
+});

--- a/rivetkit-typescript/packages/rivetkit/src/actor/instance/write-collector.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/instance/write-collector.ts
@@ -1,0 +1,29 @@
+import type { ActorDriver } from "../driver.js";
+
+/**
+ * Collects KV write entries during new actor initialization and flushes them
+ * in a single kvBatchPut call. This reduces 3 sequential write round-trips
+ * (persist data, queue metadata, inspector token) to 1 batched round-trip.
+ */
+export class WriteCollector {
+	#entries: [Uint8Array, Uint8Array][] = [];
+	#driver: ActorDriver;
+	#actorId: string;
+
+	constructor(driver: ActorDriver, actorId: string) {
+		this.#driver = driver;
+		this.#actorId = actorId;
+	}
+
+	/** Adds a key-value pair to the batch. */
+	add(key: Uint8Array, value: Uint8Array): void {
+		this.#entries.push([key, value]);
+	}
+
+	/** Sends all collected entries in a single kvBatchPut call. */
+	async flush(): Promise<void> {
+		if (this.#entries.length === 0) return;
+		await this.#driver.kvBatchPut(this.#actorId, this.#entries);
+		this.#entries = [];
+	}
+}

--- a/rivetkit-typescript/packages/rivetkit/src/db/config.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/db/config.ts
@@ -45,6 +45,13 @@ export interface DatabaseProviderContext {
 	 * Actor metrics instance. When provided, KV and SQL operations are tracked.
 	 */
 	metrics?: ActorMetrics;
+
+	/**
+	 * Preloaded SQLite KV entries for VFS read optimization during startup.
+	 * When provided, database reads check these sorted entries via binary
+	 * search before falling back to KV.
+	 */
+	preloadedEntries?: [Uint8Array, Uint8Array][];
 }
 
 export type DatabaseProvider<DB extends RawAccess> = {

--- a/rivetkit-typescript/packages/rivetkit/src/db/drizzle/mod.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/db/drizzle/mod.ts
@@ -126,6 +126,7 @@ export function db<
 	// concurrently: the last writer won, and earlier actors' migrations
 	// ran on the wrong database.
 	const clientToRawDb = new WeakMap<object, IDatabase>();
+	let kvStoreRef: ReturnType<typeof createActorKvStore> | null = null;
 
 	return {
 		createClient: async (ctx) => {
@@ -136,7 +137,8 @@ export function db<
 				);
 			}
 
-			const kvStore = createActorKvStore(ctx.kv, ctx.metrics);
+			const kvStore = createActorKvStore(ctx.kv, ctx.metrics, ctx.preloadedEntries);
+			kvStoreRef = kvStore;
 			const waDb = await ctx.sqliteVfs.open(ctx.actorId, kvStore);
 			// Per-client mutex so actors of the same type do not serialize
 			// against each other. Each actor has its own database handle and
@@ -228,6 +230,8 @@ export function db<
 					config.migrations,
 				);
 			}
+			kvStoreRef?.clearPreload();
+			kvStoreRef = null;
 		},
 		onDestroy: async (client) => {
 			await client.close();

--- a/rivetkit-typescript/packages/rivetkit/src/db/mod.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/db/mod.ts
@@ -10,6 +10,8 @@ interface DatabaseFactoryConfig {
 export function db({
 	onMigrate,
 }: DatabaseFactoryConfig = {}): DatabaseProvider<RawAccess> {
+	let kvStoreRef: ReturnType<typeof createActorKvStore> | null = null;
+
 	return {
 		createClient: async (ctx) => {
 			// Check if override is provided
@@ -44,7 +46,8 @@ export function db({
 				);
 			}
 
-			const kvStore = createActorKvStore(ctx.kv, ctx.metrics);
+			const kvStore = createActorKvStore(ctx.kv, ctx.metrics, ctx.preloadedEntries);
+			kvStoreRef = kvStore;
 			const db = await ctx.sqliteVfs.open(ctx.actorId, kvStore);
 			let closed = false;
 			const mutex = new AsyncMutex();
@@ -142,6 +145,8 @@ export function db({
 			if (onMigrate) {
 				await onMigrate(client);
 			}
+			kvStoreRef?.clearPreload();
+			kvStoreRef = null;
 		},
 		onDestroy: async (client) => {
 			await client.close();

--- a/rivetkit-typescript/packages/rivetkit/src/db/shared.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/db/shared.ts
@@ -2,6 +2,10 @@ import type { DatabaseProviderContext } from "./config";
 import type { IDatabase } from "@rivetkit/sqlite-vfs";
 import type { KvVfsOptions } from "@rivetkit/sqlite-vfs";
 import type { ActorMetrics } from "@/actor/metrics";
+import {
+	binarySearch,
+	type PreloadedEntries,
+} from "../actor/instance/preload-map";
 
 type ActorKvOperations = DatabaseProviderContext["kv"];
 type SqliteBindings = NonNullable<Parameters<IDatabase["run"]>[1]>;
@@ -37,13 +41,27 @@ export function toSqliteBindings(args: unknown[]): SqliteBindings {
 /**
  * Create a KV store wrapper that uses the actor driver's KV operations.
  * Tracks per-operation metrics when an ActorMetrics instance is provided.
+ *
+ * When `preloadedEntries` is provided, `get` and `getBatch` check the
+ * preloaded sorted array via binary search before falling back to KV.
+ * Write operations always pass through to KV unchanged.
+ *
+ * Call `clearPreload()` on the returned object after migrations complete
+ * to release the preloaded data and free memory.
  */
 export function createActorKvStore(
 	kv: ActorKvOperations,
 	metrics?: ActorMetrics,
-): KvVfsOptions {
+	preloadedEntries?: PreloadedEntries,
+): KvVfsOptions & { clearPreload: () => void } {
+	let preload: PreloadedEntries | undefined = preloadedEntries;
+
 	return {
 		get: async (key: Uint8Array) => {
+			if (preload) {
+				const value = binarySearch(preload, key);
+				if (value !== undefined) return value;
+			}
 			const start = performance.now();
 			const results = await kv.batchGet([key]);
 			if (metrics) {
@@ -54,13 +72,46 @@ export function createActorKvStore(
 			return results[0] ?? null;
 		},
 		getBatch: async (keys: Uint8Array[]) => {
-			const start = performance.now();
-			const results = await kv.batchGet(keys);
-			if (metrics) {
-				metrics.kvGetBatch.calls++;
-				metrics.kvGetBatch.keys += keys.length;
-				metrics.kvGetBatch.totalMs += performance.now() - start;
+			if (!preload || keys.length === 0) {
+				const start = performance.now();
+				const results = await kv.batchGet(keys);
+				if (metrics) {
+					metrics.kvGetBatch.calls++;
+					metrics.kvGetBatch.keys += keys.length;
+					metrics.kvGetBatch.totalMs += performance.now() - start;
+				}
+				return results;
 			}
+
+			const results: (Uint8Array | null)[] = new Array<Uint8Array | null>(
+				keys.length,
+			).fill(null);
+			const missIndices: number[] = [];
+			const missKeys: Uint8Array[] = [];
+
+			for (let i = 0; i < keys.length; i++) {
+				const value = binarySearch(preload, keys[i]);
+				if (value !== undefined) {
+					results[i] = value;
+				} else {
+					missIndices.push(i);
+					missKeys.push(keys[i]);
+				}
+			}
+
+			if (missKeys.length > 0) {
+				const start = performance.now();
+				const kvResults = await kv.batchGet(missKeys);
+				if (metrics) {
+					metrics.kvGetBatch.calls++;
+					metrics.kvGetBatch.keys += missKeys.length;
+					metrics.kvGetBatch.totalMs += performance.now() - start;
+				}
+				for (let i = 0; i < missIndices.length; i++) {
+					results[missIndices[i]] = kvResults[i] ?? null;
+				}
+			}
+
 			return results;
 		},
 		put: async (key: Uint8Array, value: Uint8Array) => {
@@ -89,6 +140,9 @@ export function createActorKvStore(
 				metrics.kvDeleteBatch.keys += keys.length;
 				metrics.kvDeleteBatch.totalMs += performance.now() - start;
 			}
+		},
+		clearPreload: () => {
+			preload = undefined;
 		},
 	};
 }

--- a/rivetkit-typescript/packages/rivetkit/src/drivers/engine/actor-driver.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/drivers/engine/actor-driver.ts
@@ -14,6 +14,7 @@ import invariant from "invariant";
 import { type AnyConn, CONN_STATE_MANAGER_SYMBOL } from "@/actor/conn/mod";
 import { lookupInRegistry } from "@/actor/definition";
 import { KEYS } from "@/actor/instance/keys";
+import { buildPreloadMap, type PreloadMap } from "@/actor/instance/preload-map";
 import { deserializeActorKey } from "@/actor/keys";
 import { getValueLength } from "@/actor/protocol/old";
 import { type ActorRouter, createActorRouter } from "@/actor/router";
@@ -532,11 +533,25 @@ export class EngineActorDriver implements ActorDriver {
 		const key = deserializeActorKey(actorConfig.key);
 
 		try {
-			// Initialize storage
-			const [persistDataBuffer] = await this.#runner.kvGet(actorId, [
-				KEYS.PERSIST_DATA,
-			]);
-			if (persistDataBuffer === null) {
+			// Initialize storage. Use preloaded data when available to
+			// avoid a redundant KV round-trip for the persist data check.
+			const preloadMap = buildPreloadMap(actorConfig.preloadedKv);
+			const preloadedPersistData = preloadMap?.get(KEYS.PERSIST_DATA);
+
+			let isNewActor: boolean;
+			if (preloadedPersistData !== undefined) {
+				// Preload was available. null means key not found (new actor),
+				// Uint8Array means existing actor.
+				isNewActor = preloadedPersistData === null;
+			} else {
+				// No preload available, fall back to kvGet.
+				const [persistDataBuffer] = await this.#runner.kvGet(actorId, [
+					KEYS.PERSIST_DATA,
+				]);
+				isNewActor = persistDataBuffer === null;
+			}
+
+			if (isNewActor) {
 				const initialKvState = getInitialActorKvState(input);
 				await this.#runner.kvPut(actorId, initialKvState);
 				logger().debug({
@@ -547,7 +562,6 @@ export class EngineActorDriver implements ActorDriver {
 				logger().debug({
 					msg: "found existing persist data for actor",
 					actorId,
-					dataSize: persistDataBuffer.byteLength,
 				});
 			}
 
@@ -590,6 +604,7 @@ export class EngineActorDriver implements ActorDriver {
 				name,
 				key,
 				"unknown", // TODO: Add regions
+				preloadMap,
 			);
 
 			logger().debug({ msg: "runner actor started", actorId, name, key });

--- a/rivetkit-typescript/packages/rivetkit/src/registry/config/index.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/config/index.ts
@@ -319,6 +319,16 @@ export function buildActorNames(
 			// Remove undefined values
 			if (!metadata.icon) delete metadata.icon;
 			if (!metadata.name) delete metadata.name;
+			// Include preload config overrides only when explicitly set
+			if (options.preloadMaxSqliteBytes !== undefined) {
+				metadata.preloadMaxSqliteBytes = options.preloadMaxSqliteBytes;
+			}
+			if (options.preloadMaxWorkflowBytes !== undefined) {
+				metadata.preloadMaxWorkflowBytes = options.preloadMaxWorkflowBytes;
+			}
+			if (options.preloadMaxConnectionsBytes !== undefined) {
+				metadata.preloadMaxConnectionsBytes = options.preloadMaxConnectionsBytes;
+			}
 			return [actorName, { metadata }];
 		}),
 	);

--- a/scripts/ralph/ralph.sh
+++ b/scripts/ralph/ralph.sh
@@ -43,20 +43,20 @@ LAST_BRANCH_FILE="$SCRIPT_DIR/.last-branch"
 if [ -f "$PRD_FILE" ] && [ -f "$LAST_BRANCH_FILE" ]; then
   CURRENT_BRANCH=$(jq -r '.branchName // empty' "$PRD_FILE" 2>/dev/null || echo "")
   LAST_BRANCH=$(cat "$LAST_BRANCH_FILE" 2>/dev/null || echo "")
-
+  
   if [ -n "$CURRENT_BRANCH" ] && [ -n "$LAST_BRANCH" ] && [ "$CURRENT_BRANCH" != "$LAST_BRANCH" ]; then
     # Archive the previous run
     DATE=$(date +%Y-%m-%d)
     # Strip "ralph/" prefix from branch name for folder
     FOLDER_NAME=$(echo "$LAST_BRANCH" | sed 's|^ralph/||')
     ARCHIVE_FOLDER="$ARCHIVE_DIR/$DATE-$FOLDER_NAME"
-
+    
     echo "Archiving previous run: $LAST_BRANCH"
     mkdir -p "$ARCHIVE_FOLDER"
     [ -f "$PRD_FILE" ] && cp "$PRD_FILE" "$ARCHIVE_FOLDER/"
     [ -f "$PROGRESS_FILE" ] && cp "$PROGRESS_FILE" "$ARCHIVE_FOLDER/"
     echo "   Archived to: $ARCHIVE_FOLDER"
-
+    
     # Reset progress file for new run
     echo "# Ralph Progress Log" > "$PROGRESS_FILE"
     echo "Started: $(date)" >> "$PROGRESS_FILE"
@@ -94,7 +94,7 @@ for i in $(seq 1 $MAX_ITERATIONS); do
     # Claude Code: use --dangerously-skip-permissions for autonomous operation, --print for output
     OUTPUT=$(claude --dangerously-skip-permissions --print < "$SCRIPT_DIR/CLAUDE.md" 2>&1 | tee /dev/stderr) || true
   fi
-
+  
   # Check for completion signal
   if echo "$OUTPUT" | grep -q "<promise>COMPLETE</promise>"; then
     echo ""
@@ -102,7 +102,7 @@ for i in $(seq 1 $MAX_ITERATIONS); do
     echo "Completed at iteration $i of $MAX_ITERATIONS"
     exit 0
   fi
-
+  
   echo "Iteration $i complete. Continuing..."
   sleep 2
 done

--- a/website/src/content/docs/actors/limits.mdx
+++ b/website/src/content/docs/actors/limits.mdx
@@ -91,6 +91,35 @@ These limits apply to the [SQLite database](/docs/actors/state#sqlite-database) 
 |------|------------|------------|-------------|
 | Max storage size per actor | — | 10 GiB | Maximum total storage size for a single actor. This limit is shared with KV storage. |
 
+### KV Preloading
+
+When an actor starts, the engine pre-fetches commonly needed KV data and delivers it alongside the start command. This eliminates round-trips to the database during actor startup. Preload limits are configurable in the [engine config](/docs/self-hosting/configuration) (`pegboard.preload_max_*` fields) and can be overridden per actor via `options`.
+
+| Name | Soft Limit | Hard Limit | Description |
+|------|------------|------------|-------------|
+| Max total preload size | 1 MiB | — | Maximum total size of all preloaded KV data sent with the start command. Configurable via engine config `pegboard.preload_max_total_bytes`. Setting to 0 disables all preloading. |
+| Max SQLite preload size | 768 KiB | — | Maximum size of preloaded SQLite VFS data. Configurable via engine config `pegboard.preload_max_sqlite_bytes` or per-actor `options.preloadMaxSqliteBytes`. Setting to 0 disables SQLite preloading. |
+| Max workflow preload size | 128 KiB | — | Maximum size of preloaded workflow data. Configurable via engine config `pegboard.preload_max_workflow_bytes` or per-actor `options.preloadMaxWorkflowBytes`. Setting to 0 disables workflow preloading. |
+| Max connections preload size | 64 KiB | — | Maximum size of preloaded connection data. Configurable via engine config `pegboard.preload_max_connections_bytes` or per-actor `options.preloadMaxConnectionsBytes`. Setting to 0 disables connections preloading. |
+
+Per-actor overrides are set in the actor config:
+
+```typescript
+import { actor, setup } from "rivetkit";
+
+const myActor = actor({
+  state: { count: 0 },
+  actions: { increment: (c) => ++c.state.count },
+  options: {
+    preloadMaxSqliteBytes: 1_048_576,  // 1 MiB
+    preloadMaxWorkflowBytes: 0,        // Disable workflow preloading
+  },
+});
+
+const app = setup({ use: { myActor } });
+export default app;
+```
+
 ### Actor Input
 
 See [Actor Input](/docs/actors/input) for details.


### PR DESCRIPTION
## Summary

- Eliminate KV round-trips during actor startup by pre-fetching required keys from FoundationDB and delivering them alongside the `CommandStartActor` protocol message (v8)
- Preloads persist data, connections, inspector token, queue metadata, workflow data, and SQLite VFS chunks in a single FDB snapshot transaction
- Adds `PreloadMap` interface with binary search for efficient subsystem consumption, `WriteCollector` for batching new-actor initialization writes, and `#expectNoKvRoundTrips` detection flag
- Configurable per-deployment limits (1 MB global, 768 KB SQLite, 128 KB workflows, 64 KB connections) with per-actor overrides via actor config options

## Implementation

### Engine (Rust)
- **US-001**: Preload config fields in `engine/packages/config/src/config/pegboard.rs`
- **US-002**: v8 runner protocol schema with `PreloadedKv` type and v7/v8 converters
- **US-003**: `batch_preload()` function in `actor_kv/preload.rs` with single FDB snapshot transaction
- **US-004**: Populate preloaded KV at send time in `InsertAndSendCommands` activity (not persisted in workflow history)
- **US-005**: Runner stores preload config from `prepopulateActorNames` metadata

### TypeScript (RivetKit)
- **US-006**: Parse preloaded KV in runner SDK from v8 protocol
- **US-007**: Per-actor preload size overrides in actor config schema
- **US-008**: `PreloadMap` with binary search (no hex string conversion)
- **US-009**: Subsystems consume `PreloadMap` before issuing KV reads
- **US-010**: SQLite VFS preload integration with partial preload support
- **US-011**: Wire preloaded data into `ActorInstance.start()`
- **US-012**: `WriteCollector` batches new-actor init writes into single `kvBatchPut`
- **US-013**: `#expectNoKvRoundTrips` flag warns on unexpected KV reads during startup
- **US-014**: Eliminate redundant persist data read in engine driver

### Bugfixes (from adversarial review)
- **US-016**: Fix `requested_prefixes`/`requested_get_keys` including skipped entries (critical: prevented silent data loss for actors exceeding preload budgets)
- **US-017**: Fix `entry_size` to include metadata in budget calculation
- **US-018**: Call `clearPreload()` on SQLite VFS store after migration (768 KB memory leak fix)
- **US-019**: Remove dead `actor_preload_configs` field from runner conn
- **US-020**: Avoid building `PreloadMap` twice from same data

### Docs
- **US-015**: Updated `limits.mdx` and `configuration.mdx` with preload limits

## Test plan

- [ ] File system driver tests pass (`pnpm test driver-file-system`)
- [ ] Engine driver tests pass (`pnpm test driver-engine`)
- [ ] `cargo build -p pegboard` succeeds
- [ ] `cargo build -p rivet-runner-protocol` succeeds
- [ ] `cargo build -p rivet-pegboard-runner` succeeds
- [ ] Verify actor startup with preloaded data (new and existing actors)
- [ ] Verify actor startup without preloaded data (v7 engine fallback)
- [ ] Verify connections/workflows exceeding budget fall back to KV reads
- [ ] Verify SQLite partial preload with KV fallback on miss