### PR TITLE
[codex] Split vergen and vergen-gitcl emitters

### DIFF
--- a/engine/packages/util/build.rs
+++ b/engine/packages/util/build.rs
@@ -6,6 +6,9 @@ fn main() -> Result<()> {
 		.add_instructions(&vergen::BuildBuilder::all_build()?)?
 		.add_instructions(&vergen::CargoBuilder::all_cargo()?)?
 		.add_instructions(&vergen::RustcBuilder::all_rustc()?)?
+		.emit()?;
+
+	vergen_gitcl::Emitter::default()
 		.add_instructions(&vergen_gitcl::GitclBuilder::all_git()?)?
 		.emit()?;
 


### PR DESCRIPTION
## What changed
- split `vergen` and `vergen-gitcl` emission in `engine/packages/util/build.rs`
- keep the rest of the repo out of scope by isolating this on a dedicated branch

## Why
`vergen::Emitter` and `vergen_gitcl::GitclBuilder` no longer compose through the same emitter API. This broke `cargo build` for downstream consumers such as `open-artifacts` when `~/r5` was checked out without the local working-tree fix.

## Impact
Downstream Rust builds that pull `rivetkit` through `/home/nathan/r5` can compile from a committed branch instead of relying on an uncommitted local patch.

## Validation
- `cargo build` in `open-artifacts`
