### PR TITLE
test(rivetkit): import vi for actor-queue waitFor

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/tests/driver/actor-queue.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/driver/actor-queue.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { describeDriverMatrix } from "./shared-matrix";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import type { ActorError } from "@/client/mod";
 import { MANY_QUEUE_NAMES } from "../../fixtures/driver-test-suite/queue";
 import { setupDriverTest, waitFor } from "./shared-utils";


### PR DESCRIPTION
## Stack Context

Part of the `/driver-test-runner` fix stack. See parent PR `driver-tests-fixes/get-params-failed-retry` (#4823).

## Why?

`tests/driver/actor-queue.test.ts` uses `vi.waitFor` in the test "drains many-queue child actors created from run handlers while connected" but the file's vitest import only pulls in `{ describe, expect, test }`. At runtime this throws `ReferenceError: vi is not defined` and the test fails.

Add `vi` to the import.
