### PR TITLE
fix(rivetkit-core): reject non-/request actor http paths

### DIFF
--- a/rivetkit-rust/packages/rivetkit-core/src/registry/http.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/registry/http.rs
@@ -17,7 +17,16 @@ impl RegistryDispatcher {
 
 		let original_path = request.path.clone();
 		let request = build_http_request(request).await?;
-		let route = RegistryHttpRoute::from_paths(&original_path, request.uri().path())?;
+		let route = match RegistryHttpRoute::from_paths(&original_path, request.uri().path()) {
+			Ok(route) => route,
+			Err(error) => {
+				return message_boundary_error_response(
+					request_encoding(request.headers()),
+					StatusCode::NOT_FOUND,
+					error,
+				);
+			}
+		};
 		let instance = match self.active_actor(actor_id).await {
 			Ok(instance) => instance,
 			Err(error) => {
@@ -411,7 +420,13 @@ impl RegistryHttpRoute {
 			"/metadata" => Ok(Self::Framework(FrameworkHttpRoute::Metadata)),
 			"/health" => Ok(Self::Framework(FrameworkHttpRoute::Health)),
 			"/" => Ok(Self::Framework(FrameworkHttpRoute::Root)),
-			_ => Ok(Self::UserRawRequest),
+			_ => Err(ProtocolError::InvalidHttpRequest {
+				field: "path".to_owned(),
+				reason: format!(
+					"unknown actor http path '{original_path}': user request paths must be prefixed with '/request/'"
+				),
+			}
+			.build()),
 		}
 	}
 }


### PR DESCRIPTION
## Stack Context

Part of the `/driver-test-runner` fix stack. See parent PR `driver-tests-fixes/get-params-failed-retry` (#4823).

## Why?

`RegistryHttpRoute::from_paths` in `rivetkit-core/src/registry/http.rs` fell through any unrecognized path to `UserRawRequest`, dispatching paths like `/api/hello` (without the `/request/` prefix) directly to the user's `onRequest` handler:

```rust
match normalized_path {
    "/metadata" => Ok(Self::Framework(FrameworkHttpRoute::Metadata)),
    "/health"   => Ok(Self::Framework(FrameworkHttpRoute::Health)),
    "/"         => Ok(Self::Framework(FrameworkHttpRoute::Root)),
    _ => Ok(Self::UserRawRequest),  // ← this is the bug
}
```

The leading `original_path.strip_prefix("/request")` block at the top of the function already covers the legitimate user-request prefix. Any path that reaches the bottom `match` and doesn't hit a framework arm is therefore unknown and should be rejected.

This change makes the catch-all return `ProtocolError::InvalidHttpRequest` and translates that to a 404 in `handle_fetch`.

## Test impact

Restores the gateway-routing driver test `does not route non-request HTTP paths to onRequest`, which was added in 41c83ab25 alongside the `/api/hello` → `/request/api/hello` URL migration but never passed because the engine-side fall-through was never updated to enforce the new contract.

Verified:

- `pnpm test gateway-routing.test.ts` — full suite (27 tests) green.
- `cargo test -p rivetkit-core normalize_actor_request_path` — existing path-normalization tests still pass.
