### PR TITLE
test(rivetkit): restore sleep wait before post-sleep integrity check

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/tests/driver/actor-db.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/driver/actor-db.test.ts
@@ -537,6 +537,7 @@ describeDriverMatrix("Actor Db", (driverTestConfig) => {
 					);
 
 					await actor.triggerSleep();
+					await waitFor(driverTestConfig, SLEEP_WAIT_MS);
 					await expectIntegrityCheckOk(
 						driverTestConfig,
 						async () => await actor.integrityCheck(),


### PR DESCRIPTION
## Stack Context

Part of the `/driver-test-runner` fix stack. See parent PR (`driver-tests-fixes/get-params-failed-retry`, #4823) for the full stack motivation.

## Why?

The `passes integrity checks after mixed workload and sleep` driver test was broken by cae28ce9a (`test(rivetkit): stabilize actor db driver tests`), which refactored the test to use `vi.waitFor` polling but accidentally removed the explicit `waitFor(SLEEP_WAIT_MS + 100)` between `triggerSleep()` and the post-sleep `integrityCheck()`.

The actor's HTTP gateway URL is unreachable for ~150 ms after `triggerSleep()` returns while the actor enters its sleep state. With no wait, every `vi.waitFor` poll iteration during that window fails fast with `TypeError: fetch failed`, exhausting the 1.2 s timeout before the wake-on-request path becomes available.

The sibling test `persists across sleep and wake cycles` establishes the correct pattern:

```
await actor.triggerSleep();
await waitFor(driverTestConfig, SLEEP_WAIT_MS);  // let the actor enter sleep
// then poll wake-on-request
```

This PR re-applies that same pattern to the integrity test.

## Why not investigate the engine path?

Open question: should the engine-side gateway either:
- Queue requests during the sleep transition window, or
- Return a structured retryable error (e.g. `actor/sleeping`) so `retryOnLifecycleBoundary` can absorb it?

That would be a deeper engine fix and is intentionally out of scope here. The 150 ms wait restores the documented test pattern; the engine improvement can land separately if/when the team decides to adopt the no-wait pattern broadly.
