### PR TITLE
fix: re-export sandbox providers from rivetkit/sandbox barrel

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/sandbox/index.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/sandbox/index.ts
@@ -39,3 +39,10 @@ export type {
 	SessionResumeOrCreateRequest,
 	SessionSendOptions,
 } from "sandbox-agent";
+export { e2b } from "sandbox-agent/e2b";
+export { docker } from "sandbox-agent/docker";
+export { local } from "sandbox-agent/local";
+export { daytona } from "sandbox-agent/daytona";
+export { vercel } from "sandbox-agent/vercel";
+export { modal } from "sandbox-agent/modal";
+export { computesdk } from "sandbox-agent/computesdk";


### PR DESCRIPTION
## Summary
- Re-export e2b, docker, local, daytona, vercel, modal, and computesdk provider functions from the main `rivetkit/sandbox` entry point
- Consumers can now `import { e2b } from "rivetkit/sandbox"` without needing sub-path imports like `rivetkit/sandbox/e2b`

## Test plan
- [x] Build passes (`pnpm --filter rivetkit build`)
- [x] Verified all provider exports present in built `dist/tsup/sandbox/index.js`