### PR TITLE
fix(rivetkit-core): defer teardown_started until drain settles

### DIFF
--- a/rivetkit-rust/packages/rivetkit-core/src/actor/sleep.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/actor/sleep.rs
@@ -458,18 +458,32 @@ impl ActorContext {
 		let counter = self.0.sleep.work.shutdown_counter.clone();
 		counter.increment();
 		let guard = CountGuard::from_incremented(counter);
+		let ctx = self.clone();
 		shutdown_tasks.spawn(
 			async move {
-				let _guard = guard;
-				fut.await;
+				{
+					let _guard = guard;
+					fut.await;
+				}
+				ctx.reset_sleep_timer();
 			}
 			.in_current_span(),
 		);
+		drop(shutdown_tasks);
+		self.reset_sleep_timer();
 		true
 	}
 
 	pub(crate) fn shutdown_task_count(&self) -> usize {
 		self.0.sleep.work.shutdown_counter.load()
+	}
+
+	pub(crate) fn mark_shutdown_deadline_reached(&self) {
+		self.0
+			.sleep
+			.work
+			.shutdown_deadline_reached
+			.store(true, Ordering::Release);
 	}
 
 	pub(crate) fn begin_core_dispatched_hook(&self) {
@@ -487,17 +501,47 @@ impl ActorContext {
 	}
 
 	pub(crate) async fn teardown_sleep_state(&self) {
-		self.0
+		let abort_remaining = self
+			.0
 			.sleep
 			.work
-			.teardown_started
-			.store(true, Ordering::Release);
-		let mut shutdown_tasks = {
-			let mut guard = self.0.sleep.work.shutdown_tasks.lock();
-			std::mem::take(&mut *guard)
-		};
-		shutdown_tasks.shutdown().await;
-		*self.0.sleep.work.shutdown_tasks.lock() = shutdown_tasks;
+			.shutdown_deadline_reached
+			.swap(false, Ordering::AcqRel);
+		if abort_remaining {
+			self.0
+				.sleep
+				.work
+				.teardown_started
+				.store(true, Ordering::Release);
+		}
+
+		loop {
+			let mut shutdown_tasks = {
+				let mut guard = self.0.sleep.work.shutdown_tasks.lock();
+				let taken = std::mem::take(&mut *guard);
+				if taken.is_empty() {
+					self.0
+						.sleep
+						.work
+						.teardown_started
+						.store(true, Ordering::Release);
+					return;
+				}
+				taken
+			};
+
+			if abort_remaining {
+				shutdown_tasks.shutdown().await;
+			} else {
+				while let Some(result) = shutdown_tasks.join_next().await {
+					if let Err(error) = result
+						&& !error.is_cancelled()
+					{
+						tracing::error!(?error, "shutdown task join failed during teardown");
+					}
+				}
+			}
+		}
 	}
 
 	pub(crate) fn sleep_state_config(&self) -> ActorConfig {

--- a/rivetkit-rust/packages/rivetkit-core/src/actor/task.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/actor/task.rs
@@ -1500,6 +1500,7 @@ impl ActorTask {
 			run_handle.abort();
 		}
 		self.ctx.cancel_shutdown_deadline();
+		self.ctx.mark_shutdown_deadline_reached();
 		self.ctx.record_shutdown_timeout(grace.reason);
 		tracing::warn!(
 			actor_id = %self.ctx.actor_id(),

--- a/rivetkit-rust/packages/rivetkit-core/src/actor/work_registry.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/actor/work_registry.rs
@@ -23,6 +23,7 @@ pub(crate) struct WorkRegistry {
 	/// outside rivetkit-core.
 	pub(crate) activity_notify: Arc<Notify>,
 	pub(crate) teardown_started: AtomicBool,
+	pub(crate) shutdown_deadline_reached: AtomicBool,
 }
 
 impl WorkRegistry {
@@ -45,6 +46,7 @@ impl WorkRegistry {
 			idle_notify,
 			activity_notify: Arc::new(Notify::new()),
 			teardown_started: AtomicBool::new(false),
+			shutdown_deadline_reached: AtomicBool::new(false),
 		}
 	}
 


### PR DESCRIPTION
## Stack Context

This stack fixes actor sleep driver-test failures around work registered during shutdown grace and a deprecated fixture sleep hold.

## Why?

`teardown_sleep_state()` set `teardown_started` before draining accepted shutdown tasks, so nested `waitUntil` work registered while the drain was active could be refused. It also relied on task-count changes without waking the actor grace loop, which could leave shutdown waiting until the grace deadline.

## What?

This PR wakes the grace loop when shutdown tasks are registered or finish, drains accepted tasks until the join set settles before setting `teardown_started`, and keeps the deadline path as aborting cleanup by marking when the grace deadline was reached.

## Validation

- `cargo test -p rivetkit-core sleep_shutdown_waits_for_keep_awake_work_then_finishes_next_tick`
- `cargo test -p rivetkit-core ctx_wait_until_during_finish_shutdown_cleanup_refused_without_leak`
- `cargo test -p rivetkit-core destroy_shutdown_concurrent_wait_until_refused`
- `cargo test -p rivetkit-core destroy_shutdown_times_out_at_deadline_and_aborts_stuck_shutdown_task`
- `cargo test -p rivetkit-core keep_awake_region_blocks_sleep_idle_until_guard_drops`
- `cargo test -p rivetkit-core nested_wait_until_during_grace_is_drained`
- `cargo test -p rivetkit-core keep_awake_in_on_sleep_blocks_finalize_until_released`
- `pnpm build:force`
- `pnpm test tests/driver/actor-sleep-db.test.ts -t "static registry.*encoding \\(bare\\).*nested waitUntil inside waitUntil"`
