### PR TITLE
fix(rivetkit): retry connection when getParams throws

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/client/lifecycle-errors.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/client/lifecycle-errors.ts
@@ -141,6 +141,18 @@ function classifyActorError(
 		);
 	}
 
+	if (error.group === "client" && error.code === "get_params_failed") {
+		return buildLifecycleBoundaryInfo(
+			"reconnect_only",
+			"actor_error",
+			error.message,
+			{
+				group: error.group,
+				code: error.code,
+			},
+		);
+	}
+
 	return undefined;
 }
 


### PR DESCRIPTION
## Stack Context

This stack collects fixes uncovered by methodically running the RivetKit driver test suite (`/driver-test-runner`) one file group at a time. Each PR addresses a single failing test with a narrow root-cause fix.

## Why?

The original `getParams` PR (#4473) promised:

> Errors from getParams are surfaced as ActorError with code `get_params_failed` and **allow the connection to retry**.

The retry classifier added later in 41c83ab25 (`fix(rivetkit): add lifecycle error retry and gateway HTTP routing`) wraps any error not recognized by `classifyActorError` in `pRetry`'s `AbortError`, halting retries. `client/get_params_failed` was never added to the classifier, silently breaking that contract.

This adds the missing classifier arm so the connection-open path retries when `getParams()` throws (e.g. a transient JWT refresh failure), restoring the documented behavior.

## Test impact

Restores the previously failing driver test:

```
tests/driver/actor-conn.test.ts > Actor Connection Tests > Connection Parameters
  > should surface getParams errors and retry connection setup
```

The test has been broken on `main` since 41c83ab25 (~2 weeks).
