### PR TITLE
fix(universaldb): enforce fdb transaction limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,12 +1861,14 @@ dependencies = [
  "rivet-pools",
  "rivet-test-deps",
  "scc",
+ "serde_json",
  "sha2",
  "tempfile",
  "tokio",
  "tracing",
  "universaldb",
  "universalpubsub",
+ "uuid",
 ]
 
 [[package]]
@@ -1880,6 +1882,7 @@ dependencies = [
  "rivet-envoy-protocol",
  "rivet-error",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -4274,6 +4277,7 @@ dependencies = [
  "universaldb",
  "universalpubsub",
  "url",
+ "uuid",
  "vbare",
 ]
 

--- a/docs-internal/engine/depot.md
+++ b/docs-internal/engine/depot.md
@@ -46,9 +46,9 @@ SQLite commits call Depot through the conveyer path:
 
 ```text
 1. Resolve DBPTR and read the current branch head in the UDB transaction.
-2. Encode dirty pages into LTX DELTA chunks.
-3. Write COMMITS, VTX, DELTA, and PIDX rows.
-4. Update META/head and quota counters.
+2. Use the fast path for commits whose encoded LTX bytes and metadata fit in one UDB transaction.
+3. For large commits, write immutable LTX bytes under DELTA_OBJ chunks before the publish transaction.
+4. Publish COMMITS, VTX, PIDX, quota, META/head, and either DELTA chunks or DELTA_MANIFEST plus DELTA_PAGEIDX rows.
 5. After commit, update SQLITE_CMP_DIRTY and send a throttled DeltasAvailable wake when lag crosses thresholds.
 ```
 

--- a/docs-internal/engine/sqlite-vfs.md
+++ b/docs-internal/engine/sqlite-vfs.md
@@ -13,7 +13,7 @@ Rules for the SQLite VFS implementation.
 
 - SQLite VFS aux-file create/open paths mutate `BTreeMap` state under one write lock with `entry(...).or_insert_with(...)`. Avoid read-then-write upgrade patterns.
 - SQLite VFS v2 storage keys use literal ASCII path segments under the `0x02` subspace prefix with big-endian numeric suffixes so `scan_prefix` and `BTreeMap` ordering stay numerically correct.
-- SQLite v2 slow-path staging writes encoded LTX bytes directly under DELTA chunk keys. Do not expect `/STAGE` keys or a fixed one-chunk-per-page mapping in tests or recovery code.
+- SQLite v2 large commits keep legacy DELTA keys for small commits, but publish large commits through `DELTA_OBJ`, `DELTA_MANIFEST`, and `DELTA_PAGEIDX`. Tests and recovery code must treat both encodings as committed delta artifacts.
 
 ## Read-mode/write-mode connection manager
 

--- a/docs-internal/engine/sqlite/storage-structure.md
+++ b/docs-internal/engine/sqlite/storage-structure.md
@@ -98,13 +98,31 @@ BR/{database_id_be:16}/PIDX/{pgno_be:4}
   -> u64 BE owner_txid
 BR/{database_id_be:16}/DELTA/{txid_be:8}/{chunk_be:4}
   -> LTX chunk blob
+BR/{database_id_be:16}/STAGE/commit/{stage_id:16}/meta
+  -> CommitStageMeta (vbare-versioned)
+BR/{database_id_be:16}/STAGE/commit/{stage_id:16}/pages/{batch_be:4}
+  -> DirtyPageBatch (vbare-versioned)
+BR/{database_id_be:16}/STAGE/commit/{stage_id:16}/complete
+  -> CommitStageComplete (vbare-versioned)
+BR/{database_id_be:16}/STAGE/commit/{stage_id:16}/finalized
+  -> CommitStageFinalized (vbare-versioned)
+BR/{database_id_be:16}/DELTA_OBJ/{object_id:16}/chunk/{chunk_be:4}
+  -> Large LTX object chunk blob
+BR/{database_id_be:16}/DELTA_OBJ/{object_id:16}/meta
+  -> DeltaObjectMeta (vbare-versioned)
+BR/{database_id_be:16}/DELTA_OBJ_REF/{object_id:16}
+  -> u64 BE committed_txid
+BR/{database_id_be:16}/DELTA_MANIFEST/{txid_be:8}
+  -> DeltaManifest (vbare-versioned)
+BR/{database_id_be:16}/DELTA_PAGEIDX/{txid_be:8}/{pgno_be:4}
+  -> DeltaPageIndexEntry (vbare-versioned)
 BR/{database_id_be:16}/SHARD/{shard_id_be:4}/{as_of_txid_be:8}
   -> LTX shard blob
 BR/{database_id_be:16}/PITR_INTERVAL/{bucket_start_ms_be:8}
   -> PitrIntervalCoverage (vbare-versioned)
 ```
 
-`COMMITS` stores commit metadata, including wall-clock time, captured versionstamp, size in pages, and post-apply checksum. `VTX` maps a versionstamp back to txid for restore point resolution and GC. `PIDX` maps a page number to the DELTA txid that currently owns it.
+`COMMITS` stores commit metadata, including wall-clock time, captured versionstamp, size in pages, and post-apply checksum. `VTX` maps a versionstamp back to txid for restore point resolution and GC. `PIDX` maps a page number to the delta txid that currently owns it. Small commits store that delta as legacy `DELTA/{txid}/{chunk}` rows. Large commits store immutable bytes in `DELTA_OBJ`, publish `DELTA_MANIFEST`, and use `DELTA_PAGEIDX` so sparse reads can fetch only the chunks covering one page frame.
 
 `SHARD` is versioned by `as_of_txid`. Reads choose the largest `as_of_txid <= read_txid`. Hot compaction writes new SHARD versions and does not overwrite older ones. When cold storage is enabled, the same FDB SHARD rows are also the shard cache for manager-published `CMP/cold_shard` refs; read-through fill can repopulate an evicted row without advancing manifest watermarks.
 

--- a/engine/artifacts/errors/depot.sqlite_commit_page_limit_exceeded.json
+++ b/engine/artifacts/errors/depot.sqlite_commit_page_limit_exceeded.json
@@ -1,0 +1,5 @@
+{
+  "code": "sqlite_commit_page_limit_exceeded",
+  "group": "depot",
+  "message": "SQLite transaction touched too many pages."
+}

--- a/engine/artifacts/errors/depot.sqlite_commit_stage_invalid.json
+++ b/engine/artifacts/errors/depot.sqlite_commit_stage_invalid.json
@@ -1,0 +1,5 @@
+{
+  "code": "sqlite_commit_stage_invalid",
+  "group": "depot",
+  "message": "SQLite commit stage is invalid."
+}

--- a/engine/artifacts/errors/depot.sqlite_commit_stage_not_found.json
+++ b/engine/artifacts/errors/depot.sqlite_commit_stage_not_found.json
@@ -1,0 +1,5 @@
+{
+  "code": "sqlite_commit_stage_not_found",
+  "group": "depot",
+  "message": "SQLite commit stage was not found."
+}

--- a/engine/packages/depot-client-embedded/Cargo.toml
+++ b/engine/packages/depot-client-embedded/Cargo.toml
@@ -18,3 +18,4 @@ depot-client.workspace = true
 rivet-envoy-protocol.workspace = true
 rivet-error.workspace = true
 tokio.workspace = true
+uuid.workspace = true

--- a/engine/packages/depot-client-embedded/src/lib.rs
+++ b/engine/packages/depot-client-embedded/src/lib.rs
@@ -15,6 +15,7 @@ use depot_client::{
 };
 use rivet_envoy_protocol as protocol;
 use tokio::runtime::Handle;
+use uuid::Uuid;
 
 pub struct EmbeddedDepotSqliteTransport {
 	db: Arc<depot::conveyer::Db>,
@@ -111,6 +112,125 @@ impl SqliteTransport for EmbeddedDepotSqliteTransport {
 			)),
 		}
 	}
+
+	async fn commit_stage_begin(
+		&self,
+		request: protocol::SqliteCommitStageBeginRequest,
+	) -> Result<protocol::SqliteCommitStageBeginResponse> {
+		match self
+			.db
+			.commit_stage_begin(
+				request.dirty_pgnos,
+				request.db_size_pages,
+				request.now_ms,
+				depot::types::CommitOptions {
+					expected_head_txid: request.expected_head_txid,
+				},
+			)
+			.await
+		{
+			Ok(result) => Ok(
+				protocol::SqliteCommitStageBeginResponse::SqliteCommitStageBeginOk(
+					protocol::SqliteCommitStageBeginOk {
+						stage_id: *result.stage_id.as_bytes(),
+						max_pages_per_batch: result.max_pages_per_batch,
+						max_batch_bytes: result.max_batch_bytes,
+						observed_head_txid: result.observed_head_txid,
+						staged_txid: result.staged_txid,
+					},
+				),
+			),
+			Err(err) => Ok(protocol::SqliteCommitStageBeginResponse::SqliteErrorResponse(
+				sqlite_error_response(&err),
+			)),
+		}
+	}
+
+	async fn commit_stage_pages(
+		&self,
+		request: protocol::SqliteCommitStagePagesRequest,
+	) -> Result<protocol::SqliteCommitStagePagesResponse> {
+		match self
+			.db
+			.commit_stage_pages(
+				stage_id_from_protocol(&request.stage_id)?,
+				request.batch_idx,
+				request
+					.dirty_pages
+					.into_iter()
+					.map(|page| depot::types::DirtyPage {
+						pgno: page.pgno,
+						bytes: page.bytes,
+					})
+					.collect(),
+			)
+			.await
+		{
+			Ok(()) => Ok(protocol::SqliteCommitStagePagesResponse::SqliteCommitStagePagesOk),
+			Err(err) => Ok(protocol::SqliteCommitStagePagesResponse::SqliteErrorResponse(
+				sqlite_error_response(&err),
+			)),
+		}
+	}
+
+	async fn commit_stage_complete(
+		&self,
+		request: protocol::SqliteCommitStageCompleteRequest,
+	) -> Result<protocol::SqliteCommitStageCompleteResponse> {
+		match self
+			.db
+			.commit_stage_complete(
+				stage_id_from_protocol(&request.stage_id)?,
+				request.page_batch_count,
+			)
+			.await
+		{
+			Ok(()) => Ok(
+				protocol::SqliteCommitStageCompleteResponse::SqliteCommitStageCompleteOk,
+			),
+			Err(err) => Ok(
+				protocol::SqliteCommitStageCompleteResponse::SqliteErrorResponse(
+					sqlite_error_response(&err),
+				),
+			),
+		}
+	}
+
+	async fn commit_stage_finalize(
+		&self,
+		request: protocol::SqliteCommitStageFinalizeRequest,
+	) -> Result<protocol::SqliteCommitResponse> {
+		match self
+			.db
+			.commit_stage_finalize(stage_id_from_protocol(&request.stage_id)?)
+			.await
+		{
+			Ok(result) => Ok(protocol::SqliteCommitResponse::SqliteCommitOk(
+				protocol::SqliteCommitOk {
+					head_txid: Some(result.head_txid),
+				},
+			)),
+			Err(err) => Ok(protocol::SqliteCommitResponse::SqliteErrorResponse(
+				sqlite_error_response(&err),
+			)),
+		}
+	}
+
+	async fn commit_stage_abort(
+		&self,
+		request: protocol::SqliteCommitStageAbortRequest,
+	) -> Result<protocol::SqliteCommitStageAbortResponse> {
+		match self
+			.db
+			.commit_stage_abort(stage_id_from_protocol(&request.stage_id)?)
+			.await
+		{
+			Ok(()) => Ok(protocol::SqliteCommitStageAbortResponse::SqliteCommitStageAbortOk),
+			Err(err) => Ok(protocol::SqliteCommitStageAbortResponse::SqliteErrorResponse(
+				sqlite_error_response(&err),
+			)),
+		}
+	}
 }
 
 fn sqlite_error_reason(err: &anyhow::Error) -> String {
@@ -128,7 +248,12 @@ fn sqlite_error_response(err: &anyhow::Error) -> protocol::SqliteErrorResponse {
 		group: structured.group().to_string(),
 		code: structured.code().to_string(),
 		message: sqlite_error_reason(err),
+		metadata: structured.metadata().map(|metadata| metadata.to_string()),
 	}
+}
+
+fn stage_id_from_protocol(stage_id: &protocol::SqliteStageId) -> Result<Uuid> {
+	Uuid::from_slice(stage_id).map_err(Into::into)
 }
 
 fn depot_error(err: &anyhow::Error) -> Option<&SqliteStorageError> {

--- a/engine/packages/depot-client/Cargo.toml
+++ b/engine/packages/depot-client/Cargo.toml
@@ -20,6 +20,7 @@ tracing.workspace = true
 getrandom = "0.2"
 rivet-envoy-protocol.workspace = true
 depot-client-types.workspace = true
+serde_json.workspace = true
 moka = { version = "0.12", default-features = false, features = ["sync"] }
 parking_lot.workspace = true
 scc.workspace = true
@@ -36,3 +37,4 @@ sha2.workspace = true
 tempfile.workspace = true
 universaldb.workspace = true
 universalpubsub.workspace = true
+uuid.workspace = true

--- a/engine/packages/depot-client/src/vfs.rs
+++ b/engine/packages/depot-client/src/vfs.rs
@@ -30,10 +30,12 @@ const DEFAULT_MAX_PREFETCH_BYTES: usize = 256 * 1024;
 const DEFAULT_ADAPTIVE_PREFETCH_DEPTH: usize = 256;
 const DEFAULT_ADAPTIVE_MAX_PREFETCH_BYTES: usize = 1024 * 1024;
 const DEFAULT_MAX_PAGES_PER_STAGE: usize = 4_000;
+const SLOW_COMMIT_DIRTY_BYTES_THRESHOLD: usize = 8 * 1024 * 1024;
 const DEFAULT_RECENT_HINT_PAGE_BUDGET: usize = 128;
 const DEFAULT_RECENT_HINT_RANGE_BUDGET: usize = 16;
 const DEFAULT_PAGE_SIZE: usize = 4096;
 const NATIVE_DATABASE_DROP_FLUSH_TIMEOUT: Duration = Duration::from_millis(250);
+const BRIDGE_RIVET_ERROR_PREFIX: &str = "__RIVET_ERROR_JSON__:";
 const MIN_RECENT_SCAN_RANGE_PAGES: u32 = 8;
 const FORWARD_SCAN_SCORE_THRESHOLD: i32 = 6;
 const FORWARD_SCAN_SCORE_MAX: i32 = 12;
@@ -117,6 +119,41 @@ pub trait SqliteTransport: Send + Sync {
 		&self,
 		request: protocol::SqliteCommitRequest,
 	) -> Result<protocol::SqliteCommitResponse>;
+
+	async fn commit_stage_begin(
+		&self,
+		_request: protocol::SqliteCommitStageBeginRequest,
+	) -> Result<protocol::SqliteCommitStageBeginResponse> {
+		anyhow::bail!("sqlite commit staging unsupported by transport")
+	}
+
+	async fn commit_stage_pages(
+		&self,
+		_request: protocol::SqliteCommitStagePagesRequest,
+	) -> Result<protocol::SqliteCommitStagePagesResponse> {
+		anyhow::bail!("sqlite commit staging unsupported by transport")
+	}
+
+	async fn commit_stage_complete(
+		&self,
+		_request: protocol::SqliteCommitStageCompleteRequest,
+	) -> Result<protocol::SqliteCommitStageCompleteResponse> {
+		anyhow::bail!("sqlite commit staging unsupported by transport")
+	}
+
+	async fn commit_stage_finalize(
+		&self,
+		_request: protocol::SqliteCommitStageFinalizeRequest,
+	) -> Result<protocol::SqliteCommitResponse> {
+		anyhow::bail!("sqlite commit staging unsupported by transport")
+	}
+
+	async fn commit_stage_abort(
+		&self,
+		_request: protocol::SqliteCommitStageAbortRequest,
+	) -> Result<protocol::SqliteCommitStageAbortResponse> {
+		anyhow::bail!("sqlite commit staging unsupported by transport")
+	}
 }
 
 pub type SqliteTransportHandle = Arc<dyn SqliteTransport>;
@@ -1455,9 +1492,9 @@ impl VfsContext {
 					return Ok(resolved);
 				}
 				if is_head_fence_mismatch_response(&error) {
-					return Err(GetPagesError::Fatal(error.message));
+					return Err(GetPagesError::Fatal(sqlite_response_message(&error)));
 				}
-				Err(GetPagesError::Other(error.message))
+				Err(GetPagesError::Other(sqlite_response_message(&error)))
 			}
 		}
 	}
@@ -1834,7 +1871,7 @@ async fn fetch_initial_pages(
 			if !is_initial_main_page_missing(&error.message) {
 				return Err(format!(
 					"sqlite initial page fetch failed: {}",
-					error.message
+					sqlite_response_message(&error)
 				));
 			}
 			tracing::debug!(
@@ -1872,6 +1909,19 @@ async fn commit_buffered_pages(
 	request: BufferedCommitRequest,
 ) -> std::result::Result<(BufferedCommitOutcome, CommitTransportMetrics), CommitBufferError> {
 	let mut metrics = CommitTransportMetrics::default();
+	let dirty_bytes = request
+		.dirty_pages
+		.iter()
+		.map(|page| page.bytes.len())
+		.sum::<usize>();
+	let path = if dirty_bytes > SLOW_COMMIT_DIRTY_BYTES_THRESHOLD {
+		CommitPath::Slow
+	} else {
+		CommitPath::Fast
+	};
+	if matches!(path, CommitPath::Slow) {
+		return commit_buffered_pages_staged(transport, request).await;
+	}
 	let serialize_start = Instant::now();
 	let commit_request = protocol::SqliteCommitRequest {
 		actor_id: request.actor_id.clone(),
@@ -1892,7 +1942,7 @@ async fn commit_buffered_pages(
 			metrics.transport_ns += transport_start.elapsed().as_nanos() as u64;
 			Ok((
 				BufferedCommitOutcome {
-					path: CommitPath::Fast,
+					path,
 					db_size_pages: request.new_db_size_pages,
 					head_txid: ok.head_txid,
 				},
@@ -1900,13 +1950,172 @@ async fn commit_buffered_pages(
 			))
 		}
 		protocol::SqliteCommitResponse::SqliteErrorResponse(error) => {
+			let message = sqlite_response_message(&error);
 			if is_head_fence_mismatch_response(&error) {
-				Err(CommitBufferError::FenceMismatch(error.message))
+				Err(CommitBufferError::FenceMismatch(message))
 			} else {
-				Err(CommitBufferError::Other(error.message))
+				Err(CommitBufferError::Other(message))
 			}
 		}
 	}
+}
+
+async fn commit_buffered_pages_staged(
+	transport: &dyn SqliteTransport,
+	request: BufferedCommitRequest,
+) -> std::result::Result<(BufferedCommitOutcome, CommitTransportMetrics), CommitBufferError> {
+	let mut metrics = CommitTransportMetrics::default();
+	let serialize_start = Instant::now();
+	let now_ms = sqlite_now_ms().map_err(|err| CommitBufferError::Other(err.to_string()))?;
+	let mut dirty_pages = request.dirty_pages.clone();
+	dirty_pages.sort_by_key(|page| page.pgno);
+	let dirty_pgnos = dirty_pages.iter().map(|page| page.pgno).collect::<Vec<_>>();
+	let begin_request = protocol::SqliteCommitStageBeginRequest {
+		actor_id: request.actor_id.clone(),
+		db_size_pages: request.new_db_size_pages,
+		now_ms,
+		expected_generation: None,
+		expected_head_txid: request.expected_head_txid,
+		dirty_pgnos,
+	};
+	metrics.serialize_ns += serialize_start.elapsed().as_nanos() as u64;
+
+	let transport_start = Instant::now();
+	let begin = match transport
+		.commit_stage_begin(begin_request)
+		.await
+		.map_err(|err| CommitBufferError::Other(err.to_string()))?
+	{
+		protocol::SqliteCommitStageBeginResponse::SqliteCommitStageBeginOk(ok) => ok,
+		protocol::SqliteCommitStageBeginResponse::SqliteErrorResponse(error) => {
+			return Err(sqlite_response_to_commit_error(error));
+		}
+	};
+	metrics.transport_ns += transport_start.elapsed().as_nanos() as u64;
+
+	let max_pages = usize::try_from(begin.max_pages_per_batch)
+		.ok()
+		.filter(|value| *value > 0)
+		.unwrap_or(1);
+	let mut page_batch_count = 0u32;
+	for (batch_idx, batch) in dirty_pages.chunks(max_pages).enumerate() {
+		let batch_idx = u32::try_from(batch_idx)
+			.map_err(|err| CommitBufferError::Other(err.to_string()))?;
+		page_batch_count = batch_idx.saturating_add(1);
+		let batch_request = protocol::SqliteCommitStagePagesRequest {
+			actor_id: request.actor_id.clone(),
+			stage_id: begin.stage_id.clone(),
+			batch_idx,
+			dirty_pages: batch.to_vec(),
+			expected_generation: None,
+		};
+		let batch_start = Instant::now();
+		match transport
+			.commit_stage_pages(batch_request)
+			.await
+			.map_err(|err| CommitBufferError::Other(err.to_string()))?
+		{
+			protocol::SqliteCommitStagePagesResponse::SqliteCommitStagePagesOk => {
+				metrics.transport_ns += batch_start.elapsed().as_nanos() as u64;
+			}
+			protocol::SqliteCommitStagePagesResponse::SqliteErrorResponse(error) => {
+				abort_commit_stage_best_effort(transport, &request.actor_id, begin.stage_id.clone()).await;
+				return Err(sqlite_response_to_commit_error(error));
+			}
+		}
+	}
+
+	let complete_start = Instant::now();
+	match transport
+		.commit_stage_complete(protocol::SqliteCommitStageCompleteRequest {
+			actor_id: request.actor_id.clone(),
+			stage_id: begin.stage_id.clone(),
+			page_batch_count,
+			expected_generation: None,
+		})
+		.await
+		.map_err(|err| CommitBufferError::Other(err.to_string()))?
+	{
+		protocol::SqliteCommitStageCompleteResponse::SqliteCommitStageCompleteOk => {
+			metrics.transport_ns += complete_start.elapsed().as_nanos() as u64;
+		}
+		protocol::SqliteCommitStageCompleteResponse::SqliteErrorResponse(error) => {
+			abort_commit_stage_best_effort(transport, &request.actor_id, begin.stage_id.clone()).await;
+			return Err(sqlite_response_to_commit_error(error));
+		}
+	}
+
+	let finalize_start = Instant::now();
+	match transport
+		.commit_stage_finalize(protocol::SqliteCommitStageFinalizeRequest {
+			actor_id: request.actor_id.clone(),
+			stage_id: begin.stage_id.clone(),
+			expected_generation: None,
+		})
+		.await
+		.map_err(|err| CommitBufferError::Other(err.to_string()))?
+	{
+		protocol::SqliteCommitResponse::SqliteCommitOk(ok) => {
+			metrics.transport_ns += finalize_start.elapsed().as_nanos() as u64;
+			Ok((
+				BufferedCommitOutcome {
+					path: CommitPath::Slow,
+					db_size_pages: request.new_db_size_pages,
+					head_txid: ok.head_txid,
+				},
+				metrics,
+			))
+		}
+		protocol::SqliteCommitResponse::SqliteErrorResponse(error) => {
+			Err(sqlite_response_to_commit_error(error))
+		}
+	}
+}
+
+async fn abort_commit_stage_best_effort(
+	transport: &dyn SqliteTransport,
+	actor_id: &str,
+	stage_id: protocol::SqliteStageId,
+) {
+	if let Err(err) = transport
+		.commit_stage_abort(protocol::SqliteCommitStageAbortRequest {
+			actor_id: actor_id.to_string(),
+			stage_id,
+			expected_generation: None,
+		})
+		.await
+	{
+		tracing::warn!(?err, "failed to abort sqlite commit stage after staged commit error");
+	}
+}
+
+fn sqlite_response_to_commit_error(error: protocol::SqliteErrorResponse) -> CommitBufferError {
+	let message = sqlite_response_message(&error);
+	if is_head_fence_mismatch_response(&error) {
+		CommitBufferError::FenceMismatch(message)
+	} else {
+		CommitBufferError::Other(message)
+	}
+}
+
+fn sqlite_response_message(error: &protocol::SqliteErrorResponse) -> String {
+	if error.group.is_empty() || error.code.is_empty() {
+		return error.message.clone();
+	}
+	let metadata = error
+		.metadata
+		.as_deref()
+		.and_then(|metadata| serde_json::from_str::<serde_json::Value>(metadata).ok());
+	format!(
+		"{BRIDGE_RIVET_ERROR_PREFIX}{}",
+		serde_json::json!({
+			"group": error.group,
+			"code": error.code,
+			"message": error.message,
+			"metadata": metadata,
+			"public": true,
+		})
+	)
 }
 
 fn is_head_fence_mismatch_response(error: &protocol::SqliteErrorResponse) -> bool {

--- a/engine/packages/depot-client/tests/inline/vfs.rs
+++ b/engine/packages/depot-client/tests/inline/vfs.rs
@@ -132,6 +132,7 @@ impl SqliteTransport for MissingDbTransport {
 				group: "depot".to_string(),
 				code: "database_not_found".to_string(),
 				message: "sqlite database was not found in this bucket branch".to_string(),
+				metadata: None,
 			},
 		))
 	}
@@ -141,6 +142,50 @@ impl SqliteTransport for MissingDbTransport {
 		_request: protocol::SqliteCommitRequest,
 	) -> anyhow::Result<protocol::SqliteCommitResponse> {
 		anyhow::bail!("missing-db transport test does not commit")
+	}
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RecordedGetPagesFailure {
+	pgnos: Vec<u32>,
+	expected_generation: Option<u64>,
+	expected_head_txid: Option<u64>,
+	message: String,
+}
+
+#[derive(Default)]
+struct RecordingMissingDbTransport {
+	failures: SyncMutex<Vec<RecordedGetPagesFailure>>,
+}
+
+#[async_trait]
+impl SqliteTransport for RecordingMissingDbTransport {
+	async fn get_pages(
+		&self,
+		request: protocol::SqliteGetPagesRequest,
+	) -> anyhow::Result<protocol::SqliteGetPagesResponse> {
+		let message = "sqlite database was not found in this bucket branch".to_string();
+		self.failures.lock().push(RecordedGetPagesFailure {
+			pgnos: request.pgnos.clone(),
+			expected_generation: request.expected_generation,
+			expected_head_txid: request.expected_head_txid,
+			message: message.clone(),
+		});
+		Ok(protocol::SqliteGetPagesResponse::SqliteErrorResponse(
+			protocol::SqliteErrorResponse {
+				group: "depot".to_string(),
+				code: "database_not_found".to_string(),
+				message,
+				metadata: None,
+			},
+		))
+	}
+
+	async fn commit(
+		&self,
+		_request: protocol::SqliteCommitRequest,
+	) -> anyhow::Result<protocol::SqliteCommitResponse> {
+		anyhow::bail!("recording missing-db transport test does not commit")
 	}
 }
 
@@ -172,6 +217,80 @@ fn startup_initial_pages_do_not_require_preload_hints_on_open() {
 		.collect::<Vec<_>>();
 	assert_eq!(*transport.requested_pgnos.lock(), vec![1, 2, 3, 4]);
 	assert_eq!(loaded_pgnos, vec![1, 2, 3, 4]);
+}
+
+#[test]
+fn missing_db_engine_log_for_initial_page_is_empty_database_bootstrap() {
+	let runtime = direct_runtime();
+	let transport = Arc::new(RecordingMissingDbTransport::default());
+	let config = VfsConfig {
+		startup_preload_first_pages: false,
+		..VfsConfig::default()
+	};
+
+	let pages = runtime
+		.block_on(fetch_initial_pages_for_registration(
+			transport.clone(),
+			"missing-db-bootstrap-actor",
+			&config,
+		))
+		.expect("missing initial database should bootstrap an empty sqlite file");
+
+	assert_eq!(pages.head_txid, Some(0));
+	assert!(pages.pages.is_empty());
+	assert_eq!(
+		*transport.failures.lock(),
+		vec![RecordedGetPagesFailure {
+			pgnos: vec![1],
+			expected_generation: None,
+			expected_head_txid: None,
+			message: "sqlite database was not found in this bucket branch".to_string(),
+		}]
+	);
+}
+
+#[test]
+fn missing_db_for_non_initial_page_is_not_empty_database_bootstrap() {
+	let runtime = direct_runtime();
+	let config = VfsConfig::default();
+	let transport = Arc::new(RecordingMissingDbTransport::default());
+	let ctx = VfsContext::new(
+		next_test_name("missing-db-non-initial-page"),
+		runtime.handle().clone(),
+		transport.clone(),
+		config,
+		unsafe { std::mem::zeroed() },
+		Vec::new(),
+		None,
+	)
+	.expect("vfs context should build");
+
+	let err = ctx
+		.resolve_pages(&[11], true)
+		.expect_err("missing non-initial page should remain a VFS error");
+
+	match err {
+		GetPagesError::Other(message) => {
+			assert!(
+				message.contains("sqlite database was not found in this bucket branch"),
+				"unexpected missing db error: {message}",
+			);
+			assert!(
+				message.contains("\"code\":\"database_not_found\""),
+				"missing db error should preserve the structured depot code: {message}",
+			);
+		}
+		GetPagesError::Fatal(message) => panic!("unexpected fatal get_pages error: {message}"),
+	}
+	assert_eq!(
+		*transport.failures.lock(),
+		vec![RecordedGetPagesFailure {
+			pgnos: vec![11],
+			expected_generation: None,
+			expected_head_txid: None,
+			message: "sqlite database was not found in this bucket branch".to_string(),
+		}]
+	);
 }
 
 #[test]
@@ -421,11 +540,49 @@ impl SqliteTransport for CommitTooLargeTransport {
 						dirty_pages * 4096,
 						(self.min_dirty_pages - 1) * 4096
 					),
+					metadata: None,
 				},
 			));
 		}
 
 		self.inner.commit(request).await
+	}
+}
+
+struct NoHeadDepotTransport {
+	inner: Arc<DirectDepotTransport>,
+}
+
+impl NoHeadDepotTransport {
+	fn new(storage: Arc<DirectStorage>) -> Self {
+		Self {
+			inner: Arc::new(DirectDepotTransport::new(storage)),
+		}
+	}
+}
+
+#[async_trait]
+impl SqliteTransport for NoHeadDepotTransport {
+	async fn get_pages(
+		&self,
+		request: protocol::SqliteGetPagesRequest,
+	) -> anyhow::Result<protocol::SqliteGetPagesResponse> {
+		let mut response = self.inner.get_pages(request).await?;
+		if let protocol::SqliteGetPagesResponse::SqliteGetPagesOk(ok) = &mut response {
+			ok.head_txid = None;
+		}
+		Ok(response)
+	}
+
+	async fn commit(
+		&self,
+		request: protocol::SqliteCommitRequest,
+	) -> anyhow::Result<protocol::SqliteCommitResponse> {
+		let mut response = self.inner.commit(request).await?;
+		if let protocol::SqliteCommitResponse::SqliteCommitOk(ok) = &mut response {
+			ok.head_txid = None;
+		}
+		Ok(response)
 	}
 }
 
@@ -837,6 +994,211 @@ fn worker_records_basic_metrics() {
 	assert_eq!(metrics.command_errors.load(Ordering::Acquire), 0);
 }
 
+#[test]
+#[ignore = "repro for missing actor-generation fencing on native VFS requests"]
+fn repro_native_vfs_requests_do_not_include_actor_generation() {
+	let runtime = direct_runtime();
+	let harness = DirectEngineHarness::new();
+	let engine = runtime.block_on(harness.open_engine());
+	let transport = Arc::new(DirectDepotTransport::new(engine));
+	let hooks = transport.direct_hooks();
+
+	let db = runtime
+		.block_on(crate::database::open_database_from_transport(
+			transport,
+			harness.actor_id.clone(),
+			42,
+			runtime.handle().clone(),
+			None,
+		))
+		.expect("sqlite database should open");
+
+	runtime.block_on(async {
+		db.exec("CREATE TABLE generation_probe(id INTEGER PRIMARY KEY);".to_owned())
+			.await
+			.expect("create table should commit");
+		db.close().await.expect("worker should close");
+	});
+
+	assert!(
+		hooks
+			.get_pages_requests()
+			.iter()
+			.all(|request| request.expected_generation.is_none()),
+		"native VFS get_pages requests should currently omit expected_generation"
+	);
+	assert!(
+		hooks
+			.commit_requests()
+			.iter()
+			.all(|request| request.expected_generation.is_none()),
+		"native VFS commit requests should currently omit expected_generation"
+	);
+}
+
+#[test]
+#[ignore = "repro for stale actor generation winning the Depot head fence race"]
+fn repro_stale_actor_generation_can_commit_before_replacement() {
+	let runtime = direct_runtime();
+	let harness = DirectEngineHarness::new();
+	let engine = runtime.block_on(harness.open_engine());
+
+	let stale = runtime
+		.block_on(crate::database::open_database_from_transport(
+			Arc::new(DirectDepotTransport::new(engine.clone())),
+			harness.actor_id.clone(),
+			1,
+			runtime.handle().clone(),
+			None,
+		))
+		.expect("stale generation database should open");
+
+	runtime.block_on(async {
+		stale
+			.exec(
+				"CREATE TABLE generation_rows(id INTEGER PRIMARY KEY, label TEXT NOT NULL);"
+					.to_owned(),
+			)
+			.await
+			.expect("stale generation should create schema");
+	});
+
+	runtime.block_on(async {
+		stale
+			.execute(
+				"INSERT INTO generation_rows(id, label) VALUES (1, 'stale-writer');".to_owned(),
+				None,
+			)
+			.await
+			.expect("stale generation commit is incorrectly accepted before replacement writes");
+
+		stale.close().await.expect("stale worker should close");
+	});
+
+	let reopened = runtime
+		.block_on(crate::database::open_database_from_transport(
+			Arc::new(DirectDepotTransport::new(engine)),
+			harness.actor_id.clone(),
+			3,
+			runtime.handle().clone(),
+			None,
+		))
+		.expect("database should reopen");
+
+	runtime.block_on(async {
+		let rows = reopened
+			.query(
+				"SELECT id, label FROM generation_rows ORDER BY id;".to_owned(),
+				None,
+			)
+			.await
+			.expect("reopened database should query");
+		assert_eq!(
+			rows.rows,
+			vec![vec![
+				ColumnValue::Integer(1),
+				ColumnValue::Text("stale-writer".to_owned()),
+			]],
+			"durable state should show the stale actor generation won"
+		);
+		reopened.close().await.expect("reopened worker should close");
+	});
+}
+
+#[test]
+#[ignore = "repro for old no-head SQLite protocol responses disabling Depot head fencing"]
+fn repro_no_head_txid_responses_allow_lost_update_between_writers() {
+	let runtime = direct_runtime();
+	let harness = DirectEngineHarness::new();
+	let engine = runtime.block_on(harness.open_engine());
+
+	let seed = runtime
+		.block_on(crate::database::open_database_from_transport(
+			Arc::new(DirectDepotTransport::new(engine.clone())),
+			harness.actor_id.clone(),
+			0,
+			runtime.handle().clone(),
+			None,
+		))
+		.expect("seed database should open");
+	runtime.block_on(async {
+		seed.exec(
+			"CREATE TABLE no_head_rows(id INTEGER PRIMARY KEY, label TEXT NOT NULL);".to_owned(),
+		)
+		.await
+		.expect("schema should commit");
+		seed.execute(
+			"INSERT INTO no_head_rows(id, label) VALUES (1, 'seed');".to_owned(),
+			None,
+		)
+		.await
+		.expect("seed row should commit");
+		seed.close().await.expect("seed worker should close");
+	});
+
+	let first = runtime
+		.block_on(crate::database::open_database_from_transport(
+			Arc::new(NoHeadDepotTransport::new(engine.clone())),
+			harness.actor_id.clone(),
+			1,
+			runtime.handle().clone(),
+			None,
+		))
+		.expect("first no-head database should open");
+	let second = runtime
+		.block_on(crate::database::open_database_from_transport(
+			Arc::new(NoHeadDepotTransport::new(engine.clone())),
+			harness.actor_id.clone(),
+			2,
+			runtime.handle().clone(),
+			None,
+		))
+		.expect("second no-head database should open");
+
+	runtime.block_on(async {
+		first
+			.execute(
+				"UPDATE no_head_rows SET label = 'first' WHERE id = 1;".to_owned(),
+				None,
+			)
+			.await
+			.expect("first no-head writer should commit");
+		second
+			.execute(
+				"UPDATE no_head_rows SET label = 'second' WHERE id = 1;".to_owned(),
+				None,
+			)
+			.await
+			.expect("second no-head writer should also commit without a head fence");
+
+		first.close().await.expect("first worker should close");
+		second.close().await.expect("second worker should close");
+	});
+
+	let reopened = runtime
+		.block_on(crate::database::open_database_from_transport(
+			Arc::new(DirectDepotTransport::new(engine)),
+			harness.actor_id.clone(),
+			3,
+			runtime.handle().clone(),
+			None,
+		))
+		.expect("database should reopen");
+
+	runtime.block_on(async {
+		let rows = reopened
+			.query("SELECT label FROM no_head_rows WHERE id = 1;".to_owned(), None)
+			.await
+			.expect("rows should query after reload");
+		assert_eq!(
+			rows.rows,
+			vec![vec![ColumnValue::Text("second".to_owned())]],
+			"both no-head writers reported success, but the later stale snapshot overwrote the earlier write"
+		);
+		reopened.close().await.expect("reopened worker should close");
+	});
+}
+
 fn sqlite_query_i64(db: *mut sqlite3, sql: &str) -> std::result::Result<i64, String> {
 	let c_sql = CString::new(sql).map_err(|err| err.to_string())?;
 	let mut stmt = ptr::null_mut();
@@ -1175,6 +1537,70 @@ fn direct_depot_transport_rejects_mirror_fallback() {
 	assert!(!err.to_string().is_empty());
 	let after = engine.stats();
 	assert_eq!(after.mirror_reads, before.mirror_reads);
+}
+
+#[test]
+fn direct_get_pages_falls_back_when_cached_pidx_delta_was_reclaimed() {
+	let runtime = direct_runtime();
+	let harness = DirectEngineHarness::new();
+	let engine = runtime.block_on(harness.open_engine());
+	let actor_db = runtime.block_on(engine.actor_db(harness.actor_id.clone()));
+	let page = empty_db_page();
+
+	runtime
+		.block_on(actor_db.commit(
+			vec![depot::types::DirtyPage {
+				pgno: 1,
+				bytes: page.clone(),
+			}],
+			1,
+			1,
+		))
+		.expect("seed commit should succeed");
+
+	let warmed = runtime
+		.block_on(engine.get_pages(&harness.actor_id, &[1]))
+		.expect("initial read should warm the pidx cache");
+	assert_eq!(warmed.pages[0].bytes.as_deref(), Some(page.as_slice()));
+
+	let (branch_id, head_txid) = runtime
+		.block_on(engine.read_branch_head(&harness.actor_id))
+		.expect("branch head should exist");
+	let shard_blob = depot::ltx::encode_ltx_v3(
+		depot::ltx::LtxHeader::delta(head_txid, 1, 0),
+		&[depot::types::DirtyPage {
+			pgno: 1,
+			bytes: page.clone(),
+		}],
+	)
+	.expect("hot shard blob should encode");
+	let db = engine.depot_database();
+	runtime
+		.block_on(db.run(move |tx| {
+			let shard_blob = shard_blob.clone();
+			async move {
+				tx.informal().set(
+					&depot::keys::branch_shard_key(branch_id, 0, head_txid),
+					&shard_blob,
+				);
+				tx.informal()
+					.clear(&depot::keys::branch_delta_chunk_key(branch_id, head_txid, 0));
+				tx.informal()
+					.clear(&depot::keys::branch_pidx_key(branch_id, 1));
+				Ok(())
+			}
+		}))
+		.expect("simulated reclaim should update depot rows");
+
+	let fetched = runtime
+		.block_on(engine.get_pages(&harness.actor_id, &[1]))
+		.expect("stale cached pidx should fall back to hot shard coverage");
+	assert_eq!(fetched.pages[0].bytes.as_deref(), Some(page.as_slice()));
+
+	let fetched_again = runtime
+		.block_on(engine.get_pages(&harness.actor_id, &[1]))
+		.expect("stale pidx eviction should keep later reads healthy");
+	assert_eq!(fetched_again.pages[0].bytes.as_deref(), Some(page.as_slice()));
 }
 
 #[test]
@@ -2532,6 +2958,10 @@ fn depot_commit_too_large_response_reproduces_dead_vfs_chain() {
 		"unexpected kv error: {kv_error}",
 	);
 	assert!(
+		kv_error.contains("\"code\":\"commit_too_large\""),
+		"commit_too_large should preserve the structured depot code: {kv_error}",
+	);
+	assert!(
 		sqlite_query_i64(db.as_ptr(), "SELECT COUNT(*) FROM too_large;").is_err(),
 		"later SQL on the same handle should fail once the VFS is dead",
 	);
@@ -3779,6 +4209,234 @@ fn commit_buffered_pages_uses_fast_path() {
 	assert!(metrics.serialize_ns > 0);
 	assert!(metrics.transport_ns > 0);
 	assert_eq!(hooks.commit_requests().len(), 1);
+	assert!(hooks.stage_begin_requests().is_empty());
+	assert!(hooks.stage_pages_requests().is_empty());
+	assert!(hooks.stage_complete_requests().is_empty());
+	assert!(hooks.stage_finalize_requests().is_empty());
+	assert!(hooks.stage_abort_requests().is_empty());
+}
+
+#[test]
+fn commit_buffered_pages_uses_slow_path_for_large_dirty_set() {
+	let runtime = direct_runtime();
+	let harness = DirectEngineHarness::new();
+	let engine = runtime.block_on(harness.open_engine());
+	let transport = Arc::new(DirectDepotTransport::new(engine));
+	let hooks = transport.direct_hooks();
+
+	let dirty_pages = (1..=2049)
+		.map(|pgno| {
+			let mut bytes = vec![0; 4096];
+			if pgno == 1 {
+				bytes = empty_db_page();
+			}
+			protocol::SqliteDirtyPage { pgno, bytes }
+		})
+		.collect::<Vec<_>>();
+
+	let outcome = runtime
+		.block_on(commit_buffered_pages(
+			&*transport,
+			BufferedCommitRequest {
+				actor_id: harness.actor_id.clone(),
+				new_db_size_pages: 2049,
+				expected_head_txid: None,
+				dirty_pages,
+			},
+		))
+		.expect("slow-path commit should succeed");
+	let (outcome, metrics) = outcome;
+
+	assert_eq!(outcome.path, CommitPath::Slow);
+	assert_eq!(outcome.db_size_pages, 2049);
+	assert_eq!(outcome.head_txid, Some(1));
+	assert!(metrics.serialize_ns > 0);
+	assert!(metrics.transport_ns > 0);
+	assert!(hooks.commit_requests().is_empty());
+	assert_eq!(hooks.stage_begin_requests().len(), 1);
+	assert!(
+		hooks.stage_pages_requests().len() > 1,
+		"slow path should split dirty pages into bounded stage batches"
+	);
+	assert_eq!(hooks.stage_complete_requests().len(), 1);
+	assert_eq!(hooks.stage_finalize_requests().len(), 1);
+	assert!(hooks.stage_abort_requests().is_empty());
+}
+
+#[test]
+fn commit_buffered_pages_aborts_stage_when_page_batch_fails() {
+	let runtime = direct_runtime();
+	let harness = DirectEngineHarness::new();
+	let engine = runtime.block_on(harness.open_engine());
+	let transport = Arc::new(DirectDepotTransport::new(Arc::clone(&engine)));
+	let hooks = transport.direct_hooks();
+	hooks.fail_next_stage_pages("injected stage page upload failure");
+
+	let err = runtime
+		.block_on(commit_buffered_pages(
+			&*transport,
+			BufferedCommitRequest {
+				actor_id: harness.actor_id.clone(),
+				new_db_size_pages: 2_049,
+				expected_head_txid: None,
+				dirty_pages: staged_dirty_pages(2_049),
+			},
+		))
+		.expect_err("stage page failure should reject the staged commit");
+
+	let CommitBufferError::Other(message) = err else {
+		panic!("stage page failure should be a normal commit error");
+	};
+	assert!(message.contains("injected stage page upload failure"));
+	assert_eq!(hooks.stage_begin_requests().len(), 1);
+	assert_eq!(hooks.stage_pages_requests().len(), 1);
+	assert!(hooks.stage_complete_requests().is_empty());
+	assert!(hooks.stage_finalize_requests().is_empty());
+	assert_aborted_stage_lookup_removed(&runtime, &engine, &hooks);
+}
+
+#[test]
+fn commit_buffered_pages_aborts_stage_when_complete_fails() {
+	let runtime = direct_runtime();
+	let harness = DirectEngineHarness::new();
+	let engine = runtime.block_on(harness.open_engine());
+	let transport = Arc::new(DirectDepotTransport::new(Arc::clone(&engine)));
+	let hooks = transport.direct_hooks();
+	hooks.fail_next_stage_complete("injected stage complete failure");
+
+	let err = runtime
+		.block_on(commit_buffered_pages(
+			&*transport,
+			BufferedCommitRequest {
+				actor_id: harness.actor_id.clone(),
+				new_db_size_pages: 2_049,
+				expected_head_txid: None,
+				dirty_pages: staged_dirty_pages(2_049),
+			},
+		))
+		.expect_err("stage complete failure should reject the staged commit");
+
+	let CommitBufferError::Other(message) = err else {
+		panic!("stage complete failure should be a normal commit error");
+	};
+	assert!(message.contains("injected stage complete failure"));
+	assert_eq!(hooks.stage_begin_requests().len(), 1);
+	assert!(hooks.stage_pages_requests().len() > 1);
+	assert_eq!(hooks.stage_complete_requests().len(), 1);
+	assert!(hooks.stage_finalize_requests().is_empty());
+	assert_aborted_stage_lookup_removed(&runtime, &engine, &hooks);
+}
+
+#[test]
+fn commit_buffered_pages_allows_documented_dirty_page_limit() {
+	let runtime = direct_runtime();
+	let harness = DirectEngineHarness::new();
+	let engine = runtime.block_on(harness.open_engine());
+	let transport = Arc::new(DirectDepotTransport::new(engine));
+	let hooks = transport.direct_hooks();
+
+	let dirty_pages = (1..=8_192)
+		.map(|pgno| {
+			let bytes = if pgno == 1 {
+				empty_db_page()
+			} else {
+				vec![(pgno % 251) as u8; DEFAULT_PAGE_SIZE]
+			};
+			protocol::SqliteDirtyPage { pgno, bytes }
+		})
+		.collect::<Vec<_>>();
+
+	let outcome = runtime
+		.block_on(commit_buffered_pages(
+			&*transport,
+			BufferedCommitRequest {
+				actor_id: harness.actor_id.clone(),
+				new_db_size_pages: 8_192,
+				expected_head_txid: None,
+				dirty_pages,
+			},
+		))
+		.expect("32 MiB staged commit at documented dirty-page limit should succeed");
+	let (outcome, _metrics) = outcome;
+
+	assert_eq!(outcome.path, CommitPath::Slow);
+	assert_eq!(outcome.db_size_pages, 8_192);
+	assert_eq!(outcome.head_txid, Some(1));
+	assert!(hooks.commit_requests().is_empty());
+	assert_eq!(hooks.stage_begin_requests().len(), 1);
+	assert_eq!(hooks.stage_complete_requests().len(), 1);
+	assert_eq!(hooks.stage_finalize_requests().len(), 1);
+	assert!(hooks.stage_abort_requests().is_empty());
+
+	let stage_pages = hooks.stage_pages_requests();
+	assert_eq!(
+		stage_pages
+			.iter()
+			.map(|request| request.dirty_pages.len())
+			.sum::<usize>(),
+		8_192
+	);
+	assert!(
+		stage_pages
+			.iter()
+			.all(|request| request.dirty_pages.len() <= 16),
+		"stage page batches should stay bounded"
+	);
+}
+
+fn staged_dirty_pages(count: u32) -> Vec<protocol::SqliteDirtyPage> {
+	(1..=count)
+		.map(|pgno| {
+			let bytes = if pgno == 1 {
+				empty_db_page()
+			} else {
+				vec![(pgno % 251) as u8; DEFAULT_PAGE_SIZE]
+			};
+			protocol::SqliteDirtyPage { pgno, bytes }
+		})
+		.collect()
+}
+
+fn assert_aborted_stage_lookup_removed(
+	runtime: &tokio::runtime::Runtime,
+	engine: &Arc<DirectStorage>,
+	hooks: &vfs_support::DirectTransportHooks,
+) {
+	let stage_id = {
+		let abort_requests = hooks.stage_abort_requests();
+		assert_eq!(abort_requests.len(), 1);
+		uuid::Uuid::from_slice(&abort_requests[0].stage_id)
+			.expect("abort request stage id should decode")
+	};
+	let lookup = read_depot_value(
+		runtime,
+		engine,
+		depot::keys::commit_stage_lookup_key(stage_id),
+	);
+	assert!(
+		lookup.is_none(),
+		"stage abort should remove the global stage lookup"
+	);
+}
+
+fn read_depot_value(
+	runtime: &tokio::runtime::Runtime,
+	engine: &Arc<DirectStorage>,
+	key: Vec<u8>,
+) -> Option<Vec<u8>> {
+	let db = engine.depot_database();
+	runtime
+		.block_on(db.run(move |tx| {
+			let key = key.clone();
+			async move {
+				Ok(tx
+					.informal()
+					.get(&key, universaldb::utils::IsolationLevel::Serializable)
+					.await?
+					.map(Vec::<u8>::from))
+			}
+		}))
+		.expect("depot value read should succeed")
 }
 
 #[test]
@@ -4343,18 +5001,23 @@ fn bench_large_tx_insert_500kb() {
 }
 
 #[test]
-fn bench_large_tx_insert_10mb_rejects_transaction_too_large() {
-	large_tx_insert_rejects_transaction_too_large(10 * 1024 * 1024);
+fn bench_large_tx_insert_10mb_uses_slow_path() {
+	large_tx_insert(10 * 1024 * 1024);
 }
 
 #[test]
-fn bench_large_tx_insert_50mb_rejects_transaction_too_large() {
-	large_tx_insert_rejects_transaction_too_large(50 * 1024 * 1024);
+fn bench_large_tx_insert_24mb_reopens_and_integrity_checks() {
+	large_tx_insert_reopens_and_integrity_checks(24 * 1024 * 1024);
 }
 
 #[test]
-fn bench_large_tx_insert_100mb_rejects_transaction_too_large() {
-	large_tx_insert_rejects_transaction_too_large(100 * 1024 * 1024);
+fn bench_large_tx_insert_50mb_rejects_page_limit() {
+	large_tx_insert_rejects_page_limit(50 * 1024 * 1024);
+}
+
+#[test]
+fn bench_large_tx_insert_100mb_rejects_page_limit() {
+	large_tx_insert_rejects_page_limit(100 * 1024 * 1024);
 }
 
 fn large_tx_insert(target_bytes: usize) {
@@ -4390,9 +5053,13 @@ fn large_tx_insert(target_bytes: usize) {
 		sqlite_query_i64(db.as_ptr(), "SELECT COUNT(*) FROM large_tx;").unwrap(),
 		rows as i64
 	);
+	assert_eq!(
+		sqlite_query_text(db.as_ptr(), "PRAGMA integrity_check;").unwrap(),
+		"ok"
+	);
 }
 
-fn large_tx_insert_rejects_transaction_too_large(target_bytes: usize) {
+fn large_tx_insert_rejects_page_limit(target_bytes: usize) {
 	let runtime = direct_runtime();
 	let db = open_bench_db(&runtime);
 	sqlite_exec(
@@ -4413,17 +5080,67 @@ fn large_tx_insert_rejects_transaction_too_large(target_bytes: usize) {
 	}
 
 	let err = sqlite_exec(db.as_ptr(), "COMMIT")
-		.expect_err("large transaction should be rejected before local UDB commit");
+		.expect_err("large transaction should be rejected by the dirty-page limit");
 	assert!(
 		err.contains("I/O") || err.contains("disk I/O"),
-		"sqlite should surface transaction-too-large as an IO error: {err}",
+		"sqlite should surface page-limit failure as an IO error: {err}",
 	);
 	let vfs_err = direct_vfs_ctx(&db)
 		.clone_last_error()
-		.expect("transaction-too-large should be recorded as the VFS last error");
+		.expect("page-limit failure should be recorded as the VFS last error");
 	assert!(
-		vfs_err.contains("CommitTooLarge") || vfs_err.contains("commit too large"),
+		vfs_err.contains("too many pages"),
 		"unexpected VFS error: {vfs_err}",
+	);
+	assert!(
+		vfs_err.contains("\"code\":\"sqlite_commit_page_limit_exceeded\""),
+		"page-limit error should preserve the structured depot code: {vfs_err}",
+	);
+	assert!(
+		vfs_err.contains("\"max_dirty_pages\":8192"),
+		"page-limit error should preserve metadata: {vfs_err}",
+	);
+}
+
+fn large_tx_insert_reopens_and_integrity_checks(target_bytes: usize) {
+	let runtime = direct_runtime();
+	let harness = DirectEngineHarness::new();
+	let db = harness.open_db(&runtime);
+	sqlite_exec(
+		db.as_ptr(),
+		"CREATE TABLE large_tx (id INTEGER PRIMARY KEY AUTOINCREMENT, payload BLOB NOT NULL);",
+	)
+	.unwrap();
+
+	let row_size = 4 * 1024;
+	let rows = (target_bytes + row_size - 1) / row_size;
+	sqlite_exec(db.as_ptr(), "BEGIN").unwrap();
+	for _ in 0..rows {
+		sqlite_exec(
+			db.as_ptr(),
+			&format!("INSERT INTO large_tx (payload) VALUES (randomblob({row_size}));"),
+		)
+		.unwrap();
+	}
+	sqlite_exec(db.as_ptr(), "COMMIT").unwrap();
+	assert_eq!(
+		sqlite_query_i64(db.as_ptr(), "SELECT COUNT(*) FROM large_tx;").unwrap(),
+		rows as i64
+	);
+	assert_eq!(
+		sqlite_query_text(db.as_ptr(), "PRAGMA integrity_check;").unwrap(),
+		"ok"
+	);
+	drop(db);
+
+	let reopened = harness.open_db(&runtime);
+	assert_eq!(
+		sqlite_query_i64(reopened.as_ptr(), "SELECT COUNT(*) FROM large_tx;").unwrap(),
+		rows as i64
+	);
+	assert_eq!(
+		sqlite_query_text(reopened.as_ptr(), "PRAGMA integrity_check;").unwrap(),
+		"ok"
 	);
 }
 

--- a/engine/packages/depot-client/tests/inline/vfs.rs
+++ b/engine/packages/depot-client/tests/inline/vfs.rs
@@ -6,7 +6,7 @@ pub(super) use vfs_support::{
 	storage_dirty_page,
 };
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier, mpsc};
 use std::thread;
 use std::time::Duration;
@@ -373,6 +373,59 @@ impl DirectEngineHarness {
 			None,
 		)
 		.expect("vfs context should build")
+	}
+}
+
+struct CommitTooLargeTransport {
+	inner: Arc<DirectDepotTransport>,
+	min_dirty_pages: usize,
+	failed_dirty_pages: AtomicUsize,
+}
+
+impl CommitTooLargeTransport {
+	fn new(inner: Arc<DirectDepotTransport>, min_dirty_pages: usize) -> Self {
+		Self {
+			inner,
+			min_dirty_pages,
+			failed_dirty_pages: AtomicUsize::new(0),
+		}
+	}
+
+	fn failed_dirty_pages(&self) -> usize {
+		self.failed_dirty_pages.load(Ordering::SeqCst)
+	}
+}
+
+#[async_trait]
+impl SqliteTransport for CommitTooLargeTransport {
+	async fn get_pages(
+		&self,
+		request: protocol::SqliteGetPagesRequest,
+	) -> Result<protocol::SqliteGetPagesResponse> {
+		self.inner.get_pages(request).await
+	}
+
+	async fn commit(
+		&self,
+		request: protocol::SqliteCommitRequest,
+	) -> Result<protocol::SqliteCommitResponse> {
+		let dirty_pages = request.dirty_pages.len();
+		if dirty_pages >= self.min_dirty_pages {
+			self.failed_dirty_pages.store(dirty_pages, Ordering::SeqCst);
+			return Ok(protocol::SqliteCommitResponse::SqliteErrorResponse(
+				protocol::SqliteErrorResponse {
+					group: "depot".to_string(),
+					code: "commit_too_large".to_string(),
+					message: format!(
+						"sqlite commit too large: actual_size_bytes={}, max_size_bytes={}",
+						dirty_pages * 4096,
+						(self.min_dirty_pages - 1) * 4096
+					),
+				},
+			));
+		}
+
+		self.inner.commit(request).await
 	}
 }
 
@@ -2425,6 +2478,66 @@ fn direct_engine_marks_vfs_dead_after_transport_errors() {
 }
 
 #[test]
+fn depot_commit_too_large_response_reproduces_dead_vfs_chain() {
+	let runtime = direct_runtime();
+	let harness = DirectEngineHarness::new();
+	let engine = runtime.block_on(harness.open_engine());
+	let inner = Arc::new(DirectDepotTransport::new(engine));
+	let transport = Arc::new(CommitTooLargeTransport::new(inner, 16));
+	let vfs = SqliteVfs::register_with_transport(
+		&next_test_name("sqlite-direct-vfs"),
+		transport.clone(),
+		harness.actor_id.clone(),
+		runtime.handle().clone(),
+		VfsConfig::default(),
+		None,
+	)
+	.expect("v2 vfs should register");
+	let db = open_database(vfs, &harness.actor_id).expect("sqlite database should open");
+
+	sqlite_exec(
+		db.as_ptr(),
+		"CREATE TABLE too_large (id INTEGER PRIMARY KEY, payload BLOB NOT NULL);",
+	)
+	.expect("setup commit should stay below the injected commit limit");
+
+	sqlite_exec(db.as_ptr(), "BEGIN;").expect("begin should succeed");
+	for i in 0..64 {
+		sqlite_step_statement(
+			db.as_ptr(),
+			&format!("INSERT INTO too_large (id, payload) VALUES ({i}, randomblob(4096));"),
+		)
+		.expect("insert should buffer before commit");
+	}
+	let err = sqlite_exec(db.as_ptr(), "COMMIT;")
+		.expect_err("oversized commit should surface as a sqlite IO error");
+
+	assert!(
+		err.contains("I/O") || err.contains("disk I/O"),
+		"sqlite should surface commit_too_large as an IO error: {err}",
+	);
+	assert!(
+		transport.failed_dirty_pages() >= 16,
+		"large transaction should dirty enough pages to trigger the repro transport",
+	);
+	assert!(
+		direct_vfs_ctx(&db).is_dead(),
+		"commit_too_large should poison the VFS",
+	);
+	let kv_error = db
+		.take_last_kv_error()
+		.expect("commit_too_large should be stored as the last sqlite kv error");
+	assert!(
+		kv_error.contains("sqlite commit too large"),
+		"unexpected kv error: {kv_error}",
+	);
+	assert!(
+		sqlite_query_i64(db.as_ptr(), "SELECT COUNT(*) FROM too_large;").is_err(),
+		"later SQL on the same handle should fail once the VFS is dead",
+	);
+}
+
+#[test]
 fn flush_dirty_pages_marks_vfs_dead_after_transport_error() {
 	let runtime = direct_runtime();
 	let harness = DirectEngineHarness::new();
@@ -4230,20 +4343,18 @@ fn bench_large_tx_insert_500kb() {
 }
 
 #[test]
-fn bench_large_tx_insert_10mb() {
-	large_tx_insert(10 * 1024 * 1024);
+fn bench_large_tx_insert_10mb_rejects_transaction_too_large() {
+	large_tx_insert_rejects_transaction_too_large(10 * 1024 * 1024);
 }
 
 #[test]
-fn bench_large_tx_insert_50mb() {
-	// 50MB exercises the slow-path stage/finalize chunking that has
-	// historically hit decode errors under certain transports.
-	large_tx_insert(50 * 1024 * 1024);
+fn bench_large_tx_insert_50mb_rejects_transaction_too_large() {
+	large_tx_insert_rejects_transaction_too_large(50 * 1024 * 1024);
 }
 
 #[test]
-fn bench_large_tx_insert_100mb() {
-	large_tx_insert(100 * 1024 * 1024);
+fn bench_large_tx_insert_100mb_rejects_transaction_too_large() {
+	large_tx_insert_rejects_transaction_too_large(100 * 1024 * 1024);
 }
 
 fn large_tx_insert(target_bytes: usize) {
@@ -4278,6 +4389,41 @@ fn large_tx_insert(target_bytes: usize) {
 	assert_eq!(
 		sqlite_query_i64(db.as_ptr(), "SELECT COUNT(*) FROM large_tx;").unwrap(),
 		rows as i64
+	);
+}
+
+fn large_tx_insert_rejects_transaction_too_large(target_bytes: usize) {
+	let runtime = direct_runtime();
+	let db = open_bench_db(&runtime);
+	sqlite_exec(
+		db.as_ptr(),
+		"CREATE TABLE large_tx (id INTEGER PRIMARY KEY AUTOINCREMENT, payload BLOB NOT NULL);",
+	)
+	.unwrap();
+
+	let row_size = 4 * 1024;
+	let rows = (target_bytes + row_size - 1) / row_size;
+	sqlite_exec(db.as_ptr(), "BEGIN").unwrap();
+	for _ in 0..rows {
+		sqlite_exec(
+			db.as_ptr(),
+			&format!("INSERT INTO large_tx (payload) VALUES (randomblob({row_size}));"),
+		)
+		.unwrap();
+	}
+
+	let err = sqlite_exec(db.as_ptr(), "COMMIT")
+		.expect_err("large transaction should be rejected before local UDB commit");
+	assert!(
+		err.contains("I/O") || err.contains("disk I/O"),
+		"sqlite should surface transaction-too-large as an IO error: {err}",
+	);
+	let vfs_err = direct_vfs_ctx(&db)
+		.clone_last_error()
+		.expect("transaction-too-large should be recorded as the VFS last error");
+	assert!(
+		vfs_err.contains("CommitTooLarge") || vfs_err.contains("commit too large"),
+		"unexpected VFS error: {vfs_err}",
 	);
 }
 

--- a/engine/packages/depot-client/tests/inline/vfs_support.rs
+++ b/engine/packages/depot-client/tests/inline/vfs_support.rs
@@ -240,6 +240,15 @@ impl DirectStorage {
 		if dirty_pages.is_empty() {
 			bail!("cold-ref seed requires at least one page");
 		}
+		let covered_pgnos = dirty_pages
+			.iter()
+			.map(|page| {
+				if page.pgno / SHARD_SIZE != shard_id {
+					bail!("cold-ref seed page {} is outside shard {shard_id}", page.pgno);
+				}
+				Ok(page.pgno)
+			})
+			.collect::<Result<Vec<_>>>()?;
 		let object_bytes = encode_ltx_v3(LtxHeader::delta(head_txid, 1, 1_000), &dirty_pages)?;
 		let digest = Sha256::digest(&object_bytes);
 		let mut content_hash = [0_u8; 32];
@@ -263,6 +272,7 @@ impl DirectStorage {
 		self.db
 			.run(move |tx| {
 				let cold_ref = cold_ref.clone();
+				let covered_pgnos = covered_pgnos.clone();
 				async move {
 					tx.informal().set(
 						&branch_compaction_cold_shard_key(branch_id, shard_id, head_txid),
@@ -278,7 +288,9 @@ impl DirectStorage {
 							cold_watermark_versionstamp: [2; 16],
 						})?,
 					);
-					tx.informal().clear(&branch_pidx_key(branch_id, pgno));
+					for covered_pgno in covered_pgnos {
+						tx.informal().clear(&branch_pidx_key(branch_id, covered_pgno));
+					}
 					for txid in 1..=head_txid {
 						tx.informal()
 							.clear(&branch_delta_chunk_key(branch_id, txid, 0));
@@ -490,6 +502,159 @@ impl SqliteTransport for DirectDepotTransport {
 			)),
 		}
 	}
+
+	async fn commit_stage_begin(
+		&self,
+		request: protocol::SqliteCommitStageBeginRequest,
+	) -> Result<protocol::SqliteCommitStageBeginResponse> {
+		self.storage
+			.hooks
+			.record_stage_begin_request(request.clone());
+
+		let actor_id = request.actor_id.clone();
+		let actor_db = self.storage.actor_db(actor_id).await;
+		match actor_db
+			.commit_stage_begin(
+				request.dirty_pgnos,
+				request.db_size_pages,
+				request.now_ms,
+				depot::types::CommitOptions {
+					expected_head_txid: request.expected_head_txid,
+				},
+			)
+			.await
+		{
+			Ok(result) => Ok(
+				protocol::SqliteCommitStageBeginResponse::SqliteCommitStageBeginOk(
+					protocol::SqliteCommitStageBeginOk {
+						stage_id: *result.stage_id.as_bytes(),
+						max_pages_per_batch: result.max_pages_per_batch,
+						max_batch_bytes: result.max_batch_bytes,
+						observed_head_txid: result.observed_head_txid,
+						staged_txid: result.staged_txid,
+					},
+				),
+			),
+			Err(err) => Ok(protocol::SqliteCommitStageBeginResponse::SqliteErrorResponse(
+				sqlite_error_response(&err),
+			)),
+		}
+	}
+
+	async fn commit_stage_pages(
+		&self,
+		request: protocol::SqliteCommitStagePagesRequest,
+	) -> Result<protocol::SqliteCommitStagePagesResponse> {
+		self.storage
+			.hooks
+			.record_stage_pages_request(request.clone());
+		if let Some(message) = self.storage.hooks.take_stage_pages_error() {
+			return Ok(protocol::SqliteCommitStagePagesResponse::SqliteErrorResponse(
+				injected_sqlite_error_response(message),
+			));
+		}
+
+		let actor_id = request.actor_id.clone();
+		let actor_db = self.storage.actor_db(actor_id).await;
+		match actor_db
+			.commit_stage_pages(
+				stage_id_from_protocol(&request.stage_id)?,
+				request.batch_idx,
+				request
+					.dirty_pages
+					.into_iter()
+					.map(storage_dirty_page)
+					.collect(),
+			)
+			.await
+		{
+			Ok(()) => Ok(protocol::SqliteCommitStagePagesResponse::SqliteCommitStagePagesOk),
+			Err(err) => Ok(protocol::SqliteCommitStagePagesResponse::SqliteErrorResponse(
+				sqlite_error_response(&err),
+			)),
+		}
+	}
+
+	async fn commit_stage_complete(
+		&self,
+		request: protocol::SqliteCommitStageCompleteRequest,
+	) -> Result<protocol::SqliteCommitStageCompleteResponse> {
+		self.storage
+			.hooks
+			.record_stage_complete_request(request.clone());
+		if let Some(message) = self.storage.hooks.take_stage_complete_error() {
+			return Ok(
+				protocol::SqliteCommitStageCompleteResponse::SqliteErrorResponse(
+					injected_sqlite_error_response(message),
+				),
+			);
+		}
+
+		let actor_id = request.actor_id.clone();
+		let actor_db = self.storage.actor_db(actor_id).await;
+		match actor_db
+			.commit_stage_complete(
+				stage_id_from_protocol(&request.stage_id)?,
+				request.page_batch_count,
+			)
+			.await
+		{
+			Ok(()) => Ok(
+				protocol::SqliteCommitStageCompleteResponse::SqliteCommitStageCompleteOk,
+			),
+			Err(err) => Ok(
+				protocol::SqliteCommitStageCompleteResponse::SqliteErrorResponse(
+					sqlite_error_response(&err),
+				),
+			),
+		}
+	}
+
+	async fn commit_stage_finalize(
+		&self,
+		request: protocol::SqliteCommitStageFinalizeRequest,
+	) -> Result<protocol::SqliteCommitResponse> {
+		self.storage
+			.hooks
+			.record_stage_finalize_request(request.clone());
+
+		let actor_id = request.actor_id.clone();
+		let actor_db = self.storage.actor_db(actor_id).await;
+		match actor_db
+			.commit_stage_finalize(stage_id_from_protocol(&request.stage_id)?)
+			.await
+		{
+			Ok(result) => Ok(protocol::SqliteCommitResponse::SqliteCommitOk(
+				protocol::SqliteCommitOk {
+					head_txid: Some(result.head_txid),
+				},
+			)),
+			Err(err) => Ok(protocol::SqliteCommitResponse::SqliteErrorResponse(
+				sqlite_error_response(&err),
+			)),
+		}
+	}
+
+	async fn commit_stage_abort(
+		&self,
+		request: protocol::SqliteCommitStageAbortRequest,
+	) -> Result<protocol::SqliteCommitStageAbortResponse> {
+		self.storage
+			.hooks
+			.record_stage_abort_request(request.clone());
+
+		let actor_id = request.actor_id.clone();
+		let actor_db = self.storage.actor_db(actor_id).await;
+		match actor_db
+			.commit_stage_abort(stage_id_from_protocol(&request.stage_id)?)
+			.await
+		{
+			Ok(()) => Ok(protocol::SqliteCommitStageAbortResponse::SqliteCommitStageAbortOk),
+			Err(err) => Ok(protocol::SqliteCommitStageAbortResponse::SqliteErrorResponse(
+				sqlite_error_response(&err),
+			)),
+		}
+	}
 }
 
 pub(crate) struct DirectMirrorTransport {
@@ -604,10 +769,17 @@ impl ColdTier for CountingColdTier {
 pub(crate) struct DirectTransportHooks {
 	fail_next_commit: Mutex<Option<String>>,
 	fail_next_get_pages: Mutex<Option<String>>,
+	fail_next_stage_pages: Mutex<Option<String>>,
+	fail_next_stage_complete: Mutex<Option<String>>,
 	hang_next_commit: Mutex<bool>,
 	pause_next_commit: Mutex<Option<DirectCommitGate>>,
 	get_pages_requests: Mutex<Vec<protocol::SqliteGetPagesRequest>>,
 	commit_requests: Mutex<Vec<protocol::SqliteCommitRequest>>,
+	stage_begin_requests: Mutex<Vec<protocol::SqliteCommitStageBeginRequest>>,
+	stage_pages_requests: Mutex<Vec<protocol::SqliteCommitStagePagesRequest>>,
+	stage_complete_requests: Mutex<Vec<protocol::SqliteCommitStageCompleteRequest>>,
+	stage_finalize_requests: Mutex<Vec<protocol::SqliteCommitStageFinalizeRequest>>,
+	stage_abort_requests: Mutex<Vec<protocol::SqliteCommitStageAbortRequest>>,
 }
 
 impl DirectTransportHooks {
@@ -617,6 +789,14 @@ impl DirectTransportHooks {
 
 	pub(crate) fn fail_next_get_pages(&self, message: impl Into<String>) {
 		*self.fail_next_get_pages.lock() = Some(message.into());
+	}
+
+	pub(crate) fn fail_next_stage_pages(&self, message: impl Into<String>) {
+		*self.fail_next_stage_pages.lock() = Some(message.into());
+	}
+
+	pub(crate) fn fail_next_stage_complete(&self, message: impl Into<String>) {
+		*self.fail_next_stage_complete.lock() = Some(message.into());
 	}
 
 	pub(crate) fn hang_next_commit(&self) {
@@ -635,12 +815,77 @@ impl DirectTransportHooks {
 		self.get_pages_requests.lock()
 	}
 
+	pub(crate) fn stage_begin_requests(
+		&self,
+	) -> parking_lot::MutexGuard<'_, Vec<protocol::SqliteCommitStageBeginRequest>> {
+		self.stage_begin_requests.lock()
+	}
+
+	pub(crate) fn stage_pages_requests(
+		&self,
+	) -> parking_lot::MutexGuard<'_, Vec<protocol::SqliteCommitStagePagesRequest>> {
+		self.stage_pages_requests.lock()
+	}
+
+	pub(crate) fn stage_complete_requests(
+		&self,
+	) -> parking_lot::MutexGuard<'_, Vec<protocol::SqliteCommitStageCompleteRequest>> {
+		self.stage_complete_requests.lock()
+	}
+
+	pub(crate) fn stage_finalize_requests(
+		&self,
+	) -> parking_lot::MutexGuard<'_, Vec<protocol::SqliteCommitStageFinalizeRequest>> {
+		self.stage_finalize_requests.lock()
+	}
+
+	pub(crate) fn stage_abort_requests(
+		&self,
+	) -> parking_lot::MutexGuard<'_, Vec<protocol::SqliteCommitStageAbortRequest>> {
+		self.stage_abort_requests.lock()
+	}
+
 	pub(crate) fn record_get_pages_request(&self, req: protocol::SqliteGetPagesRequest) {
 		self.get_pages_requests.lock().push(req);
 	}
 
 	pub(crate) fn record_commit_request(&self, req: protocol::SqliteCommitRequest) {
 		self.commit_requests.lock().push(req);
+	}
+
+	pub(crate) fn record_stage_begin_request(
+		&self,
+		req: protocol::SqliteCommitStageBeginRequest,
+	) {
+		self.stage_begin_requests.lock().push(req);
+	}
+
+	pub(crate) fn record_stage_pages_request(
+		&self,
+		req: protocol::SqliteCommitStagePagesRequest,
+	) {
+		self.stage_pages_requests.lock().push(req);
+	}
+
+	pub(crate) fn record_stage_complete_request(
+		&self,
+		req: protocol::SqliteCommitStageCompleteRequest,
+	) {
+		self.stage_complete_requests.lock().push(req);
+	}
+
+	pub(crate) fn record_stage_finalize_request(
+		&self,
+		req: protocol::SqliteCommitStageFinalizeRequest,
+	) {
+		self.stage_finalize_requests.lock().push(req);
+	}
+
+	pub(crate) fn record_stage_abort_request(
+		&self,
+		req: protocol::SqliteCommitStageAbortRequest,
+	) {
+		self.stage_abort_requests.lock().push(req);
 	}
 
 	pub(crate) fn pause_next_commit(&self) -> DirectCommitPause {
@@ -662,6 +907,14 @@ impl DirectTransportHooks {
 
 	pub(crate) fn take_get_pages_error(&self) -> Option<String> {
 		self.fail_next_get_pages.lock().take()
+	}
+
+	pub(crate) fn take_stage_pages_error(&self) -> Option<String> {
+		self.fail_next_stage_pages.lock().take()
+	}
+
+	pub(crate) fn take_stage_complete_error(&self) -> Option<String> {
+		self.fail_next_stage_complete.lock().take()
 	}
 
 	pub(crate) fn take_commit_hang(&self) -> bool {
@@ -746,7 +999,21 @@ pub(crate) fn sqlite_error_response(err: &anyhow::Error) -> protocol::SqliteErro
 		group: structured.group().to_string(),
 		code: structured.code().to_string(),
 		message: sqlite_error_reason(err),
+		metadata: structured.metadata().map(|metadata| metadata.to_string()),
 	}
+}
+
+fn injected_sqlite_error_response(message: String) -> protocol::SqliteErrorResponse {
+	protocol::SqliteErrorResponse {
+		group: "depot".to_string(),
+		code: "injected_stage_error".to_string(),
+		message,
+		metadata: None,
+	}
+}
+
+fn stage_id_from_protocol(stage_id: &protocol::SqliteStageId) -> Result<uuid::Uuid> {
+	uuid::Uuid::from_slice(stage_id).map_err(Into::into)
 }
 
 fn depot_error(err: &anyhow::Error) -> Option<&SqliteStorageError> {

--- a/engine/packages/depot/src/compaction/shared.rs
+++ b/engine/packages/depot/src/compaction/shared.rs
@@ -1,3 +1,5 @@
+use crate::conveyer::shard_blob::resolve_branch_shard_value;
+
 use super::*;
 
 pub(crate) async fn read_retired_cold_object_by_object_key(
@@ -594,6 +596,79 @@ pub(crate) async fn read_hot_input_snapshot(
 		}
 	}
 
+	for (key, value) in tx_scan_prefix_values(
+		tx,
+		&keys::branch_delta_manifest_prefix(branch_id),
+		isolation_level,
+	)
+	.await?
+	{
+		let txid = keys::decode_branch_delta_manifest_txid(branch_id, &key)?;
+		if txid < min_txid || txid > max_txid {
+			continue;
+		}
+		let manifest =
+			decode_delta_manifest(&value).context("decode sqlite large delta manifest for hot planning")?;
+		ensure!(
+			manifest.txid == txid,
+			"sqlite large delta manifest txid {} did not match key txid {}",
+			manifest.txid,
+			txid
+		);
+		snapshot.total_value_bytes = snapshot
+			.total_value_bytes
+			.saturating_add(u64::try_from(value.len()).unwrap_or(u64::MAX));
+		snapshot
+			.large_delta_manifests
+			.push((txid, key, value, manifest));
+		if hot_snapshot_key_count(&snapshot) >= CMP_FDB_BATCH_MAX_KEYS
+			|| snapshot.total_value_bytes >= CMP_FDB_BATCH_MAX_VALUE_BYTES as u64
+		{
+			break;
+		}
+	}
+
+	let large_manifest_txids = snapshot
+		.large_delta_manifests
+		.iter()
+		.map(|(txid, _, _, _)| *txid)
+		.collect::<BTreeSet<_>>();
+	for txid in large_manifest_txids {
+		for (key, value) in tx_scan_prefix_values(
+			tx,
+			&keys::branch_delta_pageidx_prefix(branch_id, txid),
+			isolation_level,
+		)
+		.await?
+		{
+			let pgno = keys::decode_branch_delta_pageidx_pgno(branch_id, txid, &key)?;
+			let entry = decode_delta_page_index_entry(&value)
+				.context("decode sqlite large delta page index for hot planning")?;
+			ensure!(
+				entry.txid == txid,
+				"sqlite large delta page index txid {} did not match key txid {}",
+				entry.txid,
+				txid
+			);
+			snapshot.total_value_bytes = snapshot
+				.total_value_bytes
+				.saturating_add(u64::try_from(value.len()).unwrap_or(u64::MAX));
+			snapshot
+				.large_delta_pageidx_entries
+				.push((txid, pgno, key, value, entry));
+			if hot_snapshot_key_count(&snapshot) >= CMP_FDB_BATCH_MAX_KEYS
+				|| snapshot.total_value_bytes >= CMP_FDB_BATCH_MAX_VALUE_BYTES as u64
+			{
+				break;
+			}
+		}
+		if hot_snapshot_key_count(&snapshot) >= CMP_FDB_BATCH_MAX_KEYS
+			|| snapshot.total_value_bytes >= CMP_FDB_BATCH_MAX_VALUE_BYTES as u64
+		{
+			break;
+		}
+	}
+
 	for (key, value) in
 		tx_scan_prefix_values(tx, &keys::branch_pidx_prefix(branch_id), isolation_level).await?
 	{
@@ -618,6 +693,14 @@ pub(crate) async fn read_hot_input_snapshot(
 		select_pitr_interval_coverage(&pitr_policy, &snapshot.commits, now_ms)?;
 
 	Ok(snapshot)
+}
+
+fn hot_snapshot_key_count(snapshot: &HotInputSnapshot) -> usize {
+	snapshot.commits.len()
+		+ snapshot.delta_chunks.len()
+		+ snapshot.large_delta_manifests.len()
+		+ snapshot.large_delta_pageidx_entries.len()
+		+ snapshot.pidx_entries.len()
 }
 
 pub(crate) fn select_pitr_interval_coverage(
@@ -769,6 +852,130 @@ pub(crate) async fn read_reclaim_input_snapshot(
 		}
 	}
 
+	for txid in &selected_txids {
+		let manifest_key = keys::branch_delta_manifest_key(branch_id, *txid);
+		let Some(manifest_value) = tx_get_value(tx, &manifest_key, isolation_level).await? else {
+			continue;
+		};
+		let mut large_delta_complete = true;
+		let manifest = decode_delta_manifest(&manifest_value)
+			.context("decode sqlite large delta manifest for reclaim")?;
+		ensure!(
+			manifest.txid == *txid,
+			"sqlite large delta manifest txid {} did not match key txid {}",
+			manifest.txid,
+			txid
+		);
+		snapshot.total_value_bytes = snapshot
+			.total_value_bytes
+			.saturating_add(u64::try_from(manifest_value.len()).unwrap_or(u64::MAX));
+		snapshot.large_delta_manifests.push((
+			*txid,
+			manifest_key,
+			manifest_value,
+			manifest.clone(),
+		));
+
+		for (key, value) in tx_scan_prefix_values(
+			tx,
+			&keys::branch_delta_pageidx_prefix(branch_id, *txid),
+			isolation_level,
+		)
+		.await?
+		{
+			let pgno = keys::decode_branch_delta_pageidx_pgno(branch_id, *txid, &key)?;
+			let entry = decode_delta_page_index_entry(&value)
+				.context("decode sqlite large delta page index for reclaim")?;
+			ensure!(
+				entry.txid == *txid,
+				"sqlite large delta page index txid {} did not match key txid {}",
+				entry.txid,
+				txid
+			);
+			snapshot.total_value_bytes = snapshot
+				.total_value_bytes
+				.saturating_add(u64::try_from(value.len()).unwrap_or(u64::MAX));
+			snapshot
+				.large_delta_pageidx_entries
+				.push((*txid, pgno, key, value, entry));
+			if reclaim_snapshot_key_count(&snapshot) >= CMP_FDB_BATCH_MAX_KEYS
+				|| snapshot.total_value_bytes >= CMP_FDB_BATCH_MAX_VALUE_BYTES as u64
+			{
+				large_delta_complete = false;
+				break;
+			}
+		}
+
+		let object_ref_key = keys::branch_delta_object_ref_key(branch_id, manifest.object_id);
+		if let Some(object_ref_value) = tx_get_value(tx, &object_ref_key, isolation_level).await? {
+			ensure!(
+				decode_txid_value(&object_ref_value)? == *txid,
+				"sqlite large delta object ref did not match manifest txid"
+			);
+			snapshot.total_value_bytes = snapshot
+				.total_value_bytes
+				.saturating_add(u64::try_from(object_ref_value.len()).unwrap_or(u64::MAX));
+			snapshot.large_delta_object_refs.push((
+				manifest.object_id,
+				object_ref_key,
+				object_ref_value,
+			));
+		}
+
+		let object_meta_key = keys::branch_delta_object_meta_key(branch_id, manifest.object_id);
+		if let Some(object_meta_value) = tx_get_value(tx, &object_meta_key, isolation_level).await? {
+			let object_meta = decode_delta_object_meta(&object_meta_value)
+				.context("decode sqlite large delta object meta for reclaim")?;
+			ensure!(
+				object_meta.object_id == manifest.object_id
+					&& object_meta.chunk_count == manifest.chunk_count
+					&& object_meta.encoded_len == manifest.encoded_len
+					&& object_meta.object_hash == manifest.object_hash,
+				"sqlite large delta object meta did not match manifest"
+			);
+			snapshot.total_value_bytes = snapshot
+				.total_value_bytes
+				.saturating_add(u64::try_from(object_meta_value.len()).unwrap_or(u64::MAX));
+			snapshot.large_delta_object_metas.push((
+				manifest.object_id,
+				object_meta_key,
+				object_meta_value,
+				object_meta,
+			));
+		}
+
+		for (key, value) in tx_scan_prefix_values(
+			tx,
+			&keys::branch_delta_object_chunk_prefix(branch_id, manifest.object_id),
+			isolation_level,
+		)
+		.await?
+		{
+			snapshot.total_value_bytes = snapshot
+				.total_value_bytes
+				.saturating_add(u64::try_from(value.len()).unwrap_or(u64::MAX));
+			snapshot
+				.large_delta_object_chunks
+				.push((manifest.object_id, key, value));
+			if reclaim_snapshot_key_count(&snapshot) >= CMP_FDB_BATCH_MAX_KEYS
+				|| snapshot.total_value_bytes >= CMP_FDB_BATCH_MAX_VALUE_BYTES as u64
+			{
+				large_delta_complete = false;
+				break;
+			}
+		}
+
+		if large_delta_complete {
+			snapshot.large_delta_complete_txids.push(*txid);
+		}
+
+		if reclaim_snapshot_key_count(&snapshot) >= CMP_FDB_BATCH_MAX_KEYS
+			|| snapshot.total_value_bytes >= CMP_FDB_BATCH_MAX_VALUE_BYTES as u64
+		{
+			break;
+		}
+	}
+
 	for (key, value) in
 		tx_scan_prefix_values(tx, &keys::branch_pidx_prefix(branch_id), isolation_level).await?
 	{
@@ -779,7 +986,7 @@ pub(crate) async fn read_reclaim_input_snapshot(
 		}
 	}
 
-	let shard_ids = reclaim_delta_shard_ids(branch_id, &snapshot.delta_chunks)?;
+	let shard_ids = reclaim_delta_shard_ids(branch_id, &snapshot)?;
 	snapshot.required_coverage_shard_count = shard_ids.len();
 	for shard_id in shard_ids {
 		let key = keys::branch_shard_key(branch_id, shard_id, root.hot_watermark_txid);
@@ -789,6 +996,23 @@ pub(crate) async fn read_reclaim_input_snapshot(
 	}
 
 	Ok(snapshot)
+}
+
+fn reclaim_snapshot_key_count(snapshot: &ReclaimInputSnapshot) -> usize {
+	snapshot.txid_refs.len()
+		+ snapshot.cold_object_refs.len()
+		+ snapshot.shard_cache_evictions.len()
+		+ snapshot.expired_pitr_interval_rows.len()
+		+ snapshot.commits.len()
+		+ snapshot.delta_chunks.len()
+		+ snapshot.large_delta_manifests.len()
+		+ snapshot.large_delta_complete_txids.len()
+		+ snapshot.large_delta_pageidx_entries.len()
+		+ snapshot.large_delta_object_refs.len()
+		+ snapshot.large_delta_object_metas.len()
+		+ snapshot.large_delta_object_chunks.len()
+		+ snapshot.pidx_entries.len()
+		+ snapshot.coverage_shards.len()
 }
 
 type PitrIntervalReclaimRows = (
@@ -875,7 +1099,7 @@ pub(crate) async fn read_shard_cache_eviction_candidates(
 	}
 
 	let mut candidates = Vec::new();
-	for (shard_key, shard_bytes) in
+	for (shard_key, shard_row_bytes) in
 		tx_scan_prefix_values(tx, &keys::branch_shard_prefix(branch_id), isolation_level).await?
 	{
 		let Some((shard_id, as_of_txid)) = decode_branch_shard_version_key(branch_id, &shard_key)?
@@ -892,6 +1116,15 @@ pub(crate) async fn read_shard_cache_eviction_candidates(
 		};
 		let cold_ref = decode_cold_shard_ref(&cold_ref_bytes)
 			.context("decode sqlite cold shard ref for shard cache eviction")?;
+		let shard_bytes = resolve_branch_shard_value(
+			tx,
+			branch_id,
+			shard_id,
+			as_of_txid,
+			&shard_row_bytes,
+			isolation_level,
+		)
+		.await?;
 		let content_hash = content_hash(&shard_bytes);
 		if cold_ref.shard_id != shard_id
 			|| cold_ref.as_of_txid != as_of_txid
@@ -909,6 +1142,7 @@ pub(crate) async fn read_shard_cache_eviction_candidates(
 				content_hash,
 			},
 			shard_key,
+			shard_row_bytes,
 			shard_bytes,
 			cold_ref_key,
 			cold_ref_bytes,
@@ -1011,14 +1245,17 @@ pub(crate) async fn read_cold_input_snapshot(
 		if as_of_txid != max_txid {
 			continue;
 		}
+		let bytes =
+			resolve_branch_shard_value(tx, branch_id, shard_id, as_of_txid, &value, isolation_level)
+				.await?;
 		snapshot.total_value_bytes = snapshot
 			.total_value_bytes
-			.saturating_add(u64::try_from(value.len()).unwrap_or(u64::MAX));
+			.saturating_add(u64::try_from(bytes.len()).unwrap_or(u64::MAX));
 		snapshot.shard_blobs.push(ColdShardBlob {
 			shard_id,
 			as_of_txid,
 			key,
-			bytes: value,
+			bytes,
 		});
 		if snapshot.shard_blobs.len() >= CMP_S3_UPLOAD_MAX_OBJECTS
 			|| snapshot.total_value_bytes >= CMP_S3_UPLOAD_LIMIT_BYTES as u64
@@ -1059,22 +1296,27 @@ pub(crate) fn reclaim_delete_upper_bound(
 
 pub(crate) fn reclaim_delta_shard_ids(
 	branch_id: DatabaseBranchId,
-	delta_chunks: &[(Vec<u8>, Vec<u8>)],
+	snapshot: &ReclaimInputSnapshot,
 ) -> Result<BTreeSet<u32>> {
-	let deltas = decode_hot_delta_chunks(branch_id, delta_chunks)?;
+	let deltas = decode_hot_delta_chunks(branch_id, &snapshot.delta_chunks)?;
 	let mut shard_ids = BTreeSet::new();
 	for delta in deltas.values() {
 		for page in &delta.pages {
 			shard_ids.insert(page.pgno / keys::SHARD_SIZE);
 		}
 	}
+	for (_, pgno, _, _, _) in &snapshot.large_delta_pageidx_entries {
+		shard_ids.insert(*pgno / keys::SHARD_SIZE);
+	}
 	Ok(shard_ids)
 }
 
 pub(crate) fn reclaim_coverage_is_complete(snapshot: &ReclaimInputSnapshot) -> bool {
-	!snapshot.delta_chunks.is_empty()
-		&& snapshot.required_coverage_shard_count > 0
-		&& snapshot.coverage_shards.len() == snapshot.required_coverage_shard_count
+	(!snapshot.delta_chunks.is_empty()
+		|| !snapshot.large_delta_manifests.is_empty()
+		|| !snapshot.large_delta_pageidx_entries.is_empty())
+		&& (snapshot.required_coverage_shard_count == 0
+			|| snapshot.coverage_shards.len() == snapshot.required_coverage_shard_count)
 }
 
 pub(crate) fn selected_hot_coverage_txids(
@@ -1135,7 +1377,14 @@ pub(crate) fn plan_hot_job(
 			max_txid: head.head_txid,
 		},
 		coverage_txids: coverage_txids.clone(),
-		max_pages: u32::try_from(snapshot.hot_inputs.pidx_entries.len()).unwrap_or(u32::MAX),
+		max_pages: u32::try_from(
+			snapshot
+				.hot_inputs
+				.pidx_entries
+				.len()
+				.saturating_add(snapshot.hot_inputs.large_delta_pageidx_entries.len()),
+		)
+		.unwrap_or(u32::MAX),
 		max_bytes: snapshot.hot_inputs.total_value_bytes,
 	};
 	let input_fingerprint = fingerprint_hot_inputs(
@@ -1339,6 +1588,25 @@ pub(crate) fn fingerprint_hot_inputs(
 		update_fingerprint(&mut fingerprint, key);
 		update_fingerprint(&mut fingerprint, value);
 	}
+	for (txid, key, value, manifest) in &hot_inputs.large_delta_manifests {
+		update_fingerprint(&mut fingerprint, &txid.to_be_bytes());
+		update_fingerprint(&mut fingerprint, key);
+		update_fingerprint(&mut fingerprint, value);
+		update_fingerprint(&mut fingerprint, manifest.object_id.as_bytes());
+		update_fingerprint(&mut fingerprint, &manifest.chunk_count.to_be_bytes());
+		update_fingerprint(&mut fingerprint, &manifest.encoded_len.to_be_bytes());
+		update_fingerprint(&mut fingerprint, &manifest.object_hash);
+	}
+	for (txid, pgno, key, value, entry) in &hot_inputs.large_delta_pageidx_entries {
+		update_fingerprint(&mut fingerprint, &txid.to_be_bytes());
+		update_fingerprint(&mut fingerprint, &pgno.to_be_bytes());
+		update_fingerprint(&mut fingerprint, key);
+		update_fingerprint(&mut fingerprint, value);
+		update_fingerprint(&mut fingerprint, entry.object_id.as_bytes());
+		update_fingerprint(&mut fingerprint, &entry.encoded_offset.to_be_bytes());
+		update_fingerprint(&mut fingerprint, &entry.encoded_size.to_be_bytes());
+		update_fingerprint(&mut fingerprint, &entry.page_hash);
+	}
 	for (key, value) in &hot_inputs.pidx_entries {
 		update_fingerprint(&mut fingerprint, key);
 		update_fingerprint(&mut fingerprint, value);
@@ -1388,6 +1656,7 @@ pub(crate) fn fingerprint_reclaim_inputs(
 		);
 		update_fingerprint(&mut fingerprint, &candidate.reference.content_hash);
 		update_fingerprint(&mut fingerprint, &candidate.shard_key);
+		update_fingerprint(&mut fingerprint, &candidate.shard_row_bytes);
 		update_fingerprint(&mut fingerprint, &candidate.shard_bytes);
 		update_fingerprint(&mut fingerprint, &candidate.cold_ref_key);
 		update_fingerprint(&mut fingerprint, &candidate.cold_ref_bytes);
@@ -1399,6 +1668,47 @@ pub(crate) fn fingerprint_reclaim_inputs(
 		update_fingerprint(&mut fingerprint, &commit.versionstamp);
 	}
 	for (key, value) in &reclaim_inputs.delta_chunks {
+		update_fingerprint(&mut fingerprint, key);
+		update_fingerprint(&mut fingerprint, value);
+	}
+	for (txid, key, value, manifest) in &reclaim_inputs.large_delta_manifests {
+		update_fingerprint(&mut fingerprint, &txid.to_be_bytes());
+		update_fingerprint(&mut fingerprint, key);
+		update_fingerprint(&mut fingerprint, value);
+		update_fingerprint(&mut fingerprint, manifest.object_id.as_bytes());
+		update_fingerprint(&mut fingerprint, &manifest.chunk_count.to_be_bytes());
+		update_fingerprint(&mut fingerprint, &manifest.encoded_len.to_be_bytes());
+		update_fingerprint(&mut fingerprint, &manifest.object_hash);
+	}
+	for txid in &reclaim_inputs.large_delta_complete_txids {
+		update_fingerprint(&mut fingerprint, &txid.to_be_bytes());
+	}
+	for (txid, pgno, key, value, entry) in &reclaim_inputs.large_delta_pageidx_entries {
+		update_fingerprint(&mut fingerprint, &txid.to_be_bytes());
+		update_fingerprint(&mut fingerprint, &pgno.to_be_bytes());
+		update_fingerprint(&mut fingerprint, key);
+		update_fingerprint(&mut fingerprint, value);
+		update_fingerprint(&mut fingerprint, entry.object_id.as_bytes());
+		update_fingerprint(&mut fingerprint, &entry.encoded_offset.to_be_bytes());
+		update_fingerprint(&mut fingerprint, &entry.encoded_size.to_be_bytes());
+		update_fingerprint(&mut fingerprint, &entry.page_hash);
+	}
+	for (object_id, key, value) in &reclaim_inputs.large_delta_object_refs {
+		update_fingerprint(&mut fingerprint, object_id.as_bytes());
+		update_fingerprint(&mut fingerprint, key);
+		update_fingerprint(&mut fingerprint, value);
+	}
+	for (object_id, key, value, meta) in &reclaim_inputs.large_delta_object_metas {
+		update_fingerprint(&mut fingerprint, object_id.as_bytes());
+		update_fingerprint(&mut fingerprint, key);
+		update_fingerprint(&mut fingerprint, value);
+		update_fingerprint(&mut fingerprint, &meta.staged_txid.to_be_bytes());
+		update_fingerprint(&mut fingerprint, &meta.chunk_count.to_be_bytes());
+		update_fingerprint(&mut fingerprint, &meta.encoded_len.to_be_bytes());
+		update_fingerprint(&mut fingerprint, &meta.object_hash);
+	}
+	for (object_id, key, value) in &reclaim_inputs.large_delta_object_chunks {
+		update_fingerprint(&mut fingerprint, object_id.as_bytes());
 		update_fingerprint(&mut fingerprint, key);
 		update_fingerprint(&mut fingerprint, value);
 	}
@@ -1501,7 +1811,7 @@ pub(crate) async fn write_staged_hot_shards(
 	head: &DBHead,
 	hot_inputs: &HotInputSnapshot,
 ) -> Result<Vec<HotShardOutputRef>> {
-	let deltas = decode_hot_delta_chunks(input.database_branch_id, &hot_inputs.delta_chunks)?;
+	let deltas = load_hot_delta_pages(tx, input.database_branch_id, hot_inputs).await?;
 	let mut output_refs = Vec::new();
 
 	for as_of_txid in &input.input_range.coverage_txids {
@@ -1516,16 +1826,16 @@ pub(crate) async fn write_staged_hot_shards(
 				page_updates,
 			)
 			.await?;
-			let key = keys::branch_compaction_stage_hot_shard_key(
+			let content_hash = content_hash(&encoded);
+
+			write_staged_hot_shard_chunks(
+				tx,
 				input.database_branch_id,
 				input.job_id,
 				shard_id,
 				*as_of_txid,
-				0,
-			);
-			let content_hash = content_hash(&encoded);
-
-			tx.informal().set(&key, &encoded);
+				&encoded,
+			)?;
 			output_refs.push(HotShardOutputRef {
 				shard_id,
 				as_of_txid: *as_of_txid,
@@ -1538,6 +1848,226 @@ pub(crate) async fn write_staged_hot_shards(
 	}
 
 	Ok(output_refs)
+}
+
+fn write_staged_hot_shard_chunks(
+	tx: &universaldb::Transaction,
+	branch_id: DatabaseBranchId,
+	job_id: Id,
+	shard_id: u32,
+	as_of_txid: u64,
+	blob: &[u8],
+) -> Result<()> {
+	for (chunk_idx, chunk) in blob.chunks(DELTA_OBJECT_CHUNK_BYTES).enumerate() {
+		let chunk_idx =
+			u32::try_from(chunk_idx).context("sqlite staged hot shard chunk index exceeded u32")?;
+		tx.informal().set(
+			&keys::branch_compaction_stage_hot_shard_key(
+				branch_id, job_id, shard_id, as_of_txid, chunk_idx,
+			),
+			chunk,
+		);
+	}
+
+	Ok(())
+}
+
+pub(crate) async fn load_staged_hot_shard_blob(
+	tx: &universaldb::Transaction,
+	branch_id: DatabaseBranchId,
+	job_id: Id,
+	output_ref: &HotShardOutputRef,
+	isolation_level: universaldb::utils::IsolationLevel,
+) -> Result<Option<Vec<u8>>> {
+	let prefix = keys::branch_compaction_stage_hot_shard_chunk_prefix(
+		branch_id,
+		job_id,
+		output_ref.shard_id,
+		output_ref.as_of_txid,
+	);
+	let mut chunks = tx_scan_prefix_values(tx, &prefix, isolation_level).await?;
+	if chunks.is_empty() {
+		return Ok(None);
+	}
+	chunks.sort_by_key(|(key, _)| key.clone());
+
+	let mut blob = Vec::new();
+	for (expected_idx, (key, chunk)) in chunks.into_iter().enumerate() {
+		let chunk_idx = decode_staged_hot_shard_chunk_idx(&prefix, &key)?;
+		ensure!(
+			chunk_idx == u32::try_from(expected_idx).unwrap_or(u32::MAX),
+			"sqlite staged hot shard chunks must be contiguous from chunk 0"
+		);
+		blob.extend_from_slice(&chunk);
+	}
+
+	Ok(Some(blob))
+}
+
+pub(crate) async fn clear_staged_hot_shard_blob(
+	tx: &universaldb::Transaction,
+	branch_id: DatabaseBranchId,
+	job_id: Id,
+	output_ref: &HotShardOutputRef,
+	isolation_level: universaldb::utils::IsolationLevel,
+) -> Result<()> {
+	let prefix = keys::branch_compaction_stage_hot_shard_chunk_prefix(
+		branch_id,
+		job_id,
+		output_ref.shard_id,
+		output_ref.as_of_txid,
+	);
+	for (key, _) in tx_scan_prefix_values(tx, &prefix, isolation_level).await? {
+		tx.informal().clear(&key);
+	}
+
+	Ok(())
+}
+
+fn decode_staged_hot_shard_chunk_idx(prefix: &[u8], key: &[u8]) -> Result<u32> {
+	let suffix = key
+		.strip_prefix(prefix)
+		.context("sqlite staged hot shard chunk key did not start with expected prefix")?;
+	let bytes: [u8; std::mem::size_of::<u32>()] = suffix.try_into().with_context(|| {
+		format!(
+			"sqlite staged hot shard chunk key suffix had {} bytes, expected {}",
+			suffix.len(),
+			std::mem::size_of::<u32>()
+		)
+	})?;
+
+	Ok(u32::from_be_bytes(bytes))
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct HotDeltaPages {
+	pub(crate) pages: Vec<DirtyPage>,
+}
+
+pub(crate) async fn load_hot_delta_pages(
+	tx: &universaldb::Transaction,
+	branch_id: DatabaseBranchId,
+	hot_inputs: &HotInputSnapshot,
+) -> Result<BTreeMap<u64, HotDeltaPages>> {
+	let mut deltas = decode_hot_delta_chunks(branch_id, &hot_inputs.delta_chunks)?
+		.into_iter()
+		.map(|(txid, decoded)| {
+			(
+				txid,
+				HotDeltaPages {
+					pages: decoded.pages,
+				},
+			)
+		})
+		.collect::<BTreeMap<_, _>>();
+	let manifests = hot_inputs
+		.large_delta_manifests
+		.iter()
+		.map(|(txid, _, _, manifest)| (*txid, manifest.clone()))
+		.collect::<BTreeMap<_, _>>();
+
+	for (txid, pgno, _, _, page_index) in &hot_inputs.large_delta_pageidx_entries {
+		let manifest = manifests
+			.get(txid)
+			.with_context(|| format!("sqlite large delta manifest missing for hot txid {txid}"))?;
+		let page = load_large_delta_page(tx, branch_id, manifest, page_index, *pgno).await?;
+		deltas
+			.entry(*txid)
+			.or_insert_with(|| HotDeltaPages { pages: Vec::new() })
+			.pages
+			.push(page);
+	}
+
+	for delta in deltas.values_mut() {
+		delta.pages.sort_by_key(|page| page.pgno);
+	}
+
+	Ok(deltas)
+}
+
+pub(crate) async fn load_large_delta_page(
+	tx: &universaldb::Transaction,
+	branch_id: DatabaseBranchId,
+	manifest: &DeltaManifest,
+	page_index: &DeltaPageIndexEntry,
+	pgno: u32,
+) -> Result<DirtyPage> {
+	ensure!(
+		page_index.txid == manifest.txid,
+		"sqlite large delta page index txid {} did not match manifest txid {}",
+		page_index.txid,
+		manifest.txid
+	);
+	ensure!(
+		page_index.object_id == manifest.object_id,
+		"sqlite large delta page index object did not match manifest object"
+	);
+
+	let encoded_size = page_index.encoded_size as u64;
+	let encoded_end = page_index
+		.encoded_offset
+		.checked_add(encoded_size)
+		.context("sqlite large delta page byte range overflowed")?;
+	ensure!(
+		encoded_end <= manifest.encoded_len,
+		"sqlite large delta page byte range exceeded object length"
+	);
+
+	let first_chunk = page_index.encoded_offset / DELTA_OBJECT_CHUNK_BYTES as u64;
+	let last_chunk = (encoded_end.saturating_sub(1)) / DELTA_OBJECT_CHUNK_BYTES as u64;
+	ensure!(
+		last_chunk < u64::from(manifest.chunk_count),
+		"sqlite large delta page byte range exceeded object chunk count"
+	);
+
+	let mut object_bytes = Vec::new();
+	for chunk_idx in first_chunk..=last_chunk {
+		let chunk_idx =
+			u32::try_from(chunk_idx).context("sqlite large delta chunk index exceeded u32")?;
+		let chunk = tx_get_value(
+			tx,
+			&keys::branch_delta_object_chunk_key(branch_id, manifest.object_id, chunk_idx),
+			Snapshot,
+		)
+		.await?
+		.with_context(|| {
+			format!(
+				"sqlite large delta object chunk missing for txid {} chunk {}",
+				manifest.txid, chunk_idx
+			)
+		})?;
+		object_bytes.extend_from_slice(&chunk);
+	}
+
+	let chunk_base_offset = first_chunk * DELTA_OBJECT_CHUNK_BYTES as u64;
+	let slice_start = usize::try_from(page_index.encoded_offset - chunk_base_offset)
+		.context("sqlite large delta slice start exceeded usize")?;
+	let slice_len =
+		usize::try_from(encoded_size).context("sqlite large delta slice length exceeded usize")?;
+	let slice_end = slice_start
+		.checked_add(slice_len)
+		.context("sqlite large delta slice end overflowed")?;
+	ensure!(
+		slice_end <= object_bytes.len(),
+		"sqlite large delta page byte range exceeded fetched chunks"
+	);
+
+	let page = decode_ltx_page_frame(&object_bytes[slice_start..slice_end], pgno, keys::PAGE_SIZE)
+		.with_context(|| {
+			format!(
+				"decode sqlite large delta page frame for txid {} page {}",
+				manifest.txid, pgno
+			)
+		})?;
+	let digest = Sha256::digest(&page.bytes);
+	ensure!(
+		digest.as_slice() == page_index.page_hash,
+		"sqlite large delta page hash mismatch for txid {} page {}",
+		manifest.txid,
+		pgno
+	);
+
+	Ok(page)
 }
 
 pub(crate) fn decode_hot_delta_chunks(
@@ -1568,7 +2098,7 @@ pub(crate) fn decode_hot_delta_chunks(
 
 pub(crate) fn collect_hot_pages_by_shard(
 	head: &DBHead,
-	deltas: &BTreeMap<u64, DecodedLtx>,
+	deltas: &BTreeMap<u64, HotDeltaPages>,
 	as_of_txid: u64,
 ) -> Result<BTreeMap<u32, Vec<(u32, Vec<u8>)>>> {
 	let mut pages_by_number = BTreeMap::<u32, Vec<u8>>::new();
@@ -1669,10 +2199,30 @@ pub(crate) async fn load_latest_branch_shard_blob(
 
 	let mut latest = None;
 	while let Some(entry) = stream.try_next().await? {
-		latest = Some(entry.value().to_vec());
+		latest = Some((entry.key().to_vec(), entry.value().to_vec()));
 	}
 
-	Ok(latest)
+	let Some((key, value)) = latest else {
+		return Ok(None);
+	};
+	let Some((latest_shard_id, latest_as_of_txid)) = decode_branch_shard_version_key(branch_id, &key)?
+	else {
+		return Ok(None);
+	};
+	ensure!(
+		latest_shard_id == shard_id,
+		"sqlite latest branch shard key did not match requested shard"
+	);
+	resolve_branch_shard_value(
+		tx,
+		branch_id,
+		latest_shard_id,
+		latest_as_of_txid,
+		&value,
+		Snapshot,
+	)
+	.await
+	.map(Some)
 }
 
 pub(crate) fn decode_branch_pidx_pgno(branch_id: DatabaseBranchId, key: &[u8]) -> Result<u32> {

--- a/engine/packages/depot/src/compaction/types.rs
+++ b/engine/packages/depot/src/compaction/types.rs
@@ -16,24 +16,28 @@ pub(crate) use universaldb::{
 		end_of_key_range,
 	},
 };
+pub(crate) use uuid::Uuid;
 
 pub(crate) use crate::{
 	ACCESS_TOUCH_THROTTLE_MS, CMP_COLD_OBJECT_DELETE_GRACE_MS, CMP_FDB_BATCH_MAX_KEYS,
 	CMP_FDB_BATCH_MAX_VALUE_BYTES, CMP_S3_DELETE_MAX_OBJECTS, CMP_S3_UPLOAD_LIMIT_BYTES,
-	CMP_S3_UPLOAD_MAX_OBJECTS, HOT_BURST_COLD_LAG_THRESHOLD_TXIDS, MAX_BUCKET_DEPTH,
+	CMP_S3_UPLOAD_MAX_OBJECTS, DELTA_OBJECT_CHUNK_BYTES, HOT_BURST_COLD_LAG_THRESHOLD_TXIDS,
+	MAX_BUCKET_DEPTH,
 	cold_tier::{ColdTier, cold_tier_from_config},
 	conveyer::{
 		history_pin, keys,
-		ltx::{DecodedLtx, LtxHeader, decode_ltx_v3, encode_ltx_v3},
+		ltx::{DecodedLtx, LtxHeader, decode_ltx_page_frame, decode_ltx_v3, encode_ltx_v3},
 		quota,
 		types::{
 			BranchState, BucketCatalogDbFact, BucketForkFact, BucketId, ColdShardRef, CommitRow,
 			CompactionRoot, DBHead, DatabaseBranchId, DatabaseBranchRecord, DbHistoryPin,
-			DirtyPage, PitrIntervalCoverage, PitrPolicy, RetiredColdObject,
+			DeltaManifest, DeltaObjectMeta, DeltaPageIndexEntry, DirtyPage, PitrIntervalCoverage,
+			PitrPolicy, RetiredColdObject,
 			RetiredColdObjectDeleteState, ShardCachePolicy, SqliteCmpDirty,
 			decode_bucket_catalog_db_fact, decode_bucket_fork_fact, decode_bucket_pointer,
 			decode_cold_shard_ref, decode_commit_row, decode_compaction_root,
 			decode_database_branch_record, decode_database_pointer, decode_db_head,
+			decode_delta_manifest, decode_delta_object_meta, decode_delta_page_index_entry,
 			decode_pitr_interval_coverage, decode_pitr_policy, decode_retired_cold_object,
 			decode_shard_cache_policy, decode_sqlite_cmp_dirty, encode_cold_shard_ref,
 			encode_compaction_root, encode_pitr_interval_coverage, encode_retired_cold_object,
@@ -1074,6 +1078,8 @@ pub(crate) struct HotInputSnapshot {
 	pub(crate) commits: Vec<(u64, CommitRow)>,
 	pub(crate) pitr_interval_coverage: Vec<PitrIntervalSelection>,
 	pub(crate) delta_chunks: Vec<(Vec<u8>, Vec<u8>)>,
+	pub(crate) large_delta_manifests: Vec<(u64, Vec<u8>, Vec<u8>, DeltaManifest)>,
+	pub(crate) large_delta_pageidx_entries: Vec<(u64, u32, Vec<u8>, Vec<u8>, DeltaPageIndexEntry)>,
 	pub(crate) pidx_entries: Vec<(Vec<u8>, Vec<u8>)>,
 	pub(crate) total_value_bytes: u64,
 }
@@ -1109,6 +1115,12 @@ pub(crate) struct ReclaimInputSnapshot {
 	pub(crate) expired_pitr_interval_rows: Vec<(i64, Vec<u8>, Vec<u8>, PitrIntervalCoverage)>,
 	pub(crate) commits: Vec<(u64, Vec<u8>, Vec<u8>, CommitRow)>,
 	pub(crate) delta_chunks: Vec<(Vec<u8>, Vec<u8>)>,
+	pub(crate) large_delta_manifests: Vec<(u64, Vec<u8>, Vec<u8>, DeltaManifest)>,
+	pub(crate) large_delta_complete_txids: Vec<u64>,
+	pub(crate) large_delta_pageidx_entries: Vec<(u64, u32, Vec<u8>, Vec<u8>, DeltaPageIndexEntry)>,
+	pub(crate) large_delta_object_refs: Vec<(Uuid, Vec<u8>, Vec<u8>)>,
+	pub(crate) large_delta_object_metas: Vec<(Uuid, Vec<u8>, Vec<u8>, DeltaObjectMeta)>,
+	pub(crate) large_delta_object_chunks: Vec<(Uuid, Vec<u8>, Vec<u8>)>,
 	pub(crate) pidx_entries: Vec<(Vec<u8>, Vec<u8>)>,
 	pub(crate) coverage_shards: Vec<(Vec<u8>, Vec<u8>)>,
 	pub(crate) required_coverage_shard_count: usize,
@@ -1119,6 +1131,7 @@ pub(crate) struct ReclaimInputSnapshot {
 pub(crate) struct ShardCacheEvictionCandidate {
 	pub(crate) reference: ShardCacheEvictionRef,
 	pub(crate) shard_key: Vec<u8>,
+	pub(crate) shard_row_bytes: Vec<u8>,
 	pub(crate) shard_bytes: Vec<u8>,
 	pub(crate) cold_ref_key: Vec<u8>,
 	pub(crate) cold_ref_bytes: Vec<u8>,

--- a/engine/packages/depot/src/conveyer/commit.rs
+++ b/engine/packages/depot/src/conveyer/commit.rs
@@ -4,6 +4,7 @@ mod apply;
 mod branch_init;
 mod dirty;
 mod helpers;
+mod large;
 mod truncate;
 
 #[cfg(debug_assertions)]
@@ -13,3 +14,4 @@ pub mod test_hooks;
 mod test_hooks;
 
 pub use dirty::clear_sqlite_cmp_dirty_if_observed_idle;
+pub use large::{CommitStageGcOutcome, OrphanDeltaObjectGcOutcome};

--- a/engine/packages/depot/src/conveyer/commit/apply.rs
+++ b/engine/packages/depot/src/conveyer/commit/apply.rs
@@ -461,7 +461,8 @@ impl Db {
 					})
 				}
 			})
-			.await?;
+			.await
+			.map_err(map_udb_commit_error)?;
 		#[cfg(feature = "test-faults")]
 		maybe_fire_commit_fault(
 			&self.fault_controller,
@@ -561,6 +562,24 @@ impl Db {
 		*self.last_deltas_available_at_ms.write().await = Some(signal_at_ms);
 		Ok(())
 	}
+}
+
+fn map_udb_commit_error(err: anyhow::Error) -> anyhow::Error {
+	for source in err.chain() {
+		if let Some(universaldb::error::DatabaseError::TransactionTooLarge {
+			actual_size_bytes,
+			max_size_bytes,
+		}) = source.downcast_ref::<universaldb::error::DatabaseError>()
+		{
+			return SqliteStorageError::CommitTooLarge {
+				actual_size_bytes: *actual_size_bytes as u64,
+				max_size_bytes: *max_size_bytes as u64,
+			}
+			.into();
+		}
+	}
+
+	err
 }
 
 #[cfg(feature = "test-faults")]

--- a/engine/packages/depot/src/conveyer/commit/apply.rs
+++ b/engine/packages/depot/src/conveyer/commit/apply.rs
@@ -35,6 +35,10 @@ use super::{
 	branch_init::{resolve_or_allocate_branch, write_root_branch_metadata},
 	dirty::admit_deltas_available,
 	helpers::{tracked_entry_size, tx_get_value},
+	large::{
+		MAX_SQLITE_COMMIT_DIRTY_BYTES, MAX_SQLITE_COMMIT_DIRTY_PAGES,
+		SLOW_COMMIT_DIRTY_BYTES_THRESHOLD,
+	},
 	test_hooks,
 	truncate::{collect_truncate_cleanup, fence_truncate_cleanup_row},
 };
@@ -60,7 +64,7 @@ impl Db {
 		now_ms: i64,
 		options: CommitOptions,
 	) -> Result<CommitResult> {
-		validate_dirty_pages(&dirty_pages)?;
+		let dirty_bytes = validate_dirty_pages(&dirty_pages)?;
 		#[cfg(feature = "test-faults")]
 		maybe_fire_commit_fault(
 			&self.fault_controller,
@@ -78,6 +82,12 @@ impl Db {
 		metrics::SQLITE_PUMP_COMMIT_DIRTY_PAGE_COUNT
 			.with_label_values(labels)
 			.observe(dirty_pages.len() as f64);
+
+		if dirty_bytes > SLOW_COMMIT_DIRTY_BYTES_THRESHOLD {
+			return self
+				.commit_slow_with_options(dirty_pages, db_size_pages, now_ms, options)
+				.await;
+		}
 
 		let cached_storage_used = *self.storage_used.read().await;
 		let cached_snapshot = self.cache_snapshot.read().await.clone();
@@ -522,7 +532,7 @@ impl Db {
 		})
 	}
 
-	async fn publish_deltas_available_if_needed(
+	pub(super) async fn publish_deltas_available_if_needed(
 		&self,
 		signal: Option<DeltasAvailable>,
 		branch_id: DatabaseBranchId,
@@ -583,7 +593,7 @@ fn map_udb_commit_error(err: anyhow::Error) -> anyhow::Error {
 }
 
 #[cfg(feature = "test-faults")]
-async fn maybe_fire_commit_fault(
+pub(super) async fn maybe_fire_commit_fault(
 	controller: &Option<DepotFaultController>,
 	database_id: &str,
 	point: CommitFaultPoint,
@@ -603,8 +613,18 @@ async fn maybe_fire_commit_fault(
 	Ok(())
 }
 
-fn validate_dirty_pages(dirty_pages: &[DirtyPage]) -> Result<()> {
+fn validate_dirty_pages(dirty_pages: &[DirtyPage]) -> Result<usize> {
+	if dirty_pages.len() > MAX_SQLITE_COMMIT_DIRTY_PAGES {
+		return Err(SqliteStorageError::SqliteCommitPageLimitExceeded {
+			dirty_page_count: u32::try_from(dirty_pages.len()).unwrap_or(u32::MAX),
+			max_dirty_pages: MAX_SQLITE_COMMIT_DIRTY_PAGES as u32,
+			page_size_bytes: keys::PAGE_SIZE,
+		}
+		.into());
+	}
+
 	let mut seen = BTreeSet::new();
+	let mut dirty_bytes = 0usize;
 	for page in dirty_pages {
 		ensure!(page.pgno > 0, "sqlite commit does not accept page 0");
 		ensure!(
@@ -619,9 +639,20 @@ fn validate_dirty_pages(dirty_pages: &[DirtyPage]) -> Result<()> {
 			"sqlite commit duplicated page {} in a single request",
 			page.pgno
 		);
+		dirty_bytes = dirty_bytes
+			.checked_add(page.bytes.len())
+			.context("sqlite dirty page byte count overflowed")?;
 	}
 
-	Ok(())
+	if dirty_bytes > MAX_SQLITE_COMMIT_DIRTY_BYTES {
+		return Err(SqliteStorageError::CommitTooLarge {
+			actual_size_bytes: dirty_bytes as u64,
+			max_size_bytes: MAX_SQLITE_COMMIT_DIRTY_BYTES as u64,
+		}
+		.into());
+	}
+
+	Ok(dirty_bytes)
 }
 
 struct CommitTxResult {

--- a/engine/packages/depot/src/conveyer/commit/large.rs
+++ b/engine/packages/depot/src/conveyer/commit/large.rs
@@ -1,0 +1,2009 @@
+use std::{
+	collections::{BTreeMap, BTreeSet},
+	sync::Arc,
+};
+
+use anyhow::{Context, Result, ensure};
+use sha2::{Digest, Sha256};
+use universaldb::{
+	options::MutationType,
+	utils::IsolationLevel::{Serializable, Snapshot},
+};
+use uuid::Uuid;
+
+use crate::{
+	burst_mode,
+	conveyer::{
+		Db, branch,
+		constants::DELTA_OBJECT_CHUNK_BYTES,
+		db::{BranchAncestry, CacheSnapshot, load_branch_ancestry, touch_access_if_bucket_advanced},
+		error::SqliteStorageError,
+		keys,
+		ltx::{LtxEncoder, LtxHeader, LtxPageIndexEntry},
+		page_index::DeltaPageIndex,
+		quota,
+		types::{
+			BranchState, CommitOptions, CommitResult, CommitRow, CommitStageBeginResult,
+			CommitStageComplete, CommitStageFinalized, CommitStageMeta, CommitStageState, DBHead,
+			DatabaseBranchId, DeltaManifest, DeltaObjectMeta, DeltaObjectState,
+			DeltaPageIndexEntry, DirtyPage, DirtyPageBatch, decode_commit_stage_complete,
+			decode_commit_stage_finalized, decode_commit_stage_meta, decode_compaction_root,
+			decode_database_branch_record, decode_db_head, decode_delta_object_meta,
+			decode_dirty_page_batch, encode_commit_row, encode_commit_stage_complete,
+			encode_commit_stage_finalized, encode_commit_stage_meta, encode_db_head,
+			encode_delta_manifest, encode_delta_object_meta, encode_delta_page_index_entry,
+			encode_dirty_page_batch,
+		},
+		udb,
+	},
+	workflows::compaction::DeltasAvailable,
+};
+
+use super::{
+	branch_init::{BranchResolution, resolve_or_allocate_branch, write_root_branch_metadata},
+	dirty::admit_deltas_available,
+	helpers::{tracked_entry_size, tx_get_value, tx_scan_prefix_values},
+	test_hooks,
+	truncate::{collect_truncate_cleanup, fence_truncate_cleanup_row},
+};
+
+pub(super) const MAX_SQLITE_COMMIT_DIRTY_PAGES: usize = 8_192;
+pub(super) const MAX_SQLITE_COMMIT_DIRTY_BYTES: usize = 32 * 1024 * 1024;
+pub(super) const SLOW_COMMIT_DIRTY_BYTES_THRESHOLD: usize = 8 * 1024 * 1024;
+
+const DELTA_OBJECT_WRITE_BATCH_BYTES: usize = 8 * 1024 * 1024;
+const STAGE_TTL_MS: i64 = 24 * 60 * 60 * 1_000;
+const MAX_STAGE_PAGES_PER_BATCH: usize = 16;
+const MAX_STAGE_BATCH_BYTES: usize = 96 * 1024;
+const STAGE_RESERVATION_HEADROOM_BYTES: i64 = 2 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CommitStageGcOutcome {
+	pub stages_deleted: usize,
+	pub finalized_tombstones_deleted: usize,
+	pub stale_lookups_deleted: usize,
+	pub quota_released_bytes: i64,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct OrphanDeltaObjectGcOutcome {
+	pub stages_deleted: usize,
+	pub orphan_objects_deleted: usize,
+	pub quota_released_bytes: i64,
+}
+
+impl Db {
+	pub(super) async fn commit_slow_with_options(
+		&self,
+		dirty_pages: Vec<DirtyPage>,
+		db_size_pages: u32,
+		now_ms: i64,
+		options: CommitOptions,
+	) -> Result<CommitResult> {
+		let cached_storage_used = *self.storage_used.read().await;
+		let cached_snapshot = self.cache_snapshot.read().await.clone();
+		let cached_branch_id = cached_snapshot.as_ref().map(|snapshot| snapshot.branch_id);
+		let cached_ancestry = cached_snapshot
+			.as_ref()
+			.map(|snapshot| snapshot.ancestors.clone());
+		let cached_access_bucket = cached_snapshot
+			.as_ref()
+			.and_then(|snapshot| snapshot.last_access_bucket);
+		let last_deltas_available_at_ms = *self.last_deltas_available_at_ms.read().await;
+		let cache_was_warm = cached_snapshot
+			.as_ref()
+			.is_some_and(|snapshot| !snapshot.pidx.range(0, u32::MAX).is_empty());
+
+		let preflight = self
+			.prepare_slow_commit(
+				cached_branch_id,
+				cached_ancestry,
+				options.expected_head_txid,
+			)
+			.await?;
+		let staged_txid = preflight
+			.observed_head_txid
+			.checked_add(1)
+			.context("sqlite head txid overflowed")?;
+		let object = build_delta_object(staged_txid, db_size_pages, now_ms, &dirty_pages)?;
+
+		tracing::debug!(
+			database_id = %self.database_id,
+			branch_id = ?preflight.branch_id,
+			stage_id = %object.stage_id,
+			object_id = %object.object_id,
+			dirty_page_count = dirty_pages.len(),
+			staged_bytes = object.encoded_len,
+			staged_txid,
+			"sqlite large commit writing staged object"
+		);
+		self.write_delta_object(preflight.branch_id, &object).await?;
+
+		let result = self
+			.finalize_slow_commit(
+				preflight.clone(),
+				object,
+				dirty_pages,
+				db_size_pages,
+				now_ms,
+				options,
+				cached_storage_used,
+				cached_access_bucket,
+				last_deltas_available_at_ms,
+				None,
+			)
+			.await
+			.map_err(map_udb_commit_error)?;
+
+		*self.storage_used.write().await = Some(result.storage_used);
+		self.commit_bytes_since_rollup.fetch_add(
+			u64::try_from(result.added_bytes)
+				.context("commit added bytes should be non-negative")?,
+			std::sync::atomic::Ordering::Relaxed,
+		);
+
+		let mut cache_snapshot = self.cache_snapshot.write().await;
+		let current_branch_id = cache_snapshot.as_ref().map(|snapshot| snapshot.branch_id);
+		let publish_branch_changed =
+			current_branch_id.is_some_and(|branch_id| branch_id != result.branch_id);
+		let pidx = if publish_branch_changed {
+			Arc::new(DeltaPageIndex::new())
+		} else {
+			cache_snapshot
+				.as_ref()
+				.map(|snapshot| Arc::clone(&snapshot.pidx))
+				.unwrap_or_else(|| Arc::new(DeltaPageIndex::new()))
+		};
+		let pidx_was_warm = !pidx.range(0, u32::MAX).is_empty();
+		if cache_was_warm || pidx_was_warm || publish_branch_changed {
+			for pgno in result.truncated_pgnos {
+				pidx.remove(pgno);
+			}
+			for pgno in result.dirty_pgnos {
+				pidx.insert(pgno, result.txid);
+			}
+		}
+		let last_access_bucket = result.access_bucket.or_else(|| {
+			cache_snapshot
+				.as_ref()
+				.filter(|snapshot| snapshot.branch_id == result.branch_id)
+				.and_then(|snapshot| snapshot.last_access_bucket)
+		});
+		*cache_snapshot = Some(CacheSnapshot {
+			branch_id: result.branch_id,
+			ancestors: result.branch_ancestry.clone(),
+			last_access_bucket,
+			pidx,
+		});
+
+		self.publish_deltas_available_if_needed(result.deltas_available, result.branch_id)
+			.await?;
+
+		Ok(CommitResult {
+			head_txid: result.txid,
+			db_size_pages,
+		})
+	}
+
+	pub async fn commit_stage_begin(
+		&self,
+		dirty_pgnos: Vec<u32>,
+		db_size_pages: u32,
+		now_ms: i64,
+		options: CommitOptions,
+	) -> Result<CommitStageBeginResult> {
+		validate_stage_dirty_pgnos(&dirty_pgnos)?;
+		let preflight = self
+			.prepare_slow_commit(None, None, options.expected_head_txid)
+			.await?;
+		let staged_txid = preflight
+			.observed_head_txid
+			.checked_add(1)
+			.context("sqlite staged txid overflowed")?;
+		let stage_id = Uuid::new_v4();
+		let object_id = Uuid::new_v4();
+		let dirty_page_count =
+			u32::try_from(dirty_pgnos.len()).context("sqlite dirty page count exceeded u32")?;
+		let reserved_storage_bytes =
+			estimate_stage_reservation(preflight.branch_id, object_id, staged_txid, &dirty_pgnos)?;
+		let meta = CommitStageMeta {
+			stage_id,
+			object_id,
+			observed_head_txid: preflight.observed_head_txid,
+			staged_txid,
+			caller_expected_head_txid: options.expected_head_txid,
+			db_size_pages,
+			now_ms,
+			dirty_page_count,
+			dirty_pgnos_hash: hash_dirty_pgnos(&dirty_pgnos),
+			reserved_storage_bytes,
+			state: CommitStageState::Uploading,
+			created_at_ms: now_ms,
+			expires_after_ms: now_ms.saturating_add(STAGE_TTL_MS),
+		};
+		let encoded_meta = encode_commit_stage_meta(meta)?;
+		let stage_key = keys::branch_commit_stage_meta_key(preflight.branch_id, stage_id);
+		let lookup_key = keys::commit_stage_lookup_key(stage_id);
+		let branch_id_bytes = preflight.branch_id.as_uuid().as_bytes().to_vec();
+		let branch_id = preflight.branch_id;
+
+		self.udb
+			.run(move |tx| {
+				let stage_key = stage_key.clone();
+				let lookup_key = lookup_key.clone();
+				let encoded_meta = encoded_meta.clone();
+				let branch_id_bytes = branch_id_bytes.clone();
+				async move {
+					if tx_get_value(&tx, &lookup_key, Serializable).await?.is_some() {
+						return Err(SqliteStorageError::SqliteCommitStageInvalid {
+							reason: format!("stage id collision for {stage_id}"),
+						}
+						.into());
+					}
+					let committed = quota::read_branch(&tx, branch_id).await?;
+					let staged = quota::read_branch_staged(&tx, branch_id).await?;
+					let would_be = committed
+						.checked_add(staged)
+						.and_then(|value| value.checked_add(reserved_storage_bytes))
+						.context("sqlite staged quota reservation overflowed")?;
+					quota::cap_check(would_be)?;
+					tx.informal().set(&stage_key, &encoded_meta);
+					tx.informal().set(&lookup_key, &branch_id_bytes);
+					quota::atomic_add_branch_staged(&tx, branch_id, reserved_storage_bytes);
+					Ok(())
+				}
+			})
+			.await?;
+
+		tracing::debug!(
+			database_id = %self.database_id,
+			?branch_id,
+			%stage_id,
+			%object_id,
+			dirty_page_count,
+			reserved_storage_bytes,
+			staged_txid,
+			"sqlite commit stage begun"
+		);
+
+		Ok(CommitStageBeginResult {
+			stage_id,
+			max_pages_per_batch: MAX_STAGE_PAGES_PER_BATCH as u32,
+			max_batch_bytes: MAX_STAGE_BATCH_BYTES as u32,
+			observed_head_txid: preflight.observed_head_txid,
+			staged_txid,
+		})
+	}
+
+	pub async fn commit_stage_pages(
+		&self,
+		stage_id: Uuid,
+		batch_idx: u32,
+		pages: Vec<DirtyPage>,
+	) -> Result<()> {
+		let stage = self.load_commit_stage(stage_id).await?;
+		if !matches!(stage.meta.state, CommitStageState::Uploading) {
+			return Err(SqliteStorageError::SqliteCommitStageInvalid {
+				reason: format!("stage {stage_id} is not accepting page batches"),
+			}
+			.into());
+		}
+		validate_stage_page_batch(&pages)?;
+		let batch = DirtyPageBatch {
+			batch_idx,
+			batch_hash: hash_dirty_pages(&pages),
+			pages,
+		};
+		let encoded_batch = encode_dirty_page_batch(batch)?;
+		ensure!(
+			encoded_batch.len() <= MAX_STAGE_BATCH_BYTES,
+			"sqlite commit stage batch encoded to {} bytes, limit is {} bytes",
+			encoded_batch.len(),
+			MAX_STAGE_BATCH_BYTES
+		);
+
+		let batch_key = keys::branch_commit_stage_pages_key(stage.branch_id, stage_id, batch_idx);
+		let meta_key = keys::branch_commit_stage_meta_key(stage.branch_id, stage_id);
+		self.udb
+			.run(move |tx| {
+				let batch_key = batch_key.clone();
+				let meta_key = meta_key.clone();
+				let encoded_batch = encoded_batch.clone();
+				async move {
+					let meta_bytes = tx_get_value(&tx, &meta_key, Serializable)
+						.await?
+						.ok_or(SqliteStorageError::SqliteCommitStageNotFound { stage_id })?;
+					let meta = decode_commit_stage_meta(&meta_bytes)?;
+					if !matches!(meta.state, CommitStageState::Uploading) {
+						return Err(SqliteStorageError::SqliteCommitStageInvalid {
+							reason: format!("stage {stage_id} is not accepting page batches"),
+						}
+						.into());
+					}
+					if let Some(existing) = tx_get_value(&tx, &batch_key, Serializable).await? {
+						if existing == encoded_batch {
+							return Ok(());
+						}
+						return Err(SqliteStorageError::SqliteCommitStageInvalid {
+							reason: format!("stage {stage_id} batch {batch_idx} changed"),
+						}
+						.into());
+					}
+					tx.informal().set(&batch_key, &encoded_batch);
+					Ok(())
+				}
+			})
+			.await
+	}
+
+	pub async fn commit_stage_complete(&self, stage_id: Uuid, page_batch_count: u32) -> Result<()> {
+		let stage = self.load_commit_stage(stage_id).await?;
+		match stage.meta.state {
+			CommitStageState::ObjectWritten | CommitStageState::Finalized { .. } => return Ok(()),
+			CommitStageState::Uploading | CommitStageState::Complete => {}
+			CommitStageState::Finalizing | CommitStageState::Aborted => {
+				return Err(SqliteStorageError::SqliteCommitStageInvalid {
+					reason: format!("stage {stage_id} cannot be completed from its current state"),
+				}
+				.into());
+			}
+		}
+
+		let dirty_pages = self
+			.load_stage_pages(stage.branch_id, &stage.meta, page_batch_count)
+			.await?;
+		let object = build_delta_object_with_ids(
+			stage.meta.staged_txid,
+			stage.meta.db_size_pages,
+			stage.meta.now_ms,
+			stage.meta.stage_id,
+			stage.meta.object_id,
+			&dirty_pages,
+		)?;
+		self.write_delta_object(stage.branch_id, &object).await?;
+
+		let mut updated_meta = stage.meta.clone();
+		updated_meta.state = CommitStageState::ObjectWritten;
+		let encoded_meta = encode_commit_stage_meta(updated_meta)?;
+		let complete = CommitStageComplete {
+			page_batch_count,
+			dirty_page_count: stage.meta.dirty_page_count,
+			dirty_pages_hash: stage.meta.dirty_pgnos_hash,
+			completed_at_ms: stage.meta.now_ms,
+		};
+		let encoded_complete = encode_commit_stage_complete(complete)?;
+		let meta_key = keys::branch_commit_stage_meta_key(stage.branch_id, stage_id);
+		let complete_key = keys::branch_commit_stage_complete_key(stage.branch_id, stage_id);
+		self.udb
+			.run(move |tx| {
+				let meta_key = meta_key.clone();
+				let complete_key = complete_key.clone();
+				let encoded_meta = encoded_meta.clone();
+				let encoded_complete = encoded_complete.clone();
+				async move {
+					let current_meta = tx_get_value(&tx, &meta_key, Serializable)
+						.await?
+						.ok_or(SqliteStorageError::SqliteCommitStageNotFound { stage_id })?;
+					let current_meta = decode_commit_stage_meta(&current_meta)?;
+					match current_meta.state {
+						CommitStageState::ObjectWritten | CommitStageState::Finalized { .. } => {
+							return Ok(());
+						}
+						CommitStageState::Uploading | CommitStageState::Complete => {}
+						CommitStageState::Finalizing | CommitStageState::Aborted => {
+							return Err(SqliteStorageError::SqliteCommitStageInvalid {
+								reason: format!(
+									"stage {stage_id} cannot be completed from its current state"
+								),
+							}
+							.into());
+						}
+					}
+					tx.informal().set(&complete_key, &encoded_complete);
+					tx.informal().set(&meta_key, &encoded_meta);
+					Ok(())
+				}
+			})
+			.await?;
+
+		tracing::debug!(
+			database_id = %self.database_id,
+			branch_id = ?stage.branch_id,
+			%stage_id,
+			object_id = %stage.meta.object_id,
+			dirty_page_count = stage.meta.dirty_page_count,
+			staged_txid = stage.meta.staged_txid,
+			"sqlite commit stage object written"
+		);
+
+		Ok(())
+	}
+
+	pub async fn commit_stage_finalize(&self, stage_id: Uuid) -> Result<CommitResult> {
+		let stage = self.load_commit_stage(stage_id).await?;
+		if let Some(finalized) = self.read_commit_stage_finalized(&stage).await? {
+			tracing::debug!(
+				database_id = %self.database_id,
+				branch_id = ?stage.branch_id,
+				%stage_id,
+				txid = finalized.txid,
+				"sqlite commit stage finalize retry returned existing txid"
+			);
+			return Ok(CommitResult {
+				head_txid: finalized.txid,
+				db_size_pages: stage.meta.db_size_pages,
+			});
+		}
+		if let CommitStageState::Finalized { txid } = stage.meta.state {
+			return Ok(CommitResult {
+				head_txid: txid,
+				db_size_pages: stage.meta.db_size_pages,
+			});
+		}
+		if !matches!(stage.meta.state, CommitStageState::ObjectWritten) {
+			return Err(SqliteStorageError::SqliteCommitStageInvalid {
+				reason: format!("stage {stage_id} has not finished object staging"),
+			}
+			.into());
+		}
+		let complete = self.load_commit_stage_complete(&stage).await?;
+		let dirty_pages = self
+			.load_stage_pages(stage.branch_id, &stage.meta, complete.page_batch_count)
+			.await?;
+		let object = build_delta_object_with_ids(
+			stage.meta.staged_txid,
+			stage.meta.db_size_pages,
+			stage.meta.now_ms,
+			stage.meta.stage_id,
+			stage.meta.object_id,
+			&dirty_pages,
+		)?;
+		let preflight = self.stage_preflight(stage.branch_id, &stage.meta).await?;
+		let cached_storage_used = *self.storage_used.read().await;
+		let cached_snapshot = self.cache_snapshot.read().await.clone();
+		let cached_access_bucket = cached_snapshot
+			.as_ref()
+			.and_then(|snapshot| snapshot.last_access_bucket);
+		let last_deltas_available_at_ms = *self.last_deltas_available_at_ms.read().await;
+		let cache_was_warm = cached_snapshot
+			.as_ref()
+			.is_some_and(|snapshot| !snapshot.pidx.range(0, u32::MAX).is_empty());
+		let result = self
+			.finalize_slow_commit(
+				preflight,
+				object,
+				dirty_pages,
+				stage.meta.db_size_pages,
+				stage.meta.now_ms,
+				CommitOptions {
+					expected_head_txid: stage.meta.caller_expected_head_txid,
+				},
+				cached_storage_used,
+				cached_access_bucket,
+				last_deltas_available_at_ms,
+				Some(StageFinalizeContext {
+					stage_id,
+					stage_meta: stage.meta.clone(),
+					reserved_storage_bytes: stage.meta.reserved_storage_bytes,
+				}),
+			)
+			.await
+			.map_err(map_udb_commit_error)?;
+
+		self.apply_slow_commit_result_to_cache(cache_was_warm, result)
+			.await?;
+		self.cleanup_stage_upload_rows(stage.branch_id, stage_id)
+			.await?;
+
+		Ok(CommitResult {
+			head_txid: stage.meta.staged_txid,
+			db_size_pages: stage.meta.db_size_pages,
+		})
+	}
+
+	pub async fn commit_stage_abort(&self, stage_id: Uuid) -> Result<()> {
+		let stage = match self.load_commit_stage(stage_id).await {
+			Ok(stage) => stage,
+			Err(err)
+				if err
+					.chain()
+					.any(|source| source.downcast_ref::<SqliteStorageError>().is_some_and(
+						|storage_err| {
+							matches!(
+								storage_err,
+								SqliteStorageError::SqliteCommitStageNotFound { .. }
+							)
+						},
+					)) =>
+			{
+				return Ok(());
+			}
+			Err(err) => return Err(err),
+		};
+		if matches!(stage.meta.state, CommitStageState::Finalized { .. }) {
+			return Ok(());
+		}
+		self.clear_commit_stage(stage.branch_id, &stage.meta, true)
+			.await
+	}
+
+	pub async fn gc_expired_commit_stages(&self, now_ms: i64) -> Result<CommitStageGcOutcome> {
+		let lookup_prefix = keys::commit_stage_lookup_prefix();
+		let rows = self
+			.udb
+			.run(move |tx| {
+				let lookup_prefix = lookup_prefix.clone();
+				async move { tx_scan_prefix_values(&tx, &lookup_prefix).await }
+			})
+			.await?;
+		let mut outcome = CommitStageGcOutcome::default();
+
+		for (lookup_key, branch_bytes) in rows {
+			let stage_id = keys::decode_commit_stage_lookup_id(&lookup_key)
+				.context("decode sqlite commit stage lookup id during GC")?;
+			let branch_uuid = Uuid::from_slice(&branch_bytes)
+				.context("sqlite commit stage lookup had invalid branch id during GC")?;
+			let branch_id = DatabaseBranchId::from_uuid(branch_uuid);
+			let meta_key = keys::branch_commit_stage_meta_key(branch_id, stage_id);
+			let meta_bytes = self
+				.udb
+				.run(move |tx| {
+					let meta_key = meta_key.clone();
+					async move { tx_get_value(&tx, &meta_key, Serializable).await }
+				})
+				.await?;
+			let Some(meta_bytes) = meta_bytes else {
+				self.clear_commit_stage_lookup(stage_id).await?;
+				outcome.stale_lookups_deleted += 1;
+				continue;
+			};
+			let meta = decode_commit_stage_meta(&meta_bytes)
+				.context("decode sqlite commit stage meta during GC")?;
+			if meta.expires_after_ms > now_ms {
+				continue;
+			}
+
+			match meta.state {
+				CommitStageState::Finalized { .. } => {
+					self.clear_finalized_stage_rows(branch_id, stage_id).await?;
+					outcome.finalized_tombstones_deleted += 1;
+				}
+				CommitStageState::Uploading
+				| CommitStageState::Complete
+				| CommitStageState::ObjectWritten
+				| CommitStageState::Finalizing
+				| CommitStageState::Aborted => {
+					let released = meta.reserved_storage_bytes;
+					self.clear_commit_stage(branch_id, &meta, true).await?;
+					outcome.stages_deleted += 1;
+					outcome.quota_released_bytes += released;
+				}
+			}
+		}
+
+		Ok(outcome)
+	}
+
+	pub async fn gc_expired_orphan_delta_objects(
+		&self,
+		branch_id: DatabaseBranchId,
+		now_ms: i64,
+	) -> Result<OrphanDeltaObjectGcOutcome> {
+		let object_root_prefix = keys::branch_delta_object_root_prefix(branch_id);
+		let rows = self
+			.udb
+			.run(move |tx| {
+				let object_root_prefix = object_root_prefix.clone();
+				async move { tx_scan_prefix_values(&tx, &object_root_prefix).await }
+			})
+			.await?;
+		let mut outcome = OrphanDeltaObjectGcOutcome::default();
+
+		for (key, value) in rows {
+			let Ok(object_id) = keys::decode_branch_delta_object_meta_object_id(branch_id, &key) else {
+				continue;
+			};
+			let meta =
+				decode_delta_object_meta(&value).context("decode sqlite delta object meta during GC")?;
+			if meta.expires_after_ms > now_ms {
+				continue;
+			}
+			match meta.state {
+				DeltaObjectState::Committed { .. } => continue,
+				DeltaObjectState::StageOwned => {}
+			}
+
+			if self
+				.delta_object_ref_exists(branch_id, object_id)
+				.await
+				.context("check sqlite delta object ref during orphan GC")?
+			{
+				continue;
+			}
+
+			let stage_meta_key = keys::branch_commit_stage_meta_key(branch_id, meta.stage_id);
+			let stage_meta = self
+				.udb
+				.run(move |tx| {
+					let stage_meta_key = stage_meta_key.clone();
+					async move { tx_get_value(&tx, &stage_meta_key, Serializable).await }
+				})
+				.await?;
+			if let Some(stage_meta_bytes) = stage_meta {
+				let stage_meta = decode_commit_stage_meta(&stage_meta_bytes)
+					.context("decode sqlite commit stage meta during orphan GC")?;
+				if stage_meta.expires_after_ms > now_ms {
+					continue;
+				}
+				if matches!(stage_meta.state, CommitStageState::Finalized { .. }) {
+					continue;
+				}
+				let released = stage_meta.reserved_storage_bytes;
+				self.clear_commit_stage(branch_id, &stage_meta, true).await?;
+				outcome.stages_deleted += 1;
+				outcome.quota_released_bytes += released;
+				continue;
+			}
+
+			if self
+				.clear_delta_object_if_unreferenced(branch_id, object_id, Some(meta.stage_id))
+				.await?
+			{
+				outcome.orphan_objects_deleted += 1;
+			}
+		}
+
+		Ok(outcome)
+	}
+
+	async fn load_commit_stage(&self, stage_id: Uuid) -> Result<LoadedCommitStage> {
+		let lookup_key = keys::commit_stage_lookup_key(stage_id);
+		let udb = self.udb.clone();
+		udb.run(move |tx| {
+			let lookup_key = lookup_key.clone();
+			async move {
+				let branch_bytes = tx_get_value(&tx, &lookup_key, Serializable)
+					.await?
+					.ok_or(SqliteStorageError::SqliteCommitStageNotFound { stage_id })?;
+				let branch_uuid = Uuid::from_slice(&branch_bytes)
+					.context("sqlite commit stage lookup had invalid branch id")?;
+				let branch_id = DatabaseBranchId::from_uuid(branch_uuid);
+				let meta_key = keys::branch_commit_stage_meta_key(branch_id, stage_id);
+				let meta = tx_get_value(&tx, &meta_key, Serializable)
+					.await?
+					.ok_or(SqliteStorageError::SqliteCommitStageNotFound { stage_id })?;
+				Ok(LoadedCommitStage {
+					branch_id,
+					meta: decode_commit_stage_meta(&meta)?,
+				})
+			}
+		})
+		.await
+	}
+
+	async fn load_commit_stage_complete(
+		&self,
+		stage: &LoadedCommitStage,
+	) -> Result<CommitStageComplete> {
+		let key = keys::branch_commit_stage_complete_key(stage.branch_id, stage.meta.stage_id);
+		self.udb
+			.run(move |tx| {
+				let key = key.clone();
+				async move {
+					let value = tx_get_value(&tx, &key, Serializable).await?.ok_or_else(|| {
+						SqliteStorageError::SqliteCommitStageInvalid {
+							reason: "stage complete marker is missing".to_string(),
+						}
+					})?;
+					decode_commit_stage_complete(&value)
+				}
+			})
+			.await
+	}
+
+	async fn read_commit_stage_finalized(
+		&self,
+		stage: &LoadedCommitStage,
+	) -> Result<Option<CommitStageFinalized>> {
+		let key = keys::branch_commit_stage_finalized_key(stage.branch_id, stage.meta.stage_id);
+		self.udb
+			.run(move |tx| {
+				let key = key.clone();
+				async move {
+					tx_get_value(&tx, &key, Serializable)
+						.await?
+						.as_deref()
+						.map(decode_commit_stage_finalized)
+						.transpose()
+				}
+			})
+			.await
+	}
+
+	async fn load_stage_pages(
+		&self,
+		branch_id: DatabaseBranchId,
+		meta: &CommitStageMeta,
+		page_batch_count: u32,
+	) -> Result<Vec<DirtyPage>> {
+		ensure!(page_batch_count > 0, "sqlite commit stage has no page batches");
+		let mut pages_by_pgno = BTreeMap::new();
+		for batch_idx in 0..page_batch_count {
+			let key = keys::branch_commit_stage_pages_key(branch_id, meta.stage_id, batch_idx);
+			let batch = self
+				.udb
+				.run(move |tx| {
+					let key = key.clone();
+					async move {
+						let value = tx_get_value(&tx, &key, Serializable).await?.ok_or_else(|| {
+							SqliteStorageError::SqliteCommitStageInvalid {
+								reason: format!("stage page batch {batch_idx} is missing"),
+							}
+						})?;
+						decode_dirty_page_batch(&value)
+					}
+				})
+				.await?;
+			ensure!(
+				batch.batch_idx == batch_idx,
+				"sqlite commit stage batch index mismatch"
+			);
+			ensure!(
+				batch.batch_hash == hash_dirty_pages(&batch.pages),
+				"sqlite commit stage batch hash mismatch"
+			);
+			for page in batch.pages {
+				validate_stage_dirty_page(&page)?;
+				if pages_by_pgno.insert(page.pgno, page).is_some() {
+					return Err(SqliteStorageError::SqliteCommitStageInvalid {
+						reason: "stage uploaded a duplicate dirty page".to_string(),
+					}
+					.into());
+				}
+			}
+		}
+
+		let dirty_pgnos = pages_by_pgno.keys().copied().collect::<Vec<_>>();
+		if dirty_pgnos.len() != meta.dirty_page_count as usize {
+			return Err(SqliteStorageError::SqliteCommitStageInvalid {
+				reason: format!(
+					"stage uploaded {} pages, expected {}",
+					dirty_pgnos.len(),
+					meta.dirty_page_count
+				),
+			}
+			.into());
+		}
+		if hash_dirty_pgnos(&dirty_pgnos) != meta.dirty_pgnos_hash {
+			return Err(SqliteStorageError::SqliteCommitStageInvalid {
+				reason: "stage uploaded page numbers do not match begin request".to_string(),
+			}
+			.into());
+		}
+
+		Ok(pages_by_pgno.into_values().collect())
+	}
+
+	async fn stage_preflight(
+		&self,
+		branch_id: DatabaseBranchId,
+		meta: &CommitStageMeta,
+	) -> Result<SlowCommitPreflight> {
+		let database_id = self.database_id.clone();
+		let bucket_id = self.sqlite_bucket_id();
+		let observed_head_txid = meta.observed_head_txid;
+		self.udb
+			.run(move |tx| {
+				let database_id = database_id.clone();
+				async move {
+					let bucket = branch::resolve_or_allocate_root_bucket_branch(&tx, bucket_id).await?;
+					let current = branch::resolve_database_branch_in_bucket(
+						&tx,
+						bucket.branch_id,
+						&database_id,
+						Serializable,
+					)
+					.await?;
+					let database_initialized = current.is_none();
+					if let Some(current_branch_id) = current {
+						if current_branch_id != branch_id {
+							let actual_head_txid = read_branch_head_txid(&tx, current_branch_id)
+								.await
+								.unwrap_or(0);
+							return Err(SqliteStorageError::HeadFenceMismatch {
+								expected_head_txid: observed_head_txid,
+								actual_head_txid,
+							}
+							.into());
+						}
+					}
+					let branch_ancestry = if database_initialized {
+						BranchAncestry::root(branch_id)
+					} else {
+						load_branch_ancestry(&tx, branch_id).await?
+					};
+					Ok(SlowCommitPreflight {
+						branch_id,
+						bucket_branch_id: bucket.branch_id,
+						bucket_initialized: bucket.initialized,
+						database_initialized,
+						branch_ancestry,
+						observed_head_txid,
+					})
+				}
+			})
+			.await
+	}
+
+	async fn apply_slow_commit_result_to_cache(
+		&self,
+		cache_was_warm: bool,
+		result: SlowCommitTxResult,
+	) -> Result<()> {
+		*self.storage_used.write().await = Some(result.storage_used);
+		self.commit_bytes_since_rollup.fetch_add(
+			u64::try_from(result.added_bytes)
+				.context("commit added bytes should be non-negative")?,
+			std::sync::atomic::Ordering::Relaxed,
+		);
+
+		let mut cache_snapshot = self.cache_snapshot.write().await;
+		let current_branch_id = cache_snapshot.as_ref().map(|snapshot| snapshot.branch_id);
+		let publish_branch_changed =
+			current_branch_id.is_some_and(|branch_id| branch_id != result.branch_id);
+		let pidx = if publish_branch_changed {
+			Arc::new(DeltaPageIndex::new())
+		} else {
+			cache_snapshot
+				.as_ref()
+				.map(|snapshot| Arc::clone(&snapshot.pidx))
+				.unwrap_or_else(|| Arc::new(DeltaPageIndex::new()))
+		};
+		let pidx_was_warm = !pidx.range(0, u32::MAX).is_empty();
+		if cache_was_warm || pidx_was_warm || publish_branch_changed {
+			for pgno in result.truncated_pgnos {
+				pidx.remove(pgno);
+			}
+			for pgno in result.dirty_pgnos {
+				pidx.insert(pgno, result.txid);
+			}
+		}
+		let last_access_bucket = result.access_bucket.or_else(|| {
+			cache_snapshot
+				.as_ref()
+				.filter(|snapshot| snapshot.branch_id == result.branch_id)
+				.and_then(|snapshot| snapshot.last_access_bucket)
+		});
+		*cache_snapshot = Some(CacheSnapshot {
+			branch_id: result.branch_id,
+			ancestors: result.branch_ancestry.clone(),
+			last_access_bucket,
+			pidx,
+		});
+		drop(cache_snapshot);
+
+		self.publish_deltas_available_if_needed(result.deltas_available, result.branch_id)
+			.await
+	}
+
+	async fn cleanup_stage_upload_rows(
+		&self,
+		branch_id: DatabaseBranchId,
+		stage_id: Uuid,
+	) -> Result<()> {
+		let pages_prefix = {
+			let mut prefix = keys::branch_commit_stage_prefix(branch_id, stage_id);
+			prefix.extend_from_slice(b"/pages/");
+			prefix
+		};
+		let complete_key = keys::branch_commit_stage_complete_key(branch_id, stage_id);
+		self.udb
+			.run(move |tx| {
+				let pages_prefix = pages_prefix.clone();
+				let complete_key = complete_key.clone();
+				async move {
+					for (key, _) in tx_scan_prefix_values(&tx, &pages_prefix).await? {
+						tx.informal().clear(&key);
+					}
+					tx.informal().clear(&complete_key);
+					Ok(())
+				}
+			})
+			.await
+	}
+
+	async fn clear_commit_stage(
+		&self,
+		branch_id: DatabaseBranchId,
+		meta: &CommitStageMeta,
+		release_quota: bool,
+	) -> Result<()> {
+		let stage_prefix = keys::branch_commit_stage_prefix(branch_id, meta.stage_id);
+		let object_prefix = keys::branch_delta_object_prefix(branch_id, meta.object_id);
+		let lookup_key = keys::commit_stage_lookup_key(meta.stage_id);
+		let reserved_storage_bytes = meta.reserved_storage_bytes;
+		self.udb
+			.run(move |tx| {
+				let stage_prefix = stage_prefix.clone();
+				let object_prefix = object_prefix.clone();
+				let lookup_key = lookup_key.clone();
+				async move {
+					for (key, _) in tx_scan_prefix_values(&tx, &stage_prefix).await? {
+						tx.informal().clear(&key);
+					}
+					for (key, _) in tx_scan_prefix_values(&tx, &object_prefix).await? {
+						tx.informal().clear(&key);
+					}
+					tx.informal().clear(&lookup_key);
+					if release_quota && reserved_storage_bytes != 0 {
+						quota::atomic_add_branch_staged(&tx, branch_id, -reserved_storage_bytes);
+					}
+					Ok(())
+				}
+			})
+			.await
+	}
+
+	async fn clear_commit_stage_lookup(&self, stage_id: Uuid) -> Result<()> {
+		let lookup_key = keys::commit_stage_lookup_key(stage_id);
+		self.udb
+			.run(move |tx| {
+				let lookup_key = lookup_key.clone();
+				async move {
+					tx.informal().clear(&lookup_key);
+					Ok(())
+				}
+			})
+			.await
+	}
+
+	async fn clear_finalized_stage_rows(
+		&self,
+		branch_id: DatabaseBranchId,
+		stage_id: Uuid,
+	) -> Result<()> {
+		let stage_prefix = keys::branch_commit_stage_prefix(branch_id, stage_id);
+		let lookup_key = keys::commit_stage_lookup_key(stage_id);
+		self.udb
+			.run(move |tx| {
+				let stage_prefix = stage_prefix.clone();
+				let lookup_key = lookup_key.clone();
+				async move {
+					for (key, _) in tx_scan_prefix_values(&tx, &stage_prefix).await? {
+						tx.informal().clear(&key);
+					}
+					tx.informal().clear(&lookup_key);
+					Ok(())
+				}
+			})
+			.await
+	}
+
+	async fn delta_object_ref_exists(
+		&self,
+		branch_id: DatabaseBranchId,
+		object_id: Uuid,
+	) -> Result<bool> {
+		let object_ref_key = keys::branch_delta_object_ref_key(branch_id, object_id);
+		self.udb
+			.run(move |tx| {
+				let object_ref_key = object_ref_key.clone();
+				async move { Ok(tx_get_value(&tx, &object_ref_key, Serializable).await?.is_some()) }
+			})
+			.await
+	}
+
+	async fn clear_delta_object_if_unreferenced(
+		&self,
+		branch_id: DatabaseBranchId,
+		object_id: Uuid,
+		stage_id: Option<Uuid>,
+	) -> Result<bool> {
+		let object_ref_key = keys::branch_delta_object_ref_key(branch_id, object_id);
+		let object_prefix = keys::branch_delta_object_prefix(branch_id, object_id);
+		let lookup_key = stage_id.map(keys::commit_stage_lookup_key);
+		self.udb
+			.run(move |tx| {
+				let object_ref_key = object_ref_key.clone();
+				let object_prefix = object_prefix.clone();
+				let lookup_key = lookup_key.clone();
+				async move {
+					if tx_get_value(&tx, &object_ref_key, Serializable)
+						.await?
+						.is_some()
+					{
+						return Ok(false);
+					}
+					for (key, _) in tx_scan_prefix_values(&tx, &object_prefix).await? {
+						tx.informal().clear(&key);
+					}
+					if let Some(lookup_key) = lookup_key {
+						tx.informal().clear(&lookup_key);
+					}
+					Ok(true)
+				}
+			})
+			.await
+	}
+
+	async fn prepare_slow_commit(
+		&self,
+		cached_branch_id: Option<DatabaseBranchId>,
+		cached_ancestry: Option<BranchAncestry>,
+		expected_head_txid: Option<u64>,
+	) -> Result<SlowCommitPreflight> {
+		let database_id = self.database_id.clone();
+		let bucket_id = self.sqlite_bucket_id();
+		#[cfg(feature = "test-faults")]
+		let fault_controller = self.fault_controller.clone();
+
+		self.udb
+			.run(move |tx| {
+				let database_id = database_id.clone();
+				let cached_ancestry = cached_ancestry.clone();
+				#[cfg(feature = "test-faults")]
+				let fault_controller = fault_controller.clone();
+
+				async move {
+					let branch_resolution =
+						resolve_or_allocate_branch(&tx, bucket_id, &database_id).await?;
+					let branch_id = branch_resolution.branch_id;
+					#[cfg(feature = "test-faults")]
+					super::apply::maybe_fire_commit_fault(
+						&fault_controller,
+						&database_id,
+						crate::fault::CommitFaultPoint::AfterBranchResolution,
+						Some(branch_id),
+					)
+					.await?;
+					if !branch_resolution.database_initialized {
+						let branch_record =
+							tx_get_value(&tx, &keys::branches_list_key(branch_id), Serializable)
+								.await?
+								.as_deref()
+								.map(decode_database_branch_record)
+								.transpose()
+								.context("decode sqlite database branch record for slow commit")?;
+						if !branch_record
+							.as_ref()
+							.is_some_and(|record| record.state == BranchState::Live)
+						{
+							return Err(SqliteStorageError::BranchNotWritable.into());
+						}
+					}
+					let branch_ancestry = if branch_resolution.database_initialized {
+						BranchAncestry::root(branch_id)
+					} else if let Some(cached_ancestry) =
+						cached_ancestry.filter(|ancestry| {
+							cached_branch_id == Some(branch_id) && ancestry.root_branch_id == branch_id
+						}) {
+						cached_ancestry
+					} else {
+						load_branch_ancestry(&tx, branch_id).await?
+					};
+					let head_bytes =
+						tx_get_value(&tx, &keys::branch_meta_head_key(branch_id), Serializable)
+							.await?;
+					let head_at_fork_bytes = tx_get_value(
+						&tx,
+						&keys::branch_meta_head_at_fork_key(branch_id),
+						Serializable,
+					)
+					.await?;
+					let previous_head_bytes = head_bytes.as_ref().or(head_at_fork_bytes.as_ref());
+					let previous_head = previous_head_bytes
+						.map(|bytes| decode_db_head(bytes.as_slice()))
+						.transpose()
+						.context("decode current sqlite db head for slow commit")?;
+					let actual_head_txid = previous_head.as_ref().map_or(0, |head| head.head_txid);
+					if let Some(expected_head_txid) = expected_head_txid {
+						if expected_head_txid != actual_head_txid {
+							tracing::error!(
+								%database_id,
+								?branch_id,
+								expected_head_txid,
+								actual_head_txid,
+								"sqlite head fence mismatch; this indicates multiple actor instances are writing the same sqlite database in parallel, which is incorrect actor lifecycle behavior"
+							);
+							return Err(SqliteStorageError::HeadFenceMismatch {
+								expected_head_txid,
+								actual_head_txid,
+							}
+							.into());
+						}
+					}
+
+					Ok(SlowCommitPreflight {
+						branch_id,
+						bucket_branch_id: branch_resolution.bucket_branch_id,
+						bucket_initialized: branch_resolution.bucket_initialized,
+						database_initialized: branch_resolution.database_initialized,
+						branch_ancestry,
+						observed_head_txid: actual_head_txid,
+					})
+				}
+			})
+			.await
+	}
+
+	async fn write_delta_object(
+		&self,
+		branch_id: DatabaseBranchId,
+		object: &LargeDeltaObject,
+	) -> Result<()> {
+		let mut batch = Vec::<(Vec<u8>, Vec<u8>)>::new();
+		let mut batch_bytes = 0usize;
+		for (chunk_idx, chunk) in &object.chunks {
+			let key = keys::branch_delta_object_chunk_key(branch_id, object.object_id, *chunk_idx);
+			let next_bytes = key.len() + chunk.len();
+			if !batch.is_empty() && batch_bytes + next_bytes > DELTA_OBJECT_WRITE_BATCH_BYTES {
+				write_object_batch(&self.udb, std::mem::take(&mut batch)).await?;
+				batch_bytes = 0;
+			}
+			batch_bytes += next_bytes;
+			batch.push((key, chunk.clone()));
+		}
+		if !batch.is_empty() {
+			write_object_batch(&self.udb, batch).await?;
+		}
+
+		let object_meta_key = keys::branch_delta_object_meta_key(branch_id, object.object_id);
+		let object_meta = object.encoded_stage_meta.clone();
+		self.udb
+			.run(move |tx| {
+				let object_meta_key = object_meta_key.clone();
+				let object_meta = object_meta.clone();
+				async move {
+					tx.informal().set(&object_meta_key, &object_meta);
+					Ok(())
+				}
+			})
+			.await
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	async fn finalize_slow_commit(
+		&self,
+		preflight: SlowCommitPreflight,
+		object: LargeDeltaObject,
+		dirty_pages: Vec<DirtyPage>,
+		db_size_pages: u32,
+		now_ms: i64,
+		options: CommitOptions,
+		_cached_storage_used: Option<i64>,
+		cached_access_bucket: Option<i64>,
+		last_deltas_available_at_ms: Option<i64>,
+		stage_context: Option<StageFinalizeContext>,
+	) -> Result<SlowCommitTxResult> {
+		let database_id = self.database_id.clone();
+		let bucket_id = self.sqlite_bucket_id();
+		let expected_head_txid = options.expected_head_txid;
+		#[cfg(feature = "test-faults")]
+		let fault_controller = self.fault_controller.clone();
+
+		self.udb
+			.run(move |tx| {
+				let database_id = database_id.clone();
+				let dirty_pages = dirty_pages.clone();
+				let preflight = preflight.clone();
+				let object = object.clone();
+				let stage_context = stage_context.clone();
+				#[cfg(feature = "test-faults")]
+				let fault_controller = fault_controller.clone();
+
+				async move {
+					let branch_resolution =
+						resolve_slow_publish_branch(&tx, bucket_id, &database_id, &preflight)
+							.await?;
+					let branch_id = branch_resolution.branch_id;
+					#[cfg(feature = "test-faults")]
+					super::apply::maybe_fire_commit_fault(
+						&fault_controller,
+						&database_id,
+						crate::fault::CommitFaultPoint::AfterBranchResolution,
+						Some(branch_id),
+					)
+					.await?;
+					if !branch_resolution.database_initialized {
+						let branch_record =
+							tx_get_value(&tx, &keys::branches_list_key(branch_id), Serializable)
+								.await?
+								.as_deref()
+								.map(decode_database_branch_record)
+								.transpose()
+								.context("decode sqlite database branch record for slow finalize")?;
+						if !branch_record
+							.as_ref()
+							.is_some_and(|record| record.state == BranchState::Live)
+						{
+							return Err(SqliteStorageError::BranchNotWritable.into());
+						}
+					}
+
+					let head_key = keys::branch_meta_head_key(branch_id);
+					let head_at_fork_key = keys::branch_meta_head_at_fork_key(branch_id);
+					let quota_fut = quota::read_branch(&tx, branch_id);
+					let staged_quota_fut = quota::read_branch_staged(&tx, branch_id);
+					let head_fut = tx_get_value(&tx, &head_key, Serializable);
+					let head_at_fork_fut = tx_get_value(&tx, &head_at_fork_key, Serializable);
+					let (head_bytes, head_at_fork_bytes, storage_used, staged_storage_used) =
+						tokio::try_join!(head_fut, head_at_fork_fut, quota_fut, staged_quota_fut)?;
+
+					let previous_head_bytes = head_bytes.as_ref().or(head_at_fork_bytes.as_ref());
+					let previous_head = previous_head_bytes
+						.map(|bytes| decode_db_head(bytes.as_slice()))
+						.transpose()
+						.context("decode current sqlite db head for slow finalize")?;
+					let actual_head_txid = previous_head.as_ref().map_or(0, |head| head.head_txid);
+					if actual_head_txid != preflight.observed_head_txid {
+						return Err(SqliteStorageError::HeadFenceMismatch {
+							expected_head_txid: preflight.observed_head_txid,
+							actual_head_txid,
+						}
+						.into());
+					}
+					if let Some(expected_head_txid) = expected_head_txid {
+						if expected_head_txid != actual_head_txid {
+							return Err(SqliteStorageError::HeadFenceMismatch {
+								expected_head_txid,
+								actual_head_txid,
+							}
+							.into());
+						}
+					}
+					#[cfg(feature = "test-faults")]
+					super::apply::maybe_fire_commit_fault(
+						&fault_controller,
+						&database_id,
+						crate::fault::CommitFaultPoint::AfterHeadRead,
+						Some(branch_id),
+					)
+					.await?;
+
+					let object_meta_key =
+						keys::branch_delta_object_meta_key(branch_id, object.object_id);
+					let object_meta_bytes =
+						tx_get_value(&tx, &object_meta_key, Serializable).await?.with_context(
+							|| format!("sqlite large delta object meta missing {}", object.object_id),
+						)?;
+					let object_meta = decode_delta_object_meta(&object_meta_bytes)
+						.context("decode sqlite large delta object meta")?;
+					ensure!(
+						object_meta.object_id == object.object_id
+							&& object_meta.stage_id == object.stage_id
+							&& object_meta.staged_txid == object.txid
+							&& matches!(object_meta.state, DeltaObjectState::StageOwned),
+						"sqlite large delta object meta did not match staged object"
+					);
+
+					let compaction_root =
+						tx_get_value(&tx, &keys::branch_compaction_root_key(branch_id), Snapshot)
+							.await?
+							.as_deref()
+							.map(decode_compaction_root)
+							.transpose()
+							.context("decode sqlite compaction root for slow dirty admission")?;
+					let previous_db_size_pages = previous_head
+						.as_ref()
+						.map_or(db_size_pages, |head| head.db_size_pages);
+					let txid = previous_head
+						.as_ref()
+						.map_or(Ok(1), |head| {
+							head.head_txid
+								.checked_add(1)
+								.context("sqlite head txid overflowed")
+						})?;
+					ensure!(
+						txid == object.txid,
+						"sqlite slow commit staged txid {} did not match publish txid {}",
+						object.txid,
+						txid
+					);
+
+					let truncate_cleanup = collect_truncate_cleanup(
+						&tx,
+						branch_id,
+						previous_db_size_pages,
+						db_size_pages,
+					)
+					.await?;
+					test_hooks::maybe_pause_after_truncate_cleanup(&database_id).await;
+					#[cfg(feature = "test-faults")]
+					super::apply::maybe_fire_commit_fault(
+						&fault_controller,
+						&database_id,
+						crate::fault::CommitFaultPoint::AfterTruncateCleanup,
+						Some(branch_id),
+					)
+					.await?;
+
+					let new_head = DBHead {
+						head_txid: txid,
+						db_size_pages,
+						post_apply_checksum: previous_head
+							.as_ref()
+							.map_or(0, |head| head.post_apply_checksum),
+						branch_id,
+						#[cfg(debug_assertions)]
+						generation: previous_head.as_ref().map_or(0, |head| head.generation),
+					};
+					let encoded_head =
+						encode_db_head(new_head.clone()).context("encode new sqlite db head")?;
+					let txid_bytes = txid.to_be_bytes();
+					let commit_row = CommitRow {
+						wall_clock_ms: now_ms,
+						versionstamp: udb::INCOMPLETE_VERSIONSTAMP,
+						db_size_pages,
+						post_apply_checksum: new_head.post_apply_checksum,
+					};
+					let encoded_commit_row =
+						encode_commit_row(commit_row).context("encode sqlite commit row")?;
+					let versionstamped_commit_row = udb::append_versionstamp_offset(
+						encoded_commit_row.clone(),
+						&udb::INCOMPLETE_VERSIONSTAMP,
+					)
+					.context("prepare versionstamped sqlite commit row")?;
+					let commit_key = keys::branch_commit_key(branch_id, txid);
+					let vtx_storage_key =
+						keys::branch_vtx_key(branch_id, udb::INCOMPLETE_VERSIONSTAMP);
+					let versionstamped_vtx_key = udb::append_versionstamp_offset(
+						vtx_storage_key.clone(),
+						&udb::INCOMPLETE_VERSIONSTAMP,
+					)
+					.context("prepare versionstamped sqlite vtx key")?;
+					let dirty_pgnos = dirty_pages
+						.iter()
+						.map(|page| page.pgno)
+						.collect::<BTreeSet<_>>();
+
+					let encoded_manifest = object.encoded_manifest.clone();
+					let manifest_key = keys::branch_delta_manifest_key(branch_id, txid);
+					let object_ref_key =
+						keys::branch_delta_object_ref_key(branch_id, object.object_id);
+					let encoded_committed_meta = object.encoded_committed_meta.clone();
+					let stage_finalize_rows = stage_context
+						.as_ref()
+						.map(|context| {
+							let finalized = CommitStageFinalized {
+								stage_id: context.stage_id,
+								object_id: object.object_id,
+								txid,
+								finalized_at_ms: now_ms,
+							};
+							let mut meta = context.stage_meta.clone();
+							meta.state = CommitStageState::Finalized { txid };
+							Ok::<_, anyhow::Error>((
+								keys::branch_commit_stage_finalized_key(branch_id, context.stage_id),
+								encode_commit_stage_finalized(finalized)?,
+								keys::branch_commit_stage_meta_key(branch_id, context.stage_id),
+								encode_commit_stage_meta(meta)?,
+							))
+						})
+						.transpose()?;
+					let encoded_page_index_rows = object
+						.page_index
+						.iter()
+						.map(|(pgno, entry)| {
+							Ok((
+								keys::branch_delta_pageidx_key(branch_id, txid, *pgno),
+								encode_delta_page_index_entry(entry.clone())?,
+							))
+						})
+						.collect::<Result<Vec<_>>>()?;
+
+					let added_bytes = tracked_entry_size(&head_key, &encoded_head)?
+						+ tracked_entry_size(&commit_key, &encoded_commit_row)?
+						+ tracked_entry_size(&vtx_storage_key, &txid_bytes)?
+						+ tracked_entry_size(&manifest_key, &encoded_manifest)?
+						+ tracked_entry_size(&object_ref_key, &txid_bytes)?
+						+ tracked_entry_size(&object_meta_key, &encoded_committed_meta)?
+						+ stage_finalize_rows
+							.as_ref()
+							.map_or(Ok(0), |(finalized_key, finalized_value, meta_key, meta_value)| {
+								Ok::<_, anyhow::Error>(
+									tracked_entry_size(finalized_key, finalized_value)?
+										+ tracked_entry_size(meta_key, meta_value)?,
+								)
+							})?
+						+ object.chunk_tracked_bytes
+						+ encoded_page_index_rows
+							.iter()
+							.map(|(key, value)| tracked_entry_size(key, value))
+							.sum::<Result<i64>>()?
+						+ truncate_cleanup.added_bytes
+						+ dirty_pgnos
+							.iter()
+							.map(|pgno| {
+								tracked_entry_size(
+									&keys::branch_pidx_key(branch_id, *pgno),
+									&txid_bytes,
+								)
+							})
+							.sum::<Result<i64>>()?;
+					let removed_bytes = head_bytes
+						.as_ref()
+						.map_or(Ok(0), |bytes| tracked_entry_size(&head_key, bytes))?
+						+ truncate_cleanup.deleted_bytes;
+					let quota_delta = added_bytes
+						.checked_sub(removed_bytes)
+						.context("sqlite slow commit quota delta overflowed i64")?;
+					let would_be = storage_used
+						.checked_add(quota_delta)
+						.context("sqlite slow commit quota check overflowed i64")?;
+					let would_be_with_staged = if let Some(stage_context) = &stage_context {
+						would_be
+							.checked_add(staged_storage_used)
+							.and_then(|value| {
+								value.checked_sub(stage_context.reserved_storage_bytes)
+							})
+							.context("sqlite slow commit staged quota check overflowed i64")?
+					} else {
+						would_be
+							.checked_add(staged_storage_used)
+							.context("sqlite slow commit staged quota check overflowed i64")?
+					};
+					let burst_signal =
+						burst_mode::read_branch_signal_for_head(txid, compaction_root.as_ref());
+					let deltas_available = admit_deltas_available(
+						&tx,
+						branch_id,
+						txid,
+						compaction_root.as_ref(),
+						burst_signal.cold_watermark_txid,
+						now_ms,
+						last_deltas_available_at_ms,
+					)
+					.await?;
+					let hot_quota_cap = burst_mode::adjusted_hot_quota_cap(
+						quota::SQLITE_MAX_STORAGE_BYTES,
+						burst_signal,
+					)?;
+					quota::cap_check_with_cap(would_be_with_staged, hot_quota_cap)?;
+
+					#[cfg(feature = "test-faults")]
+					super::apply::maybe_fire_commit_fault(
+						&fault_controller,
+						&database_id,
+						crate::fault::CommitFaultPoint::BeforeDeltaWrites,
+						Some(branch_id),
+					)
+					.await?;
+					tx.informal().set(&manifest_key, &encoded_manifest);
+					tx.informal().set(&object_ref_key, &txid_bytes);
+					tx.informal().set(&object_meta_key, &encoded_committed_meta);
+					if let Some((finalized_key, finalized_value, meta_key, meta_value)) =
+						&stage_finalize_rows
+					{
+						tx.informal().set(finalized_key, finalized_value);
+						tx.informal().set(meta_key, meta_value);
+					}
+					for (key, value) in &encoded_page_index_rows {
+						tx.informal().set(key, value);
+					}
+					#[cfg(feature = "test-faults")]
+					super::apply::maybe_fire_commit_fault(
+						&fault_controller,
+						&database_id,
+						crate::fault::CommitFaultPoint::BeforePidxWrites,
+						Some(branch_id),
+					)
+					.await?;
+					for pgno in &dirty_pgnos {
+						tx.informal()
+							.set(&keys::branch_pidx_key(branch_id, *pgno), &txid_bytes);
+					}
+					for row in &truncate_cleanup.pidx_clears {
+						fence_truncate_cleanup_row(&tx, row).await?;
+						tx.informal().clear(&row.key);
+					}
+					for row in &truncate_cleanup.shard_clears {
+						fence_truncate_cleanup_row(&tx, row).await?;
+						tx.informal().clear(&row.key);
+					}
+					for (row, value) in &truncate_cleanup.shard_writes {
+						fence_truncate_cleanup_row(&tx, row).await?;
+						tx.informal().set(&row.key, value);
+					}
+					#[cfg(feature = "test-faults")]
+					super::apply::maybe_fire_commit_fault(
+						&fault_controller,
+						&database_id,
+						crate::fault::CommitFaultPoint::BeforeHeadWrite,
+						Some(branch_id),
+					)
+					.await?;
+					tx.informal().set(&head_key, &encoded_head);
+					if head_at_fork_bytes.is_some() {
+						tx.informal().clear(&head_at_fork_key);
+					}
+					if branch_resolution.bucket_initialized {
+						branch::write_root_bucket_metadata(
+							&tx,
+							bucket_id,
+							branch_resolution.bucket_branch_id,
+							now_ms,
+							&udb::INCOMPLETE_VERSIONSTAMP,
+						)?;
+					}
+					if branch_resolution.database_initialized {
+						write_root_branch_metadata(
+							&tx,
+							branch_id,
+							branch_resolution.bucket_branch_id,
+							&database_id,
+							now_ms,
+							&udb::INCOMPLETE_VERSIONSTAMP,
+							branch_resolution.bucket_initialized,
+						)
+						.await?;
+					}
+					#[cfg(feature = "test-faults")]
+					super::apply::maybe_fire_commit_fault(
+						&fault_controller,
+						&database_id,
+						crate::fault::CommitFaultPoint::BeforeCommitRows,
+						Some(branch_id),
+					)
+					.await?;
+					tx.informal().atomic_op(
+						&commit_key,
+						&versionstamped_commit_row,
+						MutationType::SetVersionstampedValue,
+					);
+					tx.informal().atomic_op(
+						&versionstamped_vtx_key,
+						&txid_bytes,
+						MutationType::SetVersionstampedKey,
+					);
+					#[cfg(feature = "test-faults")]
+					super::apply::maybe_fire_commit_fault(
+						&fault_controller,
+						&database_id,
+						crate::fault::CommitFaultPoint::BeforeQuotaMutation,
+						Some(branch_id),
+					)
+					.await?;
+					if quota_delta != 0 {
+						quota::atomic_add_branch(&tx, branch_id, quota_delta);
+					}
+					if let Some(stage_context) = &stage_context {
+						if stage_context.reserved_storage_bytes != 0 {
+							quota::atomic_add_branch_staged(
+								&tx,
+								branch_id,
+								-stage_context.reserved_storage_bytes,
+							);
+						}
+					}
+					let access_bucket = touch_access_if_bucket_advanced(
+						&tx,
+						branch_id,
+						cached_access_bucket,
+						now_ms,
+					)
+					.await?;
+
+					Ok(SlowCommitTxResult {
+						branch_id,
+						branch_ancestry: preflight.branch_ancestry,
+						access_bucket,
+						txid,
+						deltas_available,
+						dirty_pgnos,
+						truncated_pgnos: truncate_cleanup.truncated_pgnos,
+						added_bytes,
+						storage_used: would_be,
+					})
+				}
+			})
+			.await
+	}
+}
+
+async fn write_object_batch(
+	udb: &universaldb::Database,
+	batch: Vec<(Vec<u8>, Vec<u8>)>,
+) -> Result<()> {
+	udb.run(move |tx| {
+		let batch = batch.clone();
+		async move {
+			for (key, value) in &batch {
+				tx.informal().set(key, value);
+			}
+			Ok(())
+		}
+	})
+	.await
+}
+
+async fn resolve_slow_publish_branch(
+	tx: &universaldb::Transaction,
+	bucket_id: crate::conveyer::types::BucketId,
+	database_id: &str,
+	preflight: &SlowCommitPreflight,
+) -> Result<BranchResolution> {
+	if preflight.database_initialized {
+		if let Some(current_branch_id) = branch::resolve_database_branch_in_bucket(
+			tx,
+			preflight.bucket_branch_id,
+			database_id,
+			Serializable,
+		)
+		.await?
+		{
+			let actual_head_txid = read_branch_head_txid(tx, current_branch_id).await?;
+			return Err(SqliteStorageError::HeadFenceMismatch {
+				expected_head_txid: preflight.observed_head_txid,
+				actual_head_txid,
+			}
+			.into());
+		}
+
+		return Ok(BranchResolution {
+			branch_id: preflight.branch_id,
+			bucket_branch_id: preflight.bucket_branch_id,
+			bucket_initialized: preflight.bucket_initialized,
+			database_initialized: true,
+		});
+	}
+
+	let branch_resolution = resolve_or_allocate_branch(tx, bucket_id, database_id).await?;
+	if branch_resolution.branch_id != preflight.branch_id {
+		let actual_head_txid = read_branch_head_txid(tx, branch_resolution.branch_id)
+			.await
+			.unwrap_or(0);
+		return Err(SqliteStorageError::HeadFenceMismatch {
+			expected_head_txid: preflight.observed_head_txid,
+			actual_head_txid,
+		}
+		.into());
+	}
+
+	Ok(branch_resolution)
+}
+
+async fn read_branch_head_txid(
+	tx: &universaldb::Transaction,
+	branch_id: DatabaseBranchId,
+) -> Result<u64> {
+	let head_bytes = tx_get_value(tx, &keys::branch_meta_head_key(branch_id), Serializable).await?;
+	let head_at_fork_bytes =
+		tx_get_value(tx, &keys::branch_meta_head_at_fork_key(branch_id), Serializable).await?;
+	let Some(bytes) = head_bytes.as_ref().or(head_at_fork_bytes.as_ref()) else {
+		return Ok(0);
+	};
+	Ok(decode_db_head(bytes)?.head_txid)
+}
+
+fn build_delta_object(
+	txid: u64,
+	db_size_pages: u32,
+	now_ms: i64,
+	dirty_pages: &[DirtyPage],
+) -> Result<LargeDeltaObject> {
+	build_delta_object_with_ids(
+		txid,
+		db_size_pages,
+		now_ms,
+		Uuid::new_v4(),
+		Uuid::new_v4(),
+		dirty_pages,
+	)
+}
+
+fn build_delta_object_with_ids(
+	txid: u64,
+	db_size_pages: u32,
+	now_ms: i64,
+	stage_id: Uuid,
+	object_id: Uuid,
+	dirty_pages: &[DirtyPage],
+) -> Result<LargeDeltaObject> {
+	let encoded =
+		LtxEncoder::new(LtxHeader::delta(txid, db_size_pages, now_ms)).encode_with_index(dirty_pages)?;
+	let object_hash = hash_bytes(&encoded.bytes);
+	let encoded_len =
+		u64::try_from(encoded.bytes.len()).context("sqlite large delta length exceeded u64")?;
+	let chunks = encoded
+		.bytes
+		.chunks(DELTA_OBJECT_CHUNK_BYTES)
+		.enumerate()
+		.map(|(chunk_idx, chunk)| {
+			Ok((
+				u32::try_from(chunk_idx).context("sqlite large delta chunk index exceeded u32")?,
+				chunk.to_vec(),
+			))
+		})
+		.collect::<Result<Vec<_>>>()?;
+	let chunk_count =
+		u32::try_from(chunks.len()).context("sqlite large delta chunk count exceeded u32")?;
+
+	let page_hashes = dirty_pages
+		.iter()
+		.map(|page| (page.pgno, hash_bytes(&page.bytes)))
+		.collect::<BTreeMap<_, _>>();
+	let page_index = encoded
+		.page_index
+		.iter()
+		.map(|entry| {
+			Ok((
+				entry.pgno,
+				delta_page_index_entry(txid, object_id, entry, &page_hashes)?,
+			))
+		})
+		.collect::<Result<Vec<_>>>()?;
+
+	let stage_meta = DeltaObjectMeta {
+		object_id,
+		stage_id,
+		staged_txid: txid,
+		chunk_count,
+		encoded_len,
+		object_hash,
+		state: DeltaObjectState::StageOwned,
+		created_at_ms: now_ms,
+		expires_after_ms: now_ms.saturating_add(STAGE_TTL_MS),
+	};
+	let committed_meta = DeltaObjectMeta {
+		state: DeltaObjectState::Committed { txid },
+		..stage_meta.clone()
+	};
+	let manifest = DeltaManifest {
+		txid,
+		object_id,
+		chunk_count,
+		encoded_len,
+		object_hash,
+	};
+	let encoded_stage_meta = encode_delta_object_meta(stage_meta)?;
+	let encoded_committed_meta = encode_delta_object_meta(committed_meta)?;
+	let encoded_manifest = encode_delta_manifest(manifest)?;
+	let chunk_tracked_bytes = chunks
+		.iter()
+		.map(|(chunk_idx, chunk)| {
+			tracked_entry_size(
+				&keys::branch_delta_object_chunk_key(DatabaseBranchId::nil(), object_id, *chunk_idx),
+				chunk,
+			)
+		})
+		.sum::<Result<i64>>()?;
+
+	Ok(LargeDeltaObject {
+		txid,
+		stage_id,
+		object_id,
+		chunks,
+		page_index,
+		encoded_len,
+		encoded_stage_meta,
+		encoded_committed_meta,
+		encoded_manifest,
+		chunk_tracked_bytes,
+	})
+}
+
+fn delta_page_index_entry(
+	txid: u64,
+	object_id: Uuid,
+	entry: &LtxPageIndexEntry,
+	page_hashes: &BTreeMap<u32, [u8; 32]>,
+) -> Result<DeltaPageIndexEntry> {
+	Ok(DeltaPageIndexEntry {
+		txid,
+		object_id,
+		encoded_offset: entry.offset,
+		encoded_size: u32::try_from(entry.size)
+			.context("sqlite large delta page frame size exceeded u32")?,
+		page_hash: *page_hashes
+			.get(&entry.pgno)
+			.context("sqlite large delta page index referenced unknown page")?,
+	})
+}
+
+fn validate_stage_dirty_pgnos(dirty_pgnos: &[u32]) -> Result<()> {
+	if dirty_pgnos.len() > MAX_SQLITE_COMMIT_DIRTY_PAGES {
+		return Err(SqliteStorageError::SqliteCommitPageLimitExceeded {
+			dirty_page_count: u32::try_from(dirty_pgnos.len()).unwrap_or(u32::MAX),
+			max_dirty_pages: MAX_SQLITE_COMMIT_DIRTY_PAGES as u32,
+			page_size_bytes: keys::PAGE_SIZE,
+		}
+		.into());
+	}
+	let dirty_bytes = dirty_pgnos
+		.len()
+		.checked_mul(keys::PAGE_SIZE as usize)
+		.context("sqlite dirty page byte count overflowed")?;
+	if dirty_bytes > MAX_SQLITE_COMMIT_DIRTY_BYTES {
+		return Err(SqliteStorageError::CommitTooLarge {
+			actual_size_bytes: dirty_bytes as u64,
+			max_size_bytes: MAX_SQLITE_COMMIT_DIRTY_BYTES as u64,
+		}
+		.into());
+	}
+	let mut last = None;
+	for pgno in dirty_pgnos {
+		ensure!(*pgno > 0, "sqlite commit stage does not accept page 0");
+		if let Some(last) = last {
+			ensure!(
+				last < *pgno,
+				"sqlite commit stage page numbers must be sorted and unique"
+			);
+		}
+		last = Some(*pgno);
+	}
+	Ok(())
+}
+
+fn validate_stage_page_batch(pages: &[DirtyPage]) -> Result<()> {
+	ensure!(!pages.is_empty(), "sqlite commit stage batch is empty");
+	ensure!(
+		pages.len() <= MAX_STAGE_PAGES_PER_BATCH,
+		"sqlite commit stage batch had {} pages, limit is {}",
+		pages.len(),
+		MAX_STAGE_PAGES_PER_BATCH
+	);
+	let mut last = None;
+	for page in pages {
+		validate_stage_dirty_page(page)?;
+		if let Some(last) = last {
+			ensure!(
+				last < page.pgno,
+				"sqlite commit stage batch pages must be sorted and unique"
+			);
+		}
+		last = Some(page.pgno);
+	}
+	Ok(())
+}
+
+fn validate_stage_dirty_page(page: &DirtyPage) -> Result<()> {
+	ensure!(page.pgno > 0, "sqlite commit stage does not accept page 0");
+	ensure!(
+		page.bytes.len() == keys::PAGE_SIZE as usize,
+		"sqlite commit stage page {} had {} bytes, expected {}",
+		page.pgno,
+		page.bytes.len(),
+		keys::PAGE_SIZE
+	);
+	Ok(())
+}
+
+fn hash_dirty_pgnos(dirty_pgnos: &[u32]) -> [u8; 32] {
+	let mut hasher = Sha256::new();
+	for pgno in dirty_pgnos {
+		hasher.update(pgno.to_be_bytes());
+	}
+	let digest = hasher.finalize();
+	let mut out = [0_u8; 32];
+	out.copy_from_slice(&digest);
+	out
+}
+
+fn hash_dirty_pages(pages: &[DirtyPage]) -> [u8; 32] {
+	let mut hasher = Sha256::new();
+	for page in pages {
+		hasher.update(page.pgno.to_be_bytes());
+		hasher.update(hash_bytes(&page.bytes));
+	}
+	let digest = hasher.finalize();
+	let mut out = [0_u8; 32];
+	out.copy_from_slice(&digest);
+	out
+}
+
+fn estimate_stage_reservation(
+	branch_id: DatabaseBranchId,
+	object_id: Uuid,
+	staged_txid: u64,
+	dirty_pgnos: &[u32],
+) -> Result<i64> {
+	let dirty_bytes = i64::try_from(dirty_pgnos.len())
+		.context("sqlite dirty page count exceeded i64")?
+		.checked_mul(i64::from(keys::PAGE_SIZE))
+		.context("sqlite dirty page reservation overflowed")?;
+	let estimated_object_chunks = dirty_bytes
+		.checked_add(i64::try_from(DELTA_OBJECT_CHUNK_BYTES).unwrap_or(i64::MAX) - 1)
+		.context("sqlite object chunk reservation overflowed")?
+		/ i64::try_from(DELTA_OBJECT_CHUNK_BYTES).unwrap_or(i64::MAX);
+	let chunk_key_bytes = (0..estimated_object_chunks)
+		.map(|chunk_idx| {
+			let chunk_idx = u32::try_from(chunk_idx).unwrap_or(u32::MAX);
+			tracked_entry_size(
+				&keys::branch_delta_object_chunk_key(branch_id, object_id, chunk_idx),
+				&[],
+			)
+		})
+		.sum::<Result<i64>>()?;
+	let page_index_bytes = dirty_pgnos
+		.iter()
+		.map(|pgno| {
+			tracked_entry_size(
+				&keys::branch_delta_pageidx_key(branch_id, staged_txid, *pgno),
+				&[0; 96],
+			)
+		})
+		.sum::<Result<i64>>()?;
+	let pidx_bytes = dirty_pgnos
+		.iter()
+		.map(|pgno| tracked_entry_size(&keys::branch_pidx_key(branch_id, *pgno), &[0; 8]))
+		.sum::<Result<i64>>()?;
+	dirty_bytes
+		.checked_add(chunk_key_bytes)
+		.and_then(|value| value.checked_add(page_index_bytes))
+		.and_then(|value| value.checked_add(pidx_bytes))
+		.and_then(|value| value.checked_add(STAGE_RESERVATION_HEADROOM_BYTES))
+		.context("sqlite stage reservation overflowed")
+}
+
+fn hash_bytes(bytes: &[u8]) -> [u8; 32] {
+	let digest = Sha256::digest(bytes);
+	let mut out = [0_u8; 32];
+	out.copy_from_slice(&digest);
+	out
+}
+
+fn map_udb_commit_error(err: anyhow::Error) -> anyhow::Error {
+	for source in err.chain() {
+		if let Some(universaldb::error::DatabaseError::TransactionTooLarge {
+			actual_size_bytes,
+			max_size_bytes,
+		}) = source.downcast_ref::<universaldb::error::DatabaseError>()
+		{
+			return SqliteStorageError::CommitTooLarge {
+				actual_size_bytes: *actual_size_bytes as u64,
+				max_size_bytes: *max_size_bytes as u64,
+			}
+			.into();
+		}
+	}
+
+	err
+}
+
+#[derive(Clone)]
+struct SlowCommitPreflight {
+	branch_id: DatabaseBranchId,
+	bucket_branch_id: crate::conveyer::types::BucketBranchId,
+	bucket_initialized: bool,
+	database_initialized: bool,
+	branch_ancestry: BranchAncestry,
+	observed_head_txid: u64,
+}
+
+#[derive(Clone)]
+struct StageFinalizeContext {
+	stage_id: Uuid,
+	stage_meta: CommitStageMeta,
+	reserved_storage_bytes: i64,
+}
+
+struct LoadedCommitStage {
+	branch_id: DatabaseBranchId,
+	meta: CommitStageMeta,
+}
+
+#[derive(Clone)]
+struct LargeDeltaObject {
+	txid: u64,
+	stage_id: Uuid,
+	object_id: Uuid,
+	chunks: Vec<(u32, Vec<u8>)>,
+	page_index: Vec<(u32, DeltaPageIndexEntry)>,
+	encoded_len: u64,
+	encoded_stage_meta: Vec<u8>,
+	encoded_committed_meta: Vec<u8>,
+	encoded_manifest: Vec<u8>,
+	chunk_tracked_bytes: i64,
+}
+
+struct SlowCommitTxResult {
+	branch_id: DatabaseBranchId,
+	branch_ancestry: BranchAncestry,
+	access_bucket: Option<i64>,
+	txid: u64,
+	deltas_available: Option<DeltasAvailable>,
+	dirty_pgnos: BTreeSet<u32>,
+	truncated_pgnos: Vec<u32>,
+	added_bytes: i64,
+	storage_used: i64,
+}

--- a/engine/packages/depot/src/conveyer/constants.rs
+++ b/engine/packages/depot/src/conveyer/constants.rs
@@ -52,6 +52,9 @@ pub const CMP_S3_UPLOAD_MAX_OBJECTS: usize = 1;
 /// Workflow compaction caps cold shard upload activity payloads.
 pub const CMP_S3_UPLOAD_LIMIT_BYTES: usize = 64 * 1024 * 1024;
 
+/// Large SQLite delta objects use values below UniversalDB's 100 KB value limit.
+pub const DELTA_OBJECT_CHUNK_BYTES: usize = 64 * 1024;
+
 /// Workflow compaction caps S3 delete activity batches.
 pub const CMP_S3_DELETE_MAX_OBJECTS: usize = 100;
 

--- a/engine/packages/depot/src/conveyer/debug.rs
+++ b/engine/packages/depot/src/conveyer/debug.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, ensure};
 use futures_util::TryStreamExt;
 use universaldb::{
 	RangeOption,
@@ -11,16 +11,19 @@ use universaldb::{
 };
 
 use crate::{
+	compaction::shared::load_large_delta_page,
 	conveyer::{
 		Db, branch,
 		db::load_branch_ancestry,
 		keys,
 		ltx::{DecodedLtx, decode_ltx_v3},
+		shard_blob::resolve_branch_shard_value,
 		types::{
 			ColdManifestChunk, ColdManifestIndex, CommitRow, DatabaseBranchId, FetchedPage,
-			LayerEntry, LayerKind, RestorePointIndexEntry, SQLITE_STORAGE_COLD_SCHEMA_VERSION,
-			decode_cold_manifest_chunk, decode_cold_manifest_index, decode_commit_row,
-			decode_restore_point_record,
+			DeltaManifest, DeltaPageIndexEntry, LayerEntry, LayerKind, RestorePointIndexEntry,
+			SQLITE_STORAGE_COLD_SCHEMA_VERSION, decode_cold_manifest_chunk,
+			decode_cold_manifest_index, decode_commit_row, decode_delta_manifest,
+			decode_delta_page_index_entry, decode_restore_point_record,
 		},
 	},
 	gc,
@@ -54,6 +57,12 @@ pub struct PageState {
 struct DebugReadSource {
 	branch_id: DatabaseBranchId,
 	max_txid: u64,
+}
+
+#[derive(Debug, Clone)]
+struct DebugLargeDeltaEntry {
+	pgno: u32,
+	page_index: DeltaPageIndexEntry,
 }
 
 pub async fn dump_database_ancestry(db: &Db) -> Result<Vec<(DatabaseBranchId, Option<[u8; 16]>)>> {
@@ -279,20 +288,58 @@ async fn load_pages_from_hot_tier(
 		.collect::<BTreeMap<_, _>>();
 
 	for source in sources {
-		for (_txid, blob) in tx_load_delta_blobs(tx, *source).await? {
-			let decoded = decode_ltx_v3(&blob).with_context(|| {
-				format!(
-					"decode sqlite debug delta for branch {:?}",
-					source.branch_id
-				)
-			})?;
-			for pgno in 1..=db_size_pages {
-				if pages.get(&pgno).is_some_and(Option::is_some) {
-					continue;
+		let legacy_blobs = tx_load_delta_blobs(tx, *source)
+			.await?
+			.into_iter()
+			.collect::<BTreeMap<_, _>>();
+		let large_entries = tx_load_large_delta_entries(tx, *source).await?;
+		let mut txids = legacy_blobs
+			.keys()
+			.chain(large_entries.keys())
+			.copied()
+			.collect::<Vec<_>>();
+		txids.sort_unstable();
+		txids.dedup();
+
+		for txid in txids.into_iter().rev() {
+			if let Some(blob) = legacy_blobs.get(&txid) {
+				let decoded = decode_ltx_v3(blob).with_context(|| {
+					format!(
+						"decode sqlite debug delta for branch {:?}",
+						source.branch_id
+					)
+				})?;
+				for page in decoded.pages {
+					if page.pgno > db_size_pages
+						|| pages.get(&page.pgno).is_some_and(Option::is_some)
+					{
+						continue;
+					}
+					pages.insert(page.pgno, Some(page.bytes));
 				}
-				if let Some(bytes) = decoded.get_page(pgno) {
-					pages.insert(pgno, Some(bytes.to_vec()));
+			}
+
+			if let Some((manifest, entries)) = large_entries.get(&txid) {
+				for entry in entries {
+					if entry.pgno > db_size_pages
+						|| pages.get(&entry.pgno).is_some_and(Option::is_some)
+					{
+						continue;
+					}
+					let page = load_large_delta_page(
+						tx,
+						source.branch_id,
+						manifest,
+						&entry.page_index,
+						entry.pgno,
+					)
+					.await?;
+					pages.insert(page.pgno, Some(page.bytes));
 				}
+			}
+
+			if pages.values().all(Option::is_some) {
+				break;
 			}
 		}
 	}
@@ -527,6 +574,58 @@ async fn tx_load_delta_blobs(
 	Ok(blobs)
 }
 
+async fn tx_load_large_delta_entries(
+	tx: &universaldb::Transaction,
+	source: DebugReadSource,
+) -> Result<BTreeMap<u64, (DeltaManifest, Vec<DebugLargeDeltaEntry>)>> {
+	let mut manifests = BTreeMap::<u64, DeltaManifest>::new();
+	for (key, value) in scan_prefix(tx, &keys::branch_delta_manifest_prefix(source.branch_id)).await?
+	{
+		let txid = keys::decode_branch_delta_manifest_txid(source.branch_id, &key)?;
+		if txid > source.max_txid {
+			continue;
+		}
+		let manifest = decode_delta_manifest(&value)
+			.context("decode sqlite debug large delta manifest")?;
+		ensure!(
+			manifest.txid == txid,
+			"sqlite debug large delta manifest txid {} did not match key txid {}",
+			manifest.txid,
+			txid
+		);
+		manifests.insert(txid, manifest);
+	}
+
+	let mut entries_by_txid = BTreeMap::new();
+	for (txid, manifest) in manifests {
+		let mut entries = Vec::new();
+		for (key, value) in scan_prefix(
+			tx,
+			&keys::branch_delta_pageidx_prefix(source.branch_id, txid),
+		)
+		.await?
+		{
+			let pgno = keys::decode_branch_delta_pageidx_pgno(source.branch_id, txid, &key)?;
+			let page_index = decode_delta_page_index_entry(&value)
+				.context("decode sqlite debug large delta page index")?;
+			ensure!(
+				page_index.txid == txid,
+				"sqlite debug large delta page index txid {} did not match key txid {}",
+				page_index.txid,
+				txid
+			);
+			ensure!(
+				page_index.object_id == manifest.object_id,
+				"sqlite debug large delta page index object did not match manifest object"
+			);
+			entries.push(DebugLargeDeltaEntry { pgno, page_index });
+		}
+		entries_by_txid.insert(txid, (manifest, entries));
+	}
+
+	Ok(entries_by_txid)
+}
+
 async fn tx_load_latest_shard_blob(
 	tx: &universaldb::Transaction,
 	sources: &[DebugReadSource],
@@ -550,12 +649,36 @@ async fn tx_load_latest_shard_blob(
 			latest = Some((entry.key().to_vec(), entry.value().to_vec()));
 		}
 
-		if latest.is_some() {
-			return Ok(latest);
+		if let Some((key, value)) = latest {
+			let as_of_txid = decode_branch_shard_as_of_txid(source.branch_id, shard_id, &key)?;
+			let blob =
+				resolve_branch_shard_value(tx, source.branch_id, shard_id, as_of_txid, &value, Snapshot)
+					.await?;
+			return Ok(Some((key, blob)));
 		}
 	}
 
 	Ok(None)
+}
+
+fn decode_branch_shard_as_of_txid(
+	branch_id: DatabaseBranchId,
+	shard_id: u32,
+	key: &[u8],
+) -> Result<u64> {
+	let prefix = keys::branch_shard_version_prefix(branch_id, shard_id);
+	let suffix = key
+		.strip_prefix(prefix.as_slice())
+		.context("sqlite debug branch shard key did not start with expected prefix")?;
+	let bytes: [u8; std::mem::size_of::<u64>()] = suffix.try_into().with_context(|| {
+		format!(
+			"sqlite debug branch shard key suffix had {} bytes, expected {}",
+			suffix.len(),
+			std::mem::size_of::<u64>()
+		)
+	})?;
+
+	Ok(u64::from_be_bytes(bytes))
 }
 
 fn cold_manifest_index_object_key(branch_id: DatabaseBranchId) -> String {

--- a/engine/packages/depot/src/conveyer/error.rs
+++ b/engine/packages/depot/src/conveyer/error.rs
@@ -35,6 +35,31 @@ pub enum SqliteStorageError {
 	},
 
 	#[error(
+		"sqlite_commit_page_limit_exceeded",
+		"SQLite transaction touched too many pages.",
+		"SQLite transaction touched {dirty_page_count} pages, but the limit is {max_dirty_pages} pages of {page_size_bytes} bytes."
+	)]
+	SqliteCommitPageLimitExceeded {
+		dirty_page_count: u32,
+		max_dirty_pages: u32,
+		page_size_bytes: u32,
+	},
+
+	#[error(
+		"sqlite_commit_stage_not_found",
+		"SQLite commit stage was not found.",
+		"SQLite commit stage {stage_id} was not found."
+	)]
+	SqliteCommitStageNotFound { stage_id: uuid::Uuid },
+
+	#[error(
+		"sqlite_commit_stage_invalid",
+		"SQLite commit stage is invalid.",
+		"SQLite commit stage is invalid: {reason}."
+	)]
+	SqliteCommitStageInvalid { reason: String },
+
+	#[error(
 		"head_fence_mismatch",
 		"SQLite head fence mismatch.",
 		"SQLite head fence mismatch. Expected head txid {expected_head_txid}, but current head txid is {actual_head_txid}."
@@ -149,6 +174,20 @@ impl fmt::Display for SqliteStorageError {
 				f,
 				"CommitTooLarge: raw dirty pages were {actual_size_bytes} bytes, limit is {max_size_bytes} bytes"
 			),
+			SqliteStorageError::SqliteCommitPageLimitExceeded {
+				dirty_page_count,
+				max_dirty_pages,
+				page_size_bytes,
+			} => write!(
+				f,
+				"sqlite transaction touched too many pages: {dirty_page_count} pages, limit is {max_dirty_pages} pages of {page_size_bytes} bytes"
+			),
+			SqliteStorageError::SqliteCommitStageNotFound { stage_id } => {
+				write!(f, "sqlite commit stage {stage_id} was not found")
+			}
+			SqliteStorageError::SqliteCommitStageInvalid { reason } => {
+				write!(f, "sqlite commit stage is invalid: {reason}")
+			}
 			SqliteStorageError::HeadFenceMismatch {
 				expected_head_txid,
 				actual_head_txid,

--- a/engine/packages/depot/src/conveyer/keys.rs
+++ b/engine/packages/depot/src/conveyer/keys.rs
@@ -30,6 +30,7 @@ const META_HEAD_AT_FORK_PATH: &[u8] = b"/META/head_at_fork";
 const META_COMPACT_PATH: &[u8] = b"/META/compact";
 const META_COLD_COMPACT_PATH: &[u8] = b"/META/cold_compact";
 const META_QUOTA_PATH: &[u8] = b"/META/quota";
+const META_STAGED_QUOTA_PATH: &[u8] = b"/META/staged_quota";
 const META_COMPACTOR_LEASE_PATH: &[u8] = b"/META/compactor_lease";
 const META_COLD_LEASE_PATH: &[u8] = b"/META/cold_lease";
 const CMP_ROOT_PATH: &[u8] = b"/CMP/root";
@@ -38,7 +39,20 @@ const CMP_RETIRED_COLD_OBJECT_PATH: &[u8] = b"/CMP/retired_cold_object/";
 const CMP_STAGE_PATH: &[u8] = b"/CMP/stage/";
 const CMP_STAGE_HOT_SHARD_PATH: &[u8] = b"/hot_shard/";
 const SHARD_PATH: &[u8] = b"/SHARD/";
+const SHARD_CHUNK_PATH: &[u8] = b"/SHARD_CHUNK/";
 const DELTA_PATH: &[u8] = b"/DELTA/";
+const STAGE_COMMIT_PATH: &[u8] = b"/STAGE/commit/";
+const STAGE_META_PATH: &[u8] = b"/meta";
+const STAGE_PAGES_PATH: &[u8] = b"/pages/";
+const STAGE_COMPLETE_PATH: &[u8] = b"/complete";
+const STAGE_FINALIZED_PATH: &[u8] = b"/finalized";
+const STAGE_COMMIT_BY_ID_PATH: &[u8] = b"/STAGE_COMMIT_BY_ID/";
+const DELTA_OBJ_PATH: &[u8] = b"/DELTA_OBJ/";
+const DELTA_OBJ_CHUNK_PATH: &[u8] = b"/chunk/";
+const DELTA_OBJ_META_PATH: &[u8] = b"/meta";
+const DELTA_OBJ_REF_PATH: &[u8] = b"/DELTA_OBJ_REF/";
+const DELTA_MANIFEST_PATH: &[u8] = b"/DELTA_MANIFEST/";
+const DELTA_PAGEIDX_PATH: &[u8] = b"/DELTA_PAGEIDX/";
 const PIDX_DELTA_PATH: &[u8] = b"/PIDX/delta/";
 const BR_PIDX_PATH: &[u8] = b"/PIDX/";
 const COMMITS_PATH: &[u8] = b"/COMMITS/";
@@ -446,6 +460,10 @@ pub fn branch_meta_quota_key(branch_id: DatabaseBranchId) -> Vec<u8> {
 	with_suffix(database_branch_base(branch_id), META_QUOTA_PATH)
 }
 
+pub fn branch_meta_staged_quota_key(branch_id: DatabaseBranchId) -> Vec<u8> {
+	with_suffix(database_branch_base(branch_id), META_STAGED_QUOTA_PATH)
+}
+
 pub fn branch_meta_compactor_lease_key(branch_id: DatabaseBranchId) -> Vec<u8> {
 	with_suffix(database_branch_base(branch_id), META_COMPACTOR_LEASE_PATH)
 }
@@ -554,6 +572,18 @@ pub fn branch_compaction_stage_hot_shard_version_prefix(
 	key
 }
 
+pub fn branch_compaction_stage_hot_shard_chunk_prefix(
+	branch_id: DatabaseBranchId,
+	job_id: Id,
+	shard_id: u32,
+	as_of_txid: u64,
+) -> Vec<u8> {
+	let mut key = branch_compaction_stage_hot_shard_version_prefix(branch_id, job_id, shard_id);
+	key.extend_from_slice(&as_of_txid.to_be_bytes());
+	key.push(b'/');
+	key
+}
+
 pub fn branch_compaction_stage_hot_shard_key(
 	branch_id: DatabaseBranchId,
 	job_id: Id,
@@ -561,9 +591,8 @@ pub fn branch_compaction_stage_hot_shard_key(
 	as_of_txid: u64,
 	chunk_idx: u32,
 ) -> Vec<u8> {
-	let mut key = branch_compaction_stage_hot_shard_version_prefix(branch_id, job_id, shard_id);
-	key.extend_from_slice(&as_of_txid.to_be_bytes());
-	key.push(b'/');
+	let mut key =
+		branch_compaction_stage_hot_shard_chunk_prefix(branch_id, job_id, shard_id, as_of_txid);
 	key.extend_from_slice(&chunk_idx.to_be_bytes());
 	key
 }
@@ -642,6 +671,227 @@ pub fn branch_delta_chunk_key(branch_id: DatabaseBranchId, txid: u64, chunk_idx:
 	key
 }
 
+pub fn branch_commit_stage_prefix(branch_id: DatabaseBranchId, stage_id: uuid::Uuid) -> Vec<u8> {
+	let mut key = with_suffix(database_branch_base(branch_id), STAGE_COMMIT_PATH);
+	append_uuid(&mut key, stage_id);
+	key
+}
+
+pub fn branch_commit_stage_meta_key(branch_id: DatabaseBranchId, stage_id: uuid::Uuid) -> Vec<u8> {
+	with_suffix(branch_commit_stage_prefix(branch_id, stage_id), STAGE_META_PATH)
+}
+
+pub fn branch_commit_stage_pages_key(
+	branch_id: DatabaseBranchId,
+	stage_id: uuid::Uuid,
+	batch_idx: u32,
+) -> Vec<u8> {
+	let mut key = with_suffix(branch_commit_stage_prefix(branch_id, stage_id), STAGE_PAGES_PATH);
+	key.extend_from_slice(&batch_idx.to_be_bytes());
+	key
+}
+
+pub fn branch_commit_stage_complete_key(
+	branch_id: DatabaseBranchId,
+	stage_id: uuid::Uuid,
+) -> Vec<u8> {
+	with_suffix(
+		branch_commit_stage_prefix(branch_id, stage_id),
+		STAGE_COMPLETE_PATH,
+	)
+}
+
+pub fn branch_commit_stage_finalized_key(
+	branch_id: DatabaseBranchId,
+	stage_id: uuid::Uuid,
+) -> Vec<u8> {
+	with_suffix(
+		branch_commit_stage_prefix(branch_id, stage_id),
+		STAGE_FINALIZED_PATH,
+	)
+}
+
+pub fn commit_stage_lookup_key(stage_id: uuid::Uuid) -> Vec<u8> {
+	let mut key = commit_stage_lookup_prefix();
+	append_uuid(&mut key, stage_id);
+	key
+}
+
+pub fn commit_stage_lookup_prefix() -> Vec<u8> {
+	with_suffix(partition_prefix(BR_PARTITION), STAGE_COMMIT_BY_ID_PATH)
+}
+
+pub fn decode_commit_stage_lookup_id(key: &[u8]) -> Result<uuid::Uuid> {
+	let prefix = commit_stage_lookup_prefix();
+	let suffix = key
+		.strip_prefix(prefix.as_slice())
+		.context("commit stage lookup key did not start with expected prefix")?;
+	ensure!(
+		suffix.len() == std::mem::size_of::<uuid::Uuid>(),
+		"commit stage lookup key suffix had {} bytes, expected {}",
+		suffix.len(),
+		std::mem::size_of::<uuid::Uuid>()
+	);
+	uuid::Uuid::from_slice(suffix).context("commit stage lookup suffix should decode as uuid")
+}
+
+pub fn branch_delta_object_root_prefix(branch_id: DatabaseBranchId) -> Vec<u8> {
+	with_suffix(database_branch_base(branch_id), DELTA_OBJ_PATH)
+}
+
+pub fn branch_delta_object_prefix(branch_id: DatabaseBranchId, object_id: uuid::Uuid) -> Vec<u8> {
+	let mut key = branch_delta_object_root_prefix(branch_id);
+	append_uuid(&mut key, object_id);
+	key
+}
+
+pub fn branch_delta_object_chunk_prefix(
+	branch_id: DatabaseBranchId,
+	object_id: uuid::Uuid,
+) -> Vec<u8> {
+	with_suffix(
+		branch_delta_object_prefix(branch_id, object_id),
+		DELTA_OBJ_CHUNK_PATH,
+	)
+}
+
+pub fn branch_delta_object_chunk_key(
+	branch_id: DatabaseBranchId,
+	object_id: uuid::Uuid,
+	chunk_idx: u32,
+) -> Vec<u8> {
+	let mut key = branch_delta_object_chunk_prefix(branch_id, object_id);
+	key.extend_from_slice(&chunk_idx.to_be_bytes());
+	key
+}
+
+pub fn branch_delta_object_meta_key(
+	branch_id: DatabaseBranchId,
+	object_id: uuid::Uuid,
+) -> Vec<u8> {
+	with_suffix(
+		branch_delta_object_prefix(branch_id, object_id),
+		DELTA_OBJ_META_PATH,
+	)
+}
+
+pub fn decode_branch_delta_object_meta_object_id(
+	branch_id: DatabaseBranchId,
+	key: &[u8],
+) -> Result<uuid::Uuid> {
+	let prefix = branch_delta_object_root_prefix(branch_id);
+	let suffix = key
+		.strip_prefix(prefix.as_slice())
+		.context("branch delta object meta key did not start with expected prefix")?;
+	let expected_len = std::mem::size_of::<uuid::Uuid>() + DELTA_OBJ_META_PATH.len();
+	ensure!(
+		suffix.len() == expected_len,
+		"branch delta object meta key suffix had {} bytes, expected {}",
+		suffix.len(),
+		expected_len
+	);
+	let object_id = &suffix[..std::mem::size_of::<uuid::Uuid>()];
+	let meta_suffix = &suffix[std::mem::size_of::<uuid::Uuid>()..];
+	ensure!(
+		meta_suffix == DELTA_OBJ_META_PATH,
+		"branch delta object meta key did not end with meta suffix"
+	);
+	uuid::Uuid::from_slice(object_id)
+		.context("branch delta object meta suffix should decode as uuid")
+}
+
+pub fn branch_delta_object_ref_key(branch_id: DatabaseBranchId, object_id: uuid::Uuid) -> Vec<u8> {
+	let mut key = with_suffix(database_branch_base(branch_id), DELTA_OBJ_REF_PATH);
+	append_uuid(&mut key, object_id);
+	key
+}
+
+pub fn branch_delta_manifest_key(branch_id: DatabaseBranchId, txid: u64) -> Vec<u8> {
+	let mut key = with_suffix(database_branch_base(branch_id), DELTA_MANIFEST_PATH);
+	key.extend_from_slice(&txid.to_be_bytes());
+	key
+}
+
+pub fn branch_delta_manifest_prefix(branch_id: DatabaseBranchId) -> Vec<u8> {
+	with_suffix(database_branch_base(branch_id), DELTA_MANIFEST_PATH)
+}
+
+pub fn branch_delta_pageidx_prefix(branch_id: DatabaseBranchId, txid: u64) -> Vec<u8> {
+	let mut key = with_suffix(database_branch_base(branch_id), DELTA_PAGEIDX_PATH);
+	key.extend_from_slice(&txid.to_be_bytes());
+	key.push(b'/');
+	key
+}
+
+pub fn branch_delta_pageidx_key(
+	branch_id: DatabaseBranchId,
+	txid: u64,
+	pgno: u32,
+) -> Vec<u8> {
+	let mut key = branch_delta_pageidx_prefix(branch_id, txid);
+	key.extend_from_slice(&pgno.to_be_bytes());
+	key
+}
+
+pub fn decode_branch_delta_manifest_txid(branch_id: DatabaseBranchId, key: &[u8]) -> Result<u64> {
+	let prefix = branch_delta_manifest_prefix(branch_id);
+	let suffix = key
+		.strip_prefix(prefix.as_slice())
+		.context("branch delta manifest key did not start with expected prefix")?;
+	ensure!(
+		suffix.len() == std::mem::size_of::<u64>(),
+		"branch delta manifest key suffix had {} bytes, expected {}",
+		suffix.len(),
+		std::mem::size_of::<u64>()
+	);
+
+	Ok(u64::from_be_bytes(suffix.try_into().context(
+		"branch delta manifest txid suffix should decode as u64",
+	)?))
+}
+
+pub fn decode_branch_delta_pageidx_pgno(
+	branch_id: DatabaseBranchId,
+	txid: u64,
+	key: &[u8],
+) -> Result<u32> {
+	let prefix = branch_delta_pageidx_prefix(branch_id, txid);
+	let suffix = key
+		.strip_prefix(prefix.as_slice())
+		.context("branch delta page index key did not start with expected prefix")?;
+	ensure!(
+		suffix.len() == std::mem::size_of::<u32>(),
+		"branch delta page index key suffix had {} bytes, expected {}",
+		suffix.len(),
+		std::mem::size_of::<u32>()
+	);
+
+	Ok(u32::from_be_bytes(suffix.try_into().context(
+		"branch delta page index pgno suffix should decode as u32",
+	)?))
+}
+
+pub fn decode_branch_delta_object_chunk_idx(
+	branch_id: DatabaseBranchId,
+	object_id: uuid::Uuid,
+	key: &[u8],
+) -> Result<u32> {
+	let prefix = branch_delta_object_chunk_prefix(branch_id, object_id);
+	let suffix = key
+		.strip_prefix(prefix.as_slice())
+		.context("branch delta object chunk key did not start with expected prefix")?;
+	ensure!(
+		suffix.len() == std::mem::size_of::<u32>(),
+		"branch delta object chunk key suffix had {} bytes, expected {}",
+		suffix.len(),
+		std::mem::size_of::<u32>()
+	);
+
+	Ok(u32::from_be_bytes(suffix.try_into().context(
+		"branch delta object chunk suffix should decode as u32",
+	)?))
+}
+
 pub fn decode_branch_delta_chunk_txid(branch_id: DatabaseBranchId, key: &[u8]) -> Result<u64> {
 	let prefix = branch_delta_prefix(branch_id);
 	ensure!(
@@ -704,6 +954,30 @@ pub fn branch_shard_version_prefix(branch_id: DatabaseBranchId, shard_id: u32) -
 pub fn branch_shard_key(branch_id: DatabaseBranchId, shard_id: u32, as_of_txid: u64) -> Vec<u8> {
 	let mut key = branch_shard_version_prefix(branch_id, shard_id);
 	key.extend_from_slice(&as_of_txid.to_be_bytes());
+	key
+}
+
+pub fn branch_shard_chunk_prefix(
+	branch_id: DatabaseBranchId,
+	shard_id: u32,
+	as_of_txid: u64,
+) -> Vec<u8> {
+	let mut key = with_suffix(database_branch_base(branch_id), SHARD_CHUNK_PATH);
+	key.extend_from_slice(&shard_id.to_be_bytes());
+	key.push(b'/');
+	key.extend_from_slice(&as_of_txid.to_be_bytes());
+	key.push(b'/');
+	key
+}
+
+pub fn branch_shard_chunk_key(
+	branch_id: DatabaseBranchId,
+	shard_id: u32,
+	as_of_txid: u64,
+	chunk_idx: u32,
+) -> Vec<u8> {
+	let mut key = branch_shard_chunk_prefix(branch_id, shard_id, as_of_txid);
+	key.extend_from_slice(&chunk_idx.to_be_bytes());
 	key
 }
 

--- a/engine/packages/depot/src/conveyer/ltx.rs
+++ b/engine/packages/depot/src/conveyer/ltx.rs
@@ -285,6 +285,63 @@ pub fn decode_ltx_v3(bytes: &[u8]) -> Result<DecodedLtx> {
 	LtxDecoder::new(bytes).decode()
 }
 
+pub fn decode_ltx_page_frame(frame: &[u8], expected_pgno: u32, page_size: u32) -> Result<DirtyPage> {
+	ensure!(
+		frame.len() >= LTX_PAGE_HEADER_SIZE + std::mem::size_of::<u32>(),
+		"ltx page frame too small: {} bytes",
+		frame.len()
+	);
+
+	let pgno = u32::from_be_bytes(
+		frame[..4]
+			.try_into()
+			.expect("page frame pgno should decode"),
+	);
+	let flags = u16::from_be_bytes(
+		frame[4..LTX_PAGE_HEADER_SIZE]
+			.try_into()
+			.expect("page frame flags should decode"),
+	);
+	ensure!(
+		pgno == expected_pgno,
+		"ltx page frame pgno {} did not match expected {}",
+		pgno,
+		expected_pgno
+	);
+	ensure!(
+		flags == LTX_PAGE_HEADER_FLAG_SIZE,
+		"unsupported page flags 0x{:04x} for page {}",
+		flags,
+		pgno
+	);
+
+	let compressed_size_start = LTX_PAGE_HEADER_SIZE;
+	let compressed_start = compressed_size_start + std::mem::size_of::<u32>();
+	let compressed_size = u32::from_be_bytes(
+		frame[compressed_size_start..compressed_start]
+			.try_into()
+			.expect("compressed size should decode"),
+	) as usize;
+	ensure!(
+		frame.len() == compressed_start + compressed_size,
+		"page {} frame had {} bytes, expected {}",
+		pgno,
+		frame.len(),
+		compressed_start + compressed_size
+	);
+
+	let bytes = lz4_flex::block::decompress(&frame[compressed_start..], page_size as usize)?;
+	ensure!(
+		bytes.len() == page_size as usize,
+		"page {} decompressed to {} bytes, expected {}",
+		pgno,
+		bytes.len(),
+		page_size
+	);
+
+	Ok(DirtyPage { pgno, bytes })
+}
+
 fn append_uvarint(buf: &mut Vec<u8>, mut value: u64) {
 	while value >= 0x80 {
 		buf.push((value as u8 & 0x7f) | 0x80);

--- a/engine/packages/depot/src/conveyer/mod.rs
+++ b/engine/packages/depot/src/conveyer/mod.rs
@@ -15,6 +15,7 @@ pub mod policy;
 pub mod quota;
 pub mod read;
 pub mod restore_point;
+pub mod shard_blob;
 pub mod types;
 pub mod udb;
 

--- a/engine/packages/depot/src/conveyer/quota.rs
+++ b/engine/packages/depot/src/conveyer/quota.rs
@@ -33,6 +33,18 @@ pub fn atomic_add_branch(
 	);
 }
 
+pub fn atomic_add_branch_staged(
+	tx: &universaldb::Transaction,
+	branch_id: DatabaseBranchId,
+	delta_bytes: i64,
+) {
+	tx.informal().atomic_op(
+		&keys::branch_meta_staged_quota_key(branch_id),
+		&delta_bytes.to_le_bytes(),
+		MutationType::Add,
+	);
+}
+
 pub async fn read(tx: &universaldb::Transaction, database_id: &str) -> Result<i64> {
 	read_in_bucket(tx, BucketId::nil(), database_id).await
 }
@@ -85,6 +97,30 @@ pub async fn read_branch(
 		Vec::from(value).try_into().map_err(|value: Vec<u8>| {
 			Error::msg(format!(
 				"sqlite branch quota counter had {} bytes, expected {}",
+				value.len(),
+				std::mem::size_of::<i64>()
+			))
+		})?;
+
+	Ok(i64::from_le_bytes(bytes))
+}
+
+pub async fn read_branch_staged(
+	tx: &universaldb::Transaction,
+	branch_id: DatabaseBranchId,
+) -> Result<i64> {
+	let Some(value) = tx
+		.informal()
+		.get(&keys::branch_meta_staged_quota_key(branch_id), Snapshot)
+		.await?
+	else {
+		return Ok(0);
+	};
+
+	let bytes: [u8; std::mem::size_of::<i64>()] =
+		Vec::from(value).try_into().map_err(|value: Vec<u8>| {
+			Error::msg(format!(
+				"sqlite branch staged quota counter had {} bytes, expected {}",
 				value.len(),
 				std::mem::size_of::<i64>()
 			))

--- a/engine/packages/depot/src/conveyer/read.rs
+++ b/engine/packages/depot/src/conveyer/read.rs
@@ -29,10 +29,10 @@ use crate::conveyer::{
 };
 
 use self::{
-	cold::{ColdLayerCandidate, ColdPageCandidate, tx_load_latest_compaction_cold_ref},
+	cold::{ColdPageCandidate, tx_load_latest_compaction_cold_ref},
 	pidx::{PageRef, decode_pidx_txid},
 	plan::{ReadSource, StorageScope, resolve_storage_scope},
-	shard::{tx_load_delta_blob, tx_load_latest_shard_blob},
+	shard::{tx_load_delta_blob, tx_load_large_delta_page, tx_load_latest_shard_blob},
 	tx::tx_scan_prefix_values,
 };
 
@@ -163,6 +163,7 @@ impl Db {
 							loaded_pidx_rows: None,
 							page_sources: BTreeMap::new(),
 							source_blobs: BTreeMap::new(),
+							large_delta_pages: BTreeMap::new(),
 							shard_cache_read_outcomes: BTreeMap::new(),
 							cold_page_candidates: BTreeMap::new(),
 							stale_pidx_pgnos: BTreeSet::new(),
@@ -237,7 +238,7 @@ impl Db {
 
 					let mut page_sources = BTreeMap::new();
 					let mut source_blobs = BTreeMap::new();
-					let mut missing_delta_prefixes = BTreeSet::new();
+					let mut large_delta_pages = BTreeMap::new();
 					let mut shard_sources = BTreeMap::<u32, Option<(Vec<u8>, Vec<u8>)>>::new();
 					let mut stale_pidx_pgnos = BTreeSet::new();
 					let mut cold_page_candidates = BTreeMap::<u32, Vec<ColdPageCandidate>>::new();
@@ -257,16 +258,8 @@ impl Db {
 							)
 						});
 
-						if preferred_delta
-							.as_ref()
-							.is_some_and(|(prefix, _, _)| missing_delta_prefixes.contains(prefix))
-						{
-							stale_pidx_pgnos.insert(*pgno);
-						}
-
-						if let Some((delta_prefix, delta_source, delta_txid)) = preferred_delta
-							.as_ref()
-							.filter(|(prefix, _, _)| !missing_delta_prefixes.contains(prefix))
+						if let Some((delta_prefix, delta_source, delta_txid)) =
+							preferred_delta.as_ref()
 						{
 							if !source_blobs.contains_key(delta_prefix) {
 								let blob = tx_load_delta_blob(&tx, delta_prefix).await?;
@@ -297,17 +290,18 @@ impl Db {
 								if let Some(blob) = blob {
 									source_blobs.insert(delta_prefix.clone(), blob);
 								} else {
-									missing_delta_prefixes.insert(delta_prefix.clone());
+									if let Some(bytes) = tx_load_large_delta_page(
+										&tx,
+										*delta_source,
+										*delta_txid,
+										*pgno,
+									)
+									.await?
+									{
+										large_delta_pages.insert(*pgno, bytes);
+										continue;
+									}
 									stale_pidx_pgnos.insert(*pgno);
-									let ReadSource::Branch(source) = *delta_source;
-									cold_candidates.push(
-										ColdLayerCandidate {
-											branch_id: source.branch_id,
-											owner_txid: *delta_txid,
-											shard_id: pgno / SHARD_SIZE,
-										}
-										.into(),
-									);
 								}
 							}
 
@@ -415,6 +409,7 @@ impl Db {
 						loaded_pidx_rows,
 						page_sources,
 						source_blobs,
+						large_delta_pages,
 						shard_cache_read_outcomes,
 						cold_page_candidates,
 						stale_pidx_pgnos,
@@ -458,7 +453,9 @@ impl Db {
 				continue;
 			}
 
-			let bytes = if let Some(source_key) = tx_result.page_sources.get(&pgno) {
+			let bytes = if let Some(bytes) = tx_result.large_delta_pages.get(&pgno) {
+				bytes.clone()
+			} else if let Some(source_key) = tx_result.page_sources.get(&pgno) {
 				let blob = tx_result
 					.source_blobs
 					.get(source_key)
@@ -601,6 +598,7 @@ struct GetPagesTxResult {
 	loaded_pidx_rows: Option<Vec<(u32, u64)>>,
 	page_sources: BTreeMap<u32, Vec<u8>>,
 	source_blobs: BTreeMap<Vec<u8>, Vec<u8>>,
+	large_delta_pages: BTreeMap<u32, Vec<u8>>,
 	shard_cache_read_outcomes: BTreeMap<u32, ShardCacheReadOutcome>,
 	cold_page_candidates: BTreeMap<u32, Vec<ColdPageCandidate>>,
 	stale_pidx_pgnos: BTreeSet<u32>,

--- a/engine/packages/depot/src/conveyer/read/cache_fill.rs
+++ b/engine/packages/depot/src/conveyer/read/cache_fill.rs
@@ -16,6 +16,7 @@ use universaldb::{Database, utils::IsolationLevel::Serializable};
 use crate::conveyer::{
 	error::SqliteStorageError,
 	keys, metrics,
+	shard_blob::{resolve_branch_shard_value, write_branch_shard_blob},
 	types::{ColdShardRef, DatabaseBranchId, encode_cold_shard_ref},
 };
 
@@ -335,7 +336,16 @@ async fn fill_job_tx(
 
 	let shard_key = keys::branch_shard_key(job.key.branch_id, job.key.shard_id, job.key.as_of_txid);
 	if let Some(existing) = tx.informal().get(&shard_key, Serializable).await? {
-		if existing.as_slice() == job.object_bytes.as_slice() {
+		let existing_blob = resolve_branch_shard_value(
+			tx,
+			job.key.branch_id,
+			job.key.shard_id,
+			job.key.as_of_txid,
+			&existing,
+			Serializable,
+		)
+		.await?;
+		if existing_blob.as_slice() == job.object_bytes.as_slice() {
 			return Ok(ShardCacheFillOutcome::Succeeded { bytes_written: 0 });
 		}
 		return Err(SqliteStorageError::ShardCacheCorrupt {
@@ -345,7 +355,13 @@ async fn fill_job_tx(
 		.into());
 	}
 
-	tx.informal().set(&shard_key, &job.object_bytes);
+	write_branch_shard_blob(
+		tx,
+		job.key.branch_id,
+		job.key.shard_id,
+		job.key.as_of_txid,
+		&job.object_bytes,
+	)?;
 
 	Ok(ShardCacheFillOutcome::Succeeded {
 		bytes_written: u64::try_from(job.object_bytes.len()).unwrap_or(u64::MAX),

--- a/engine/packages/depot/src/conveyer/read/shard.rs
+++ b/engine/packages/depot/src/conveyer/read/shard.rs
@@ -1,12 +1,19 @@
-use anyhow::{Context, Result, ensure};
+use anyhow::{Context, Result, bail, ensure};
 use futures_util::TryStreamExt;
+use sha2::{Digest, Sha256};
 use universaldb::{
 	RangeOption,
 	options::StreamingMode,
 	utils::{IsolationLevel::Snapshot, end_of_key_range},
 };
 
-use crate::conveyer::keys;
+use crate::conveyer::{
+	constants::DELTA_OBJECT_CHUNK_BYTES,
+	keys,
+	ltx::decode_ltx_page_frame,
+	shard_blob::resolve_branch_shard_value,
+	types::{decode_delta_manifest, decode_delta_page_index_entry},
+};
 
 use super::plan::{ReadSource, StorageScope};
 
@@ -31,6 +38,119 @@ pub(super) async fn tx_load_delta_blob(
 	}
 
 	Ok(Some(delta_blob))
+}
+
+pub(super) async fn tx_load_large_delta_page(
+	tx: &universaldb::Transaction,
+	source: ReadSource,
+	txid: u64,
+	pgno: u32,
+) -> Result<Option<Vec<u8>>> {
+	let ReadSource::Branch(source) = source;
+	let manifest_key = keys::branch_delta_manifest_key(source.branch_id, txid);
+	let Some(manifest_bytes) = super::tx::tx_get_value(tx, &manifest_key).await? else {
+		if super::tx::tx_get_value(
+			tx,
+			&keys::branch_delta_pageidx_key(source.branch_id, txid, pgno),
+		)
+		.await?
+		.is_some()
+		{
+			bail!("sqlite large delta manifest missing for txid {txid} page {pgno}");
+		}
+		return Ok(None);
+	};
+	let manifest = decode_delta_manifest(&manifest_bytes)
+		.with_context(|| format!("decode sqlite large delta manifest {txid}"))?;
+	ensure!(
+		manifest.txid == txid,
+		"sqlite large delta manifest txid {} did not match key txid {}",
+		manifest.txid,
+		txid
+	);
+
+	let page_index_bytes = super::tx::tx_get_value(
+		tx,
+		&keys::branch_delta_pageidx_key(source.branch_id, txid, pgno),
+	)
+	.await?
+	.with_context(|| format!("sqlite large delta page index missing for txid {txid} page {pgno}"))?;
+	let page_index = decode_delta_page_index_entry(&page_index_bytes)
+		.with_context(|| format!("decode sqlite large delta page index for txid {txid} page {pgno}"))?;
+	ensure!(
+		page_index.txid == txid,
+		"sqlite large delta page index txid {} did not match key txid {}",
+		page_index.txid,
+		txid
+	);
+	ensure!(
+		page_index.object_id == manifest.object_id,
+		"sqlite large delta page index object did not match manifest object"
+	);
+
+	let encoded_size = page_index.encoded_size as u64;
+	let encoded_end = page_index
+		.encoded_offset
+		.checked_add(encoded_size)
+		.context("sqlite large delta page byte range overflowed")?;
+	ensure!(
+		encoded_end <= manifest.encoded_len,
+		"sqlite large delta page byte range exceeded object length"
+	);
+
+	let first_chunk = page_index.encoded_offset / DELTA_OBJECT_CHUNK_BYTES as u64;
+	let last_chunk = (encoded_end.saturating_sub(1)) / DELTA_OBJECT_CHUNK_BYTES as u64;
+	ensure!(
+		last_chunk < u64::from(manifest.chunk_count),
+		"sqlite large delta page byte range exceeded object chunk count"
+	);
+
+	let mut object_bytes = Vec::new();
+	for chunk_idx in first_chunk..=last_chunk {
+		let chunk_idx = u32::try_from(chunk_idx).context("sqlite large delta chunk index exceeded u32")?;
+		let chunk = super::tx::tx_get_value(
+			tx,
+			&keys::branch_delta_object_chunk_key(
+				source.branch_id,
+				manifest.object_id,
+				chunk_idx,
+			),
+		)
+		.await?
+		.with_context(|| {
+			format!("sqlite large delta object chunk missing for txid {txid} chunk {chunk_idx}")
+		})?;
+		object_bytes.extend_from_slice(&chunk);
+	}
+
+	let chunk_base_offset = first_chunk * DELTA_OBJECT_CHUNK_BYTES as u64;
+	let slice_start = usize::try_from(page_index.encoded_offset - chunk_base_offset)
+		.context("sqlite large delta slice start exceeded usize")?;
+	let slice_len =
+		usize::try_from(encoded_size).context("sqlite large delta slice length exceeded usize")?;
+	let slice_end = slice_start
+		.checked_add(slice_len)
+		.context("sqlite large delta slice end overflowed")?;
+	ensure!(
+		slice_end <= object_bytes.len(),
+		"sqlite large delta page byte range exceeded fetched chunks"
+	);
+
+	let page = decode_ltx_page_frame(
+		&object_bytes[slice_start..slice_end],
+		pgno,
+		keys::PAGE_SIZE,
+	)
+	.with_context(|| format!("decode sqlite large delta page frame for txid {txid} page {pgno}"))?;
+	let digest = Sha256::digest(&page.bytes);
+	ensure!(
+		digest.as_slice() == page_index.page_hash,
+		"sqlite large delta page hash mismatch for txid {} page {}",
+		txid,
+		pgno
+	);
+
+	Ok(Some(page.bytes))
 }
 
 fn decode_delta_chunk_idx(delta_prefix: &[u8], key: &[u8]) -> Result<u32> {
@@ -59,19 +179,10 @@ pub(super) async fn tx_load_latest_shard_blob(
 	};
 
 	for source in sources {
-		let as_of_txid = match source {
-			ReadSource::Branch(source) => source.max_txid,
-		};
-		let prefix = match source {
-			ReadSource::Branch(source) => {
-				keys::branch_shard_version_prefix(source.branch_id, shard_id)
-			}
-		};
-		let end_key = match source {
-			ReadSource::Branch(source) => {
-				keys::branch_shard_key(source.branch_id, shard_id, as_of_txid)
-			}
-		};
+		let ReadSource::Branch(source) = source;
+		let as_of_txid = source.max_txid;
+		let prefix = keys::branch_shard_version_prefix(source.branch_id, shard_id);
+		let end_key = keys::branch_shard_key(source.branch_id, shard_id, as_of_txid);
 		let end = end_of_key_range(&end_key);
 		let informal = tx.informal();
 		let mut stream = informal.get_ranges_keyvalues(
@@ -87,10 +198,41 @@ pub(super) async fn tx_load_latest_shard_blob(
 			latest = Some((entry.key().to_vec(), entry.value().to_vec()));
 		}
 
-		if latest.is_some() {
-			return Ok(latest);
+		if let Some((key, value)) = latest {
+			let latest_as_of_txid = decode_branch_shard_as_of_txid(source.branch_id, shard_id, &key)?;
+			let blob =
+				resolve_branch_shard_value(
+					tx,
+					source.branch_id,
+					shard_id,
+					latest_as_of_txid,
+					&value,
+					Snapshot,
+				)
+				.await?;
+			return Ok(Some((key, blob)));
 		}
 	}
 
 	Ok(None)
+}
+
+fn decode_branch_shard_as_of_txid(
+	branch_id: crate::conveyer::types::DatabaseBranchId,
+	shard_id: u32,
+	key: &[u8],
+) -> Result<u64> {
+	let prefix = keys::branch_shard_version_prefix(branch_id, shard_id);
+	let suffix = key
+		.strip_prefix(prefix.as_slice())
+		.context("sqlite branch shard key did not start with expected prefix")?;
+	let bytes: [u8; std::mem::size_of::<u64>()] = suffix.try_into().with_context(|| {
+		format!(
+			"sqlite branch shard key suffix had {} bytes, expected {}",
+			suffix.len(),
+			std::mem::size_of::<u64>()
+		)
+	})?;
+
+	Ok(u64::from_be_bytes(bytes))
 }

--- a/engine/packages/depot/src/conveyer/shard_blob.rs
+++ b/engine/packages/depot/src/conveyer/shard_blob.rs
@@ -1,0 +1,133 @@
+use anyhow::{Context, Result, ensure};
+use sha2::{Digest, Sha256};
+use universaldb::utils::IsolationLevel;
+
+use super::{
+	constants::DELTA_OBJECT_CHUNK_BYTES,
+	keys,
+	types::{
+		DatabaseBranchId, HotShardManifest, decode_hot_shard_manifest,
+		encode_hot_shard_manifest,
+	},
+};
+
+pub fn write_branch_shard_blob(
+	tx: &universaldb::Transaction,
+	branch_id: DatabaseBranchId,
+	shard_id: u32,
+	as_of_txid: u64,
+	blob: &[u8],
+) -> Result<()> {
+	let shard_key = keys::branch_shard_key(branch_id, shard_id, as_of_txid);
+	if blob.len() <= DELTA_OBJECT_CHUNK_BYTES {
+		tx.informal().set(&shard_key, blob);
+		return Ok(());
+	}
+
+	let content_hash = content_hash(blob);
+	let chunks = blob
+		.chunks(DELTA_OBJECT_CHUNK_BYTES)
+		.enumerate()
+		.map(|(chunk_idx, chunk)| {
+			Ok((
+				u32::try_from(chunk_idx).context("sqlite hot shard chunk index exceeded u32")?,
+				chunk,
+			))
+		})
+		.collect::<Result<Vec<_>>>()?;
+	let manifest = HotShardManifest {
+		shard_id,
+		as_of_txid,
+		chunk_count: u32::try_from(chunks.len())
+			.context("sqlite hot shard chunk count exceeded u32")?,
+		encoded_len: u64::try_from(blob.len()).unwrap_or(u64::MAX),
+		content_hash,
+	};
+	let manifest_bytes = encode_hot_shard_manifest(manifest)?;
+
+	tx.informal().set(&shard_key, &manifest_bytes);
+	for (chunk_idx, chunk) in chunks {
+		tx.informal().set(
+			&keys::branch_shard_chunk_key(branch_id, shard_id, as_of_txid, chunk_idx),
+			chunk,
+		);
+	}
+
+	Ok(())
+}
+
+pub async fn resolve_branch_shard_value(
+	tx: &universaldb::Transaction,
+	branch_id: DatabaseBranchId,
+	shard_id: u32,
+	as_of_txid: u64,
+	value: &[u8],
+	isolation_level: IsolationLevel,
+) -> Result<Vec<u8>> {
+	let Ok(manifest) = decode_hot_shard_manifest(value) else {
+		return Ok(value.to_vec());
+	};
+	ensure!(
+		manifest.shard_id == shard_id && manifest.as_of_txid == as_of_txid,
+		"sqlite hot shard manifest key did not match row key"
+	);
+
+	let mut blob = Vec::new();
+	for chunk_idx in 0..manifest.chunk_count {
+		let chunk_key = keys::branch_shard_chunk_key(branch_id, shard_id, as_of_txid, chunk_idx);
+		let chunk = tx
+			.informal()
+			.get(&chunk_key, isolation_level)
+			.await?
+			.with_context(|| {
+				format!(
+					"sqlite hot shard chunk missing for shard {} txid {} chunk {}",
+					shard_id, as_of_txid, chunk_idx
+				)
+			})?;
+		blob.extend_from_slice(&chunk);
+	}
+
+	ensure!(
+		manifest.encoded_len == u64::try_from(blob.len()).unwrap_or(u64::MAX),
+		"sqlite hot shard chunk length mismatch"
+	);
+	ensure!(
+		manifest.content_hash == content_hash(&blob),
+		"sqlite hot shard chunk hash mismatch"
+	);
+
+	Ok(blob)
+}
+
+pub fn clear_branch_shard_chunks(
+	tx: &universaldb::Transaction,
+	branch_id: DatabaseBranchId,
+	shard_id: u32,
+	as_of_txid: u64,
+	row_value: &[u8],
+) -> Result<()> {
+	let Ok(manifest) = decode_hot_shard_manifest(row_value) else {
+		return Ok(());
+	};
+	ensure!(
+		manifest.shard_id == shard_id && manifest.as_of_txid == as_of_txid,
+		"sqlite hot shard manifest key did not match row key"
+	);
+
+	for chunk_idx in 0..manifest.chunk_count {
+		tx.informal()
+			.clear(&keys::branch_shard_chunk_key(
+				branch_id, shard_id, as_of_txid, chunk_idx,
+			));
+	}
+
+	Ok(())
+}
+
+fn content_hash(bytes: &[u8]) -> [u8; 32] {
+	let digest = Sha256::digest(bytes);
+	let mut hash = [0_u8; 32];
+	hash.copy_from_slice(&digest);
+	hash
+}

--- a/engine/packages/depot/src/conveyer/types/pages.rs
+++ b/engine/packages/depot/src/conveyer/types/pages.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DirtyPage {
@@ -33,4 +34,13 @@ pub struct CommitOptions {
 pub struct CommitResult {
 	pub head_txid: u64,
 	pub db_size_pages: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommitStageBeginResult {
+	pub stage_id: Uuid,
+	pub max_pages_per_batch: u32,
+	pub max_batch_bytes: u32,
+	pub observed_head_txid: u64,
+	pub staged_txid: u64,
 }

--- a/engine/packages/depot/src/conveyer/types/storage.rs
+++ b/engine/packages/depot/src/conveyer/types/storage.rs
@@ -1,9 +1,12 @@
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 use vbare::OwnedVersionedData;
 
-use super::ids::DatabaseBranchId;
+use super::{DirtyPage, ids::DatabaseBranchId};
 use super::serialization::SQLITE_STORAGE_META_VERSION;
+
+const HOT_SHARD_MANIFEST_MAGIC: &[u8] = b"rivet.depot.hot_shard_manifest.v1\0";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BranchManifest {
@@ -34,6 +37,102 @@ pub struct DBHead {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MetaCompact {
 	pub materialized_txid: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommitStageMeta {
+	pub stage_id: Uuid,
+	pub object_id: Uuid,
+	pub observed_head_txid: u64,
+	pub staged_txid: u64,
+	pub caller_expected_head_txid: Option<u64>,
+	pub db_size_pages: u32,
+	pub now_ms: i64,
+	pub dirty_page_count: u32,
+	pub dirty_pgnos_hash: [u8; 32],
+	pub reserved_storage_bytes: i64,
+	pub state: CommitStageState,
+	pub created_at_ms: i64,
+	pub expires_after_ms: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CommitStageState {
+	Uploading,
+	Complete,
+	ObjectWritten,
+	Finalizing,
+	Finalized { txid: u64 },
+	Aborted,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirtyPageBatch {
+	pub batch_idx: u32,
+	pub pages: Vec<DirtyPage>,
+	pub batch_hash: [u8; 32],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommitStageComplete {
+	pub page_batch_count: u32,
+	pub dirty_page_count: u32,
+	pub dirty_pages_hash: [u8; 32],
+	pub completed_at_ms: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommitStageFinalized {
+	pub stage_id: Uuid,
+	pub object_id: Uuid,
+	pub txid: u64,
+	pub finalized_at_ms: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeltaObjectMeta {
+	pub object_id: Uuid,
+	pub stage_id: Uuid,
+	pub staged_txid: u64,
+	pub chunk_count: u32,
+	pub encoded_len: u64,
+	pub object_hash: [u8; 32],
+	pub state: DeltaObjectState,
+	pub created_at_ms: i64,
+	pub expires_after_ms: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DeltaObjectState {
+	StageOwned,
+	Committed { txid: u64 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeltaManifest {
+	pub txid: u64,
+	pub object_id: Uuid,
+	pub chunk_count: u32,
+	pub encoded_len: u64,
+	pub object_hash: [u8; 32],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeltaPageIndexEntry {
+	pub txid: u64,
+	pub object_id: Uuid,
+	pub encoded_offset: u64,
+	pub encoded_size: u32,
+	pub page_hash: [u8; 32],
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HotShardManifest {
+	pub shard_id: u32,
+	pub as_of_txid: u64,
+	pub chunk_count: u32,
+	pub encoded_len: u64,
+	pub content_hash: [u8; 32],
 }
 
 enum VersionedDBHead {
@@ -102,6 +201,69 @@ enum VersionedMetaCompact {
 	V1(MetaCompact),
 }
 
+enum VersionedCommitStageMeta {
+	V1(CommitStageMeta),
+}
+
+enum VersionedDirtyPageBatch {
+	V1(DirtyPageBatch),
+}
+
+enum VersionedCommitStageComplete {
+	V1(CommitStageComplete),
+}
+
+enum VersionedCommitStageFinalized {
+	V1(CommitStageFinalized),
+}
+
+enum VersionedDeltaObjectMeta {
+	V1(DeltaObjectMeta),
+}
+
+enum VersionedDeltaManifest {
+	V1(DeltaManifest),
+}
+
+enum VersionedDeltaPageIndexEntry {
+	V1(DeltaPageIndexEntry),
+}
+
+enum VersionedHotShardManifest {
+	V1(HotShardManifest),
+}
+
+macro_rules! impl_versioned_record {
+	($versioned:ident, $latest:ty, $name:literal) => {
+		impl OwnedVersionedData for $versioned {
+			type Latest = $latest;
+
+			fn wrap_latest(latest: Self::Latest) -> Self {
+				Self::V1(latest)
+			}
+
+			fn unwrap_latest(self) -> Result<Self::Latest> {
+				match self {
+					Self::V1(data) => Ok(data),
+				}
+			}
+
+			fn deserialize_version(payload: &[u8], version: u16) -> Result<Self> {
+				match version {
+					1 => Ok(Self::V1(serde_bare::from_slice(payload)?)),
+					_ => bail!("invalid depot {} version: {}", $name, version),
+				}
+			}
+
+			fn serialize_version(self, _version: u16) -> Result<Vec<u8>> {
+				match self {
+					Self::V1(data) => serde_bare::to_vec(&data).map_err(Into::into),
+				}
+			}
+		}
+	};
+}
+
 impl OwnedVersionedData for VersionedMetaCompact {
 	type Latest = MetaCompact;
 
@@ -128,6 +290,31 @@ impl OwnedVersionedData for VersionedMetaCompact {
 		}
 	}
 }
+
+impl_versioned_record!(VersionedCommitStageMeta, CommitStageMeta, "CommitStageMeta");
+impl_versioned_record!(VersionedDirtyPageBatch, DirtyPageBatch, "DirtyPageBatch");
+impl_versioned_record!(
+	VersionedCommitStageComplete,
+	CommitStageComplete,
+	"CommitStageComplete"
+);
+impl_versioned_record!(
+	VersionedCommitStageFinalized,
+	CommitStageFinalized,
+	"CommitStageFinalized"
+);
+impl_versioned_record!(VersionedDeltaObjectMeta, DeltaObjectMeta, "DeltaObjectMeta");
+impl_versioned_record!(VersionedDeltaManifest, DeltaManifest, "DeltaManifest");
+impl_versioned_record!(
+	VersionedDeltaPageIndexEntry,
+	DeltaPageIndexEntry,
+	"DeltaPageIndexEntry"
+);
+impl_versioned_record!(
+	VersionedHotShardManifest,
+	HotShardManifest,
+	"HotShardManifest"
+);
 
 pub fn encode_db_head(head: DBHead) -> Result<Vec<u8>> {
 	VersionedDBHead::wrap_latest(head)
@@ -159,4 +346,99 @@ pub fn encode_meta_compact(compact: MetaCompact) -> Result<Vec<u8>> {
 pub fn decode_meta_compact(payload: &[u8]) -> Result<MetaCompact> {
 	VersionedMetaCompact::deserialize_with_embedded_version(payload)
 		.context("decode sqlite compact meta")
+}
+
+pub fn encode_commit_stage_meta(meta: CommitStageMeta) -> Result<Vec<u8>> {
+	VersionedCommitStageMeta::wrap_latest(meta)
+		.serialize_with_embedded_version(SQLITE_STORAGE_META_VERSION)
+		.context("encode sqlite commit stage meta")
+}
+
+pub fn decode_commit_stage_meta(payload: &[u8]) -> Result<CommitStageMeta> {
+	VersionedCommitStageMeta::deserialize_with_embedded_version(payload)
+		.context("decode sqlite commit stage meta")
+}
+
+pub fn encode_dirty_page_batch(batch: DirtyPageBatch) -> Result<Vec<u8>> {
+	VersionedDirtyPageBatch::wrap_latest(batch)
+		.serialize_with_embedded_version(SQLITE_STORAGE_META_VERSION)
+		.context("encode sqlite dirty page batch")
+}
+
+pub fn decode_dirty_page_batch(payload: &[u8]) -> Result<DirtyPageBatch> {
+	VersionedDirtyPageBatch::deserialize_with_embedded_version(payload)
+		.context("decode sqlite dirty page batch")
+}
+
+pub fn encode_commit_stage_complete(complete: CommitStageComplete) -> Result<Vec<u8>> {
+	VersionedCommitStageComplete::wrap_latest(complete)
+		.serialize_with_embedded_version(SQLITE_STORAGE_META_VERSION)
+		.context("encode sqlite commit stage complete")
+}
+
+pub fn decode_commit_stage_complete(payload: &[u8]) -> Result<CommitStageComplete> {
+	VersionedCommitStageComplete::deserialize_with_embedded_version(payload)
+		.context("decode sqlite commit stage complete")
+}
+
+pub fn encode_commit_stage_finalized(finalized: CommitStageFinalized) -> Result<Vec<u8>> {
+	VersionedCommitStageFinalized::wrap_latest(finalized)
+		.serialize_with_embedded_version(SQLITE_STORAGE_META_VERSION)
+		.context("encode sqlite commit stage finalized")
+}
+
+pub fn decode_commit_stage_finalized(payload: &[u8]) -> Result<CommitStageFinalized> {
+	VersionedCommitStageFinalized::deserialize_with_embedded_version(payload)
+		.context("decode sqlite commit stage finalized")
+}
+
+pub fn encode_delta_object_meta(meta: DeltaObjectMeta) -> Result<Vec<u8>> {
+	VersionedDeltaObjectMeta::wrap_latest(meta)
+		.serialize_with_embedded_version(SQLITE_STORAGE_META_VERSION)
+		.context("encode sqlite delta object meta")
+}
+
+pub fn decode_delta_object_meta(payload: &[u8]) -> Result<DeltaObjectMeta> {
+	VersionedDeltaObjectMeta::deserialize_with_embedded_version(payload)
+		.context("decode sqlite delta object meta")
+}
+
+pub fn encode_delta_manifest(manifest: DeltaManifest) -> Result<Vec<u8>> {
+	VersionedDeltaManifest::wrap_latest(manifest)
+		.serialize_with_embedded_version(SQLITE_STORAGE_META_VERSION)
+		.context("encode sqlite delta manifest")
+}
+
+pub fn decode_delta_manifest(payload: &[u8]) -> Result<DeltaManifest> {
+	VersionedDeltaManifest::deserialize_with_embedded_version(payload)
+		.context("decode sqlite delta manifest")
+}
+
+pub fn encode_delta_page_index_entry(entry: DeltaPageIndexEntry) -> Result<Vec<u8>> {
+	VersionedDeltaPageIndexEntry::wrap_latest(entry)
+		.serialize_with_embedded_version(SQLITE_STORAGE_META_VERSION)
+		.context("encode sqlite delta page index entry")
+}
+
+pub fn decode_delta_page_index_entry(payload: &[u8]) -> Result<DeltaPageIndexEntry> {
+	VersionedDeltaPageIndexEntry::deserialize_with_embedded_version(payload)
+		.context("decode sqlite delta page index entry")
+}
+
+pub fn encode_hot_shard_manifest(manifest: HotShardManifest) -> Result<Vec<u8>> {
+	let mut bytes = HOT_SHARD_MANIFEST_MAGIC.to_vec();
+	bytes.extend(
+		VersionedHotShardManifest::wrap_latest(manifest)
+		.serialize_with_embedded_version(SQLITE_STORAGE_META_VERSION)
+			.context("encode sqlite hot shard manifest")?,
+	);
+	Ok(bytes)
+}
+
+pub fn decode_hot_shard_manifest(payload: &[u8]) -> Result<HotShardManifest> {
+	let payload = payload
+		.strip_prefix(HOT_SHARD_MANIFEST_MAGIC)
+		.context("sqlite hot shard value is not a manifest")?;
+	VersionedHotShardManifest::deserialize_with_embedded_version(payload)
+		.context("decode sqlite hot shard manifest")
 }

--- a/engine/packages/depot/src/workflows/db_hot_compacter.rs
+++ b/engine/packages/depot/src/workflows/db_hot_compacter.rs
@@ -3,6 +3,7 @@ use crate::compaction::{
 	shared::*,
 	*,
 };
+use crate::conveyer::shard_blob::write_branch_shard_blob;
 use crate::workflows::db_manager::branch_record_is_live_at_generation;
 
 #[cfg(feature = "test-faults")]
@@ -182,14 +183,14 @@ async fn hot_stage_after_shard_write_fault_output(
 	{
 		Ok(Some(fired)) if fired.action == DepotFaultAction::DropArtifact => {
 			for output_ref in output_refs {
-				tx.informal()
-					.clear(&keys::branch_compaction_stage_hot_shard_key(
-						input.database_branch_id,
-						input.job_id,
-						output_ref.shard_id,
-						output_ref.as_of_txid,
-						0,
-					));
+				clear_staged_hot_shard_blob(
+					tx,
+					input.database_branch_id,
+					input.job_id,
+					output_ref,
+					Serializable,
+				)
+				.await?;
 			}
 			Ok(Some(StageHotJobOutput {
 				status: CompactionJobStatus::Succeeded,
@@ -227,7 +228,7 @@ pub async fn install_hot_job(
 		.await
 }
 
-async fn install_hot_job_tx(
+pub(crate) async fn install_hot_job_tx(
 	tx: &universaldb::Transaction,
 	input: &InstallHotJobInput,
 	now_ms: i64,
@@ -357,14 +358,15 @@ async fn install_hot_job_tx(
 			));
 		}
 
-		let stage_key = keys::branch_compaction_stage_hot_shard_key(
+		let Some(staged_blob) = load_staged_hot_shard_blob(
+			tx,
 			input.database_branch_id,
 			input.job_id,
-			output_ref.shard_id,
-			output_ref.as_of_txid,
-			0,
-		);
-		let Some(staged_blob) = tx_get_value(tx, &stage_key, Serializable).await? else {
+			output_ref,
+			Serializable,
+		)
+		.await?
+		else {
 			return Ok(rejected_hot_install("staged hot shard is missing"));
 		};
 		if output_ref.size_bytes != u64::try_from(staged_blob.len()).unwrap_or(u64::MAX)
@@ -394,14 +396,13 @@ async fn install_hot_job_tx(
 		return Ok(output);
 	}
 	for (output_ref, staged_blob) in &staged_blobs {
-		tx.informal().set(
-			&keys::branch_shard_key(
-				input.database_branch_id,
-				output_ref.shard_id,
-				output_ref.as_of_txid,
-			),
+		write_branch_shard_blob(
+			tx,
+			input.database_branch_id,
+			output_ref.shard_id,
+			output_ref.as_of_txid,
 			staged_blob,
-		);
+		)?;
 	}
 	#[cfg(feature = "test-faults")]
 	if let Some(output) = hot_install_fault_output(
@@ -497,14 +498,14 @@ async fn hot_install_before_staged_read_fault_output(
 	{
 		Ok(Some(fired)) if fired.action == DepotFaultAction::DropArtifact => {
 			for output_ref in &input.output_refs {
-				tx.informal()
-					.clear(&keys::branch_compaction_stage_hot_shard_key(
-						input.database_branch_id,
-						input.job_id,
-						output_ref.shard_id,
-						output_ref.as_of_txid,
-						0,
-					));
+				clear_staged_hot_shard_blob(
+					tx,
+					input.database_branch_id,
+					input.job_id,
+					output_ref,
+					Serializable,
+				)
+				.await?;
 			}
 			Ok(None)
 		}

--- a/engine/packages/depot/src/workflows/db_reclaimer.rs
+++ b/engine/packages/depot/src/workflows/db_reclaimer.rs
@@ -4,6 +4,7 @@ use crate::{
 		shared::*,
 		test_hooks, *,
 	},
+	conveyer::shard_blob::clear_branch_shard_chunks,
 	conveyer::metrics,
 	workflows::db_manager::branch_record_is_live_at_generation,
 };
@@ -62,7 +63,7 @@ fn record_shard_cache_eviction_metrics(input: &ReclaimFdbJobInput, output: &Recl
 	}
 }
 
-async fn reclaim_fdb_job_tx(
+pub(crate) async fn reclaim_fdb_job_tx(
 	tx: &universaldb::Transaction,
 	input: &ReclaimFdbJobInput,
 	cold_storage_enabled: bool,
@@ -189,6 +190,22 @@ async fn reclaim_fdb_job_tx(
 		.iter()
 		.map(|txid_ref| txid_ref.txid)
 		.collect::<BTreeSet<_>>();
+	let large_delta_txids = snapshot
+		.large_delta_manifests
+		.iter()
+		.map(|(txid, _, _, _)| *txid)
+		.collect::<BTreeSet<_>>();
+	let complete_large_delta_txids = snapshot
+		.large_delta_complete_txids
+		.iter()
+		.copied()
+		.collect::<BTreeSet<_>>();
+	let complete_large_delta_objects = snapshot
+		.large_delta_manifests
+		.iter()
+		.filter(|(txid, _, _, _)| complete_large_delta_txids.contains(txid))
+		.map(|(_, _, _, manifest)| manifest.object_id)
+		.collect::<BTreeSet<_>>();
 	let mut key_count = 0_u32;
 	let mut byte_count = 0_u64;
 	#[cfg(feature = "test-faults")]
@@ -200,6 +217,9 @@ async fn reclaim_fdb_job_tx(
 	}
 	for (txid, key, value, commit) in &snapshot.commits {
 		if !selected_reclaim_txids.contains(txid) {
+			continue;
+		}
+		if large_delta_txids.contains(txid) && !complete_large_delta_txids.contains(txid) {
 			continue;
 		}
 		udb::compare_and_clear(tx, key, value);
@@ -227,6 +247,46 @@ async fn reclaim_fdb_job_tx(
 		key_count = key_count.saturating_add(1);
 		byte_count = byte_count.saturating_add(u64::try_from(value.len()).unwrap_or(u64::MAX));
 	}
+	for (txid, key, value, _) in &snapshot.large_delta_manifests {
+		if !selected_reclaim_txids.contains(txid) {
+			continue;
+		}
+		if !complete_large_delta_txids.contains(txid) {
+			continue;
+		}
+		udb::compare_and_clear(tx, key, value);
+		key_count = key_count.saturating_add(1);
+		byte_count = byte_count.saturating_add(u64::try_from(value.len()).unwrap_or(u64::MAX));
+	}
+	for (txid, _, key, value, _) in &snapshot.large_delta_pageidx_entries {
+		if !selected_reclaim_txids.contains(txid) {
+			continue;
+		}
+		udb::compare_and_clear(tx, key, value);
+		key_count = key_count.saturating_add(1);
+		byte_count = byte_count.saturating_add(u64::try_from(value.len()).unwrap_or(u64::MAX));
+	}
+	for (object_id, key, value) in &snapshot.large_delta_object_refs {
+		if !complete_large_delta_objects.contains(object_id) {
+			continue;
+		}
+		udb::compare_and_clear(tx, key, value);
+		key_count = key_count.saturating_add(1);
+		byte_count = byte_count.saturating_add(u64::try_from(value.len()).unwrap_or(u64::MAX));
+	}
+	for (object_id, key, value, _) in &snapshot.large_delta_object_metas {
+		if !complete_large_delta_objects.contains(object_id) {
+			continue;
+		}
+		udb::compare_and_clear(tx, key, value);
+		key_count = key_count.saturating_add(1);
+		byte_count = byte_count.saturating_add(u64::try_from(value.len()).unwrap_or(u64::MAX));
+	}
+	for (_, key, value) in &snapshot.large_delta_object_chunks {
+		udb::compare_and_clear(tx, key, value);
+		key_count = key_count.saturating_add(1);
+		byte_count = byte_count.saturating_add(u64::try_from(value.len()).unwrap_or(u64::MAX));
+	}
 	for (_, key, value, _) in &snapshot.expired_pitr_interval_rows {
 		udb::compare_and_clear(tx, key, value);
 		key_count = key_count.saturating_add(1);
@@ -240,7 +300,14 @@ async fn reclaim_fdb_job_tx(
 		{
 			continue;
 		}
-		udb::compare_and_clear(tx, &candidate.shard_key, &candidate.shard_bytes);
+		udb::compare_and_clear(tx, &candidate.shard_key, &candidate.shard_row_bytes);
+		clear_branch_shard_chunks(
+			tx,
+			input.database_branch_id,
+			candidate.reference.shard_id,
+			candidate.reference.as_of_txid,
+			&candidate.shard_row_bytes,
+		)?;
 		key_count = key_count.saturating_add(1);
 		byte_count = byte_count
 			.saturating_add(u64::try_from(candidate.shard_bytes.len()).unwrap_or(u64::MAX));
@@ -309,14 +376,15 @@ pub(super) async fn cleanup_repair_fdb_outputs_tx(
 	let mut key_count = 0_u32;
 	let mut byte_count = 0_u64;
 	for staged in &input.input_range.staged_hot_shards {
-		let stage_key = keys::branch_compaction_stage_hot_shard_key(
+		let Some(stage_value) = load_staged_hot_shard_blob(
+			tx,
 			input.database_branch_id,
 			staged.job_id,
-			staged.output_ref.shard_id,
-			staged.output_ref.as_of_txid,
-			0,
-		);
-		let Some(stage_value) = tx_get_value(tx, &stage_key, Serializable).await? else {
+			&staged.output_ref,
+			Serializable,
+		)
+		.await?
+		else {
 			continue;
 		};
 		if staged.output_ref.size_bytes != u64::try_from(stage_value.len()).unwrap_or(u64::MAX)
@@ -345,7 +413,14 @@ pub(super) async fn cleanup_repair_fdb_outputs_tx(
 			repair_action = "clear_staged_hot_output",
 			"clearing orphan staged hot shard output"
 		);
-		udb::compare_and_clear(tx, &stage_key, &stage_value);
+		clear_staged_hot_shard_blob(
+			tx,
+			input.database_branch_id,
+			staged.job_id,
+			&staged.output_ref,
+			Serializable,
+		)
+		.await?;
 		key_count = key_count.saturating_add(1);
 		byte_count =
 			byte_count.saturating_add(u64::try_from(stage_value.len()).unwrap_or(u64::MAX));

--- a/engine/packages/depot/src/workflows/mod.rs
+++ b/engine/packages/depot/src/workflows/mod.rs
@@ -19,11 +19,15 @@ pub mod compaction {
 
 #[cfg(test)]
 use crate::compaction::shared::{
-	content_hash, fingerprint_repair_reclaim_range, plan_cold_job, plan_hot_job,
-	read_reclaim_input_snapshot,
+	content_hash, fingerprint_hot_inputs, fingerprint_reclaim_inputs,
+	fingerprint_repair_reclaim_range, load_staged_hot_shard_blob, plan_cold_job, plan_hot_job,
+	read_hot_input_snapshot, read_reclaim_input_snapshot,
+	reclaim_coverage_is_complete, write_staged_hot_shards,
 };
 #[cfg(test)]
 use compaction::*;
+#[cfg(test)]
+use db_hot_compacter::install_hot_job_tx;
 #[cfg(test)]
 use db_manager::{
 	ManagerEffect, manager_effect_for_requested_stop, manager_effects_after_refresh,
@@ -31,7 +35,9 @@ use db_manager::{
 	manager_effects_for_reclaim_job_finished, repair_reclaim_input_range,
 };
 #[cfg(test)]
-use db_reclaimer::{cleanup_repair_fdb_outputs_tx, plan_orphan_cold_object_deletes_tx};
+use db_reclaimer::{
+	cleanup_repair_fdb_outputs_tx, plan_orphan_cold_object_deletes_tx, reclaim_fdb_job_tx,
+};
 
 #[cfg(test)]
 #[path = "../../tests/inline/workflows_compaction.rs"]

--- a/engine/packages/depot/tests/conveyer_read.rs
+++ b/engine/packages/depot/tests/conveyer_read.rs
@@ -11,17 +11,19 @@ use depot::{
 	error::SqliteStorageError,
 	keys::{
 		PAGE_SIZE, branch_commit_key, branch_compaction_cold_shard_key, branch_compaction_root_key,
-		branch_delta_chunk_key, branch_delta_chunk_prefix, branch_manifest_last_access_bucket_key,
-		branch_manifest_last_access_ts_ms_key, branch_meta_head_key, branch_pidx_key,
-		branch_shard_key,
+		branch_delta_chunk_key, branch_delta_chunk_prefix, branch_delta_manifest_key,
+		branch_delta_object_chunk_key, branch_delta_pageidx_key,
+		branch_manifest_last_access_bucket_key, branch_manifest_last_access_ts_ms_key,
+		branch_meta_head_key, branch_pidx_key, branch_shard_key,
 	},
 	ltx::{LtxHeader, encode_ltx_v3},
 	types::{
 		ColdManifestChunk, ColdManifestChunkRef, ColdManifestIndex, ColdShardRef, CompactionRoot,
 		DBHead, DatabaseBranchId, DirtyPage, FetchedPage, LayerEntry, LayerKind,
 		ResolvedVersionstamp, SQLITE_STORAGE_COLD_SCHEMA_VERSION, decode_commit_row,
-		decode_compaction_root, encode_cold_manifest_chunk, encode_cold_manifest_index,
-		encode_cold_shard_ref, encode_compaction_root, encode_db_head,
+		decode_compaction_root, decode_delta_manifest, decode_delta_page_index_entry,
+		encode_cold_manifest_chunk, encode_cold_manifest_index, encode_cold_shard_ref,
+		encode_compaction_root, encode_db_head, encode_delta_page_index_entry,
 	},
 };
 #[cfg(feature = "test-faults")]
@@ -65,6 +67,12 @@ fn dirty_page(pgno: u32, fill: u8) -> DirtyPage {
 		pgno,
 		bytes: page(fill),
 	}
+}
+
+fn large_dirty_pages(count: u32) -> Vec<DirtyPage> {
+	(1..=count)
+		.map(|pgno| dirty_page(pgno, (pgno % 251) as u8))
+		.collect()
 }
 
 fn encoded_blob(txid: u64, pages: &[(u32, u8)]) -> Result<Vec<u8>> {
@@ -890,6 +898,138 @@ async fn get_pages_errors_for_corrupted_delta_source() -> Result<()> {
 
 		Ok(())
 	})
+}
+
+#[tokio::test]
+async fn get_pages_errors_when_large_delta_page_index_is_missing() -> Result<()> {
+	let db = common::test_db_arc("depot-read-large-delta-missing-pageidx").await?;
+	let database_db = common::make_db(Arc::clone(&db), test_bucket(), TEST_DATABASE);
+	let target_pgno = 128;
+
+	database_db
+		.commit(large_dirty_pages(2_049), 2_049, 1_000)
+		.await?;
+	let branch_id = read_database_branch_id(&db).await?;
+	seed(
+		&db,
+		Vec::new(),
+		vec![branch_delta_pageidx_key(branch_id, 1, target_pgno)],
+	)
+	.await?;
+
+	let err = database_db
+		.get_pages(vec![target_pgno])
+		.await
+		.expect_err("missing large delta page index should be a hard storage error");
+	assert!(
+		err.chain()
+			.any(|cause| cause.to_string().contains("large delta page index missing")),
+		"unexpected error chain: {err:?}"
+	);
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn get_pages_errors_when_large_delta_manifest_is_missing() -> Result<()> {
+	let db = common::test_db_arc("depot-read-large-delta-missing-manifest").await?;
+	let database_db = common::make_db(Arc::clone(&db), test_bucket(), TEST_DATABASE);
+	let target_pgno = 128;
+
+	database_db
+		.commit(large_dirty_pages(2_049), 2_049, 1_000)
+		.await?;
+	let branch_id = read_database_branch_id(&db).await?;
+	seed(
+		&db,
+		Vec::new(),
+		vec![branch_delta_manifest_key(branch_id, 1)],
+	)
+	.await?;
+
+	let err = database_db
+		.get_pages(vec![target_pgno])
+		.await
+		.expect_err("missing large delta manifest should be a hard storage error");
+	assert!(
+		err.chain()
+			.any(|cause| cause.to_string().contains("large delta manifest missing")),
+		"unexpected error chain: {err:?}"
+	);
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn get_pages_errors_when_large_delta_object_chunk_is_missing() -> Result<()> {
+	let db = common::test_db_arc("depot-read-large-delta-missing-chunk").await?;
+	let database_db = common::make_db(Arc::clone(&db), test_bucket(), TEST_DATABASE);
+
+	database_db
+		.commit(large_dirty_pages(2_049), 2_049, 1_000)
+		.await?;
+	let branch_id = read_database_branch_id(&db).await?;
+	let manifest_bytes = read_value(&db, branch_delta_manifest_key(branch_id, 1))
+		.await?
+		.expect("large delta manifest should exist");
+	let manifest = decode_delta_manifest(&manifest_bytes)?;
+	seed(
+		&db,
+		Vec::new(),
+		vec![branch_delta_object_chunk_key(branch_id, manifest.object_id, 0)],
+	)
+	.await?;
+
+	let err = database_db
+		.get_pages(vec![1])
+		.await
+		.expect_err("missing large delta object chunk should be a hard storage error");
+	assert!(
+		err.chain()
+			.any(|cause| cause.to_string().contains("large delta object chunk missing")),
+		"unexpected error chain: {err:?}"
+	);
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn get_pages_errors_when_large_delta_page_hash_is_bad() -> Result<()> {
+	let db = common::test_db_arc("depot-read-large-delta-bad-page-hash").await?;
+	let database_db = common::make_db(Arc::clone(&db), test_bucket(), TEST_DATABASE);
+	let target_pgno = 128;
+
+	database_db
+		.commit(large_dirty_pages(2_049), 2_049, 1_000)
+		.await?;
+	let branch_id = read_database_branch_id(&db).await?;
+	let page_index_key = branch_delta_pageidx_key(branch_id, 1, target_pgno);
+	let page_index_bytes = read_value(&db, page_index_key.clone())
+		.await?
+		.expect("large delta page index should exist");
+	let mut page_index = decode_delta_page_index_entry(&page_index_bytes)?;
+	page_index.page_hash[0] ^= 0xff;
+	seed(
+		&db,
+		vec![(
+			page_index_key,
+			encode_delta_page_index_entry(page_index)?,
+		)],
+		Vec::new(),
+	)
+	.await?;
+
+	let err = database_db
+		.get_pages(vec![target_pgno])
+		.await
+		.expect_err("bad large delta page hash should be a hard storage error");
+	assert!(
+		err.chain()
+			.any(|cause| cause.to_string().contains("large delta page hash mismatch")),
+		"unexpected error chain: {err:?}"
+	);
+
+	Ok(())
 }
 
 #[tokio::test]

--- a/engine/packages/depot/tests/gc.rs
+++ b/engine/packages/depot/tests/gc.rs
@@ -8,16 +8,26 @@ use depot::{
 		sweep_unreferenced_branch,
 	},
 	keys::{
-		branch_commit_key, branch_delta_chunk_key, branch_meta_head_key, branch_pidx_key,
-		branch_shard_key, branch_vtx_key, branches_desc_pin_key, branches_list_key,
-		branches_refcount_key, branches_restore_point_pin_key, db_pin_key,
+		PAGE_SIZE, branch_commit_key, branch_commit_stage_meta_key, branch_commit_stage_prefix,
+		branch_delta_chunk_key, branch_delta_object_chunk_prefix, branch_delta_object_meta_key,
+		branch_delta_object_prefix, branch_meta_head_key, branch_pidx_key, branch_shard_key,
+		branch_vtx_key, branches_desc_pin_key, branches_list_key, branches_refcount_key,
+		branches_restore_point_pin_key, commit_stage_lookup_key, db_pin_key,
 	},
+	quota,
 	types::{
-		BranchState, BucketBranchId, CommitRow, DatabaseBranchId, DatabaseBranchRecord,
-		encode_commit_row, encode_database_branch_record,
+		BranchState, BucketBranchId, CommitOptions, CommitRow, DatabaseBranchId,
+		DatabaseBranchRecord, DirtyPage, decode_commit_stage_meta, encode_commit_row,
+		encode_database_branch_record,
 	},
 };
-use universaldb::utils::IsolationLevel::Snapshot;
+use futures_util::TryStreamExt;
+use universaldb::{
+	RangeOption,
+	options::StreamingMode,
+	utils::IsolationLevel::{Serializable, Snapshot},
+};
+use uuid::Uuid;
 
 fn branch_id() -> DatabaseBranchId {
 	DatabaseBranchId::from_uuid(uuid::Uuid::from_u128(
@@ -37,6 +47,110 @@ async fn read_value(db: &universaldb::Database, key: Vec<u8>) -> Result<Option<V
 		}
 	})
 	.await
+}
+
+async fn prefix_count(db: &universaldb::Database, prefix: Vec<u8>) -> Result<usize> {
+	db.run(move |tx| {
+		let prefix = prefix.clone();
+		async move {
+			let prefix_subspace = universaldb::Subspace::from(
+				universaldb::tuple::Subspace::from_bytes(prefix),
+			);
+			let informal = tx.informal();
+			let mut stream = informal.get_ranges_keyvalues(
+				RangeOption {
+					mode: StreamingMode::WantAll,
+					..RangeOption::from(&prefix_subspace)
+				},
+				Snapshot,
+			);
+			let mut count = 0;
+			while stream.try_next().await?.is_some() {
+				count += 1;
+			}
+			Ok(count)
+		}
+	})
+	.await
+}
+
+async fn clear_prefix(db: &universaldb::Database, prefix: Vec<u8>) -> Result<()> {
+	db.run(move |tx| {
+		let prefix = prefix.clone();
+		async move {
+			let prefix_subspace = universaldb::Subspace::from(
+				universaldb::tuple::Subspace::from_bytes(prefix),
+			);
+			let informal = tx.informal();
+			let mut stream = informal.get_ranges_keyvalues(
+				RangeOption {
+					mode: StreamingMode::WantAll,
+					..RangeOption::from(&prefix_subspace)
+				},
+				Serializable,
+			);
+			let mut keys = Vec::new();
+			while let Some(entry) = stream.try_next().await? {
+				keys.push(entry.key().to_vec());
+			}
+			for key in keys {
+				tx.informal().clear(&key);
+			}
+			Ok(())
+		}
+	})
+	.await
+}
+
+async fn read_staged_quota(
+	db: &universaldb::Database,
+	branch_id: DatabaseBranchId,
+) -> Result<i64> {
+	db.run(move |tx| async move { quota::read_branch_staged(&tx, branch_id).await })
+		.await
+}
+
+fn gc_dirty_pages(count: u32) -> Vec<DirtyPage> {
+	(1..=count)
+		.map(|pgno| DirtyPage {
+			pgno,
+			bytes: vec![(pgno % 251) as u8; PAGE_SIZE as usize],
+		})
+		.collect()
+}
+
+async fn stage_branch_id(db: &universaldb::Database, stage_id: Uuid) -> Result<DatabaseBranchId> {
+	let bytes = read_value(db, commit_stage_lookup_key(stage_id))
+		.await?
+		.expect("stage lookup should exist");
+	Ok(DatabaseBranchId::from_uuid(Uuid::from_slice(&bytes)?))
+}
+
+async fn complete_test_stage(ctx: &common::TestDb, now_ms: i64) -> Result<(Uuid, DatabaseBranchId, Uuid)> {
+	let dirty_pages = gc_dirty_pages(32);
+	let begin = ctx
+		.db
+		.commit_stage_begin(
+			dirty_pages.iter().map(|page| page.pgno).collect(),
+			32,
+			now_ms,
+			CommitOptions::default(),
+		)
+		.await?;
+	let branch_id = stage_branch_id(&ctx.udb, begin.stage_id).await?;
+	for (batch_idx, batch) in dirty_pages.chunks(16).enumerate() {
+		ctx.db
+			.commit_stage_pages(begin.stage_id, batch_idx as u32, batch.to_vec())
+			.await?;
+	}
+	ctx.db
+		.commit_stage_complete(begin.stage_id, 2)
+		.await?;
+	let meta_bytes = read_value(&ctx.udb, branch_commit_stage_meta_key(branch_id, begin.stage_id))
+		.await?
+		.expect("stage meta should exist");
+	let meta = decode_commit_stage_meta(&meta_bytes)?;
+	Ok((begin.stage_id, branch_id, meta.object_id))
 }
 
 async fn read_refcount(db: &universaldb::Database, branch_id: DatabaseBranchId) -> Result<i64> {
@@ -97,6 +211,141 @@ async fn write_commit(db: &universaldb::Database, txid: u64, versionstamp: [u8; 
 			&txid.to_be_bytes(),
 		);
 		Ok(())
+	})
+	.await
+}
+
+#[tokio::test]
+async fn commit_stage_abort_removes_stage_object_and_releases_quota() -> Result<()> {
+	common::test_matrix("depot-gc-stage-abort", |_tier, ctx| {
+		Box::pin(async move {
+			let (stage_id, branch_id, object_id) = complete_test_stage(&ctx, 1_000).await?;
+			assert!(
+				read_staged_quota(&ctx.udb, branch_id).await? > 0,
+				"stage begin should reserve staged quota"
+			);
+			assert!(
+				prefix_count(&ctx.udb, branch_delta_object_prefix(branch_id, object_id)).await? > 0,
+				"completed stage should write object rows"
+			);
+
+			ctx.db.commit_stage_abort(stage_id).await?;
+
+			assert_eq!(read_staged_quota(&ctx.udb, branch_id).await?, 0);
+			assert!(
+				read_value(&ctx.udb, commit_stage_lookup_key(stage_id))
+					.await?
+					.is_none()
+			);
+			assert_eq!(
+				prefix_count(&ctx.udb, branch_commit_stage_prefix(branch_id, stage_id)).await?,
+				0
+			);
+			assert_eq!(
+				prefix_count(&ctx.udb, branch_delta_object_prefix(branch_id, object_id)).await?,
+				0
+			);
+			Ok(())
+		})
+	})
+	.await
+}
+
+#[tokio::test]
+async fn expired_commit_stage_gc_removes_object_and_releases_quota() -> Result<()> {
+	common::test_matrix("depot-gc-expired-stage", |_tier, ctx| {
+		Box::pin(async move {
+			let (stage_id, branch_id, object_id) = complete_test_stage(&ctx, 2_000).await?;
+			let before_quota = read_staged_quota(&ctx.udb, branch_id).await?;
+			assert!(before_quota > 0);
+
+			let outcome = ctx
+				.db
+				.gc_expired_commit_stages(2_000 + 24 * 60 * 60 * 1_000 + 1)
+				.await?;
+
+			assert_eq!(outcome.stages_deleted, 1);
+			assert_eq!(outcome.quota_released_bytes, before_quota);
+			assert_eq!(read_staged_quota(&ctx.udb, branch_id).await?, 0);
+			assert!(
+				read_value(&ctx.udb, commit_stage_lookup_key(stage_id))
+					.await?
+					.is_none()
+			);
+			assert_eq!(
+				prefix_count(&ctx.udb, branch_delta_object_prefix(branch_id, object_id)).await?,
+				0
+			);
+			Ok(())
+		})
+	})
+	.await
+}
+
+#[tokio::test]
+async fn expired_orphan_delta_object_gc_removes_unreferenced_object_rows() -> Result<()> {
+	common::test_matrix("depot-gc-orphan-delta-object", |_tier, ctx| {
+		Box::pin(async move {
+			let (stage_id, branch_id, object_id) = complete_test_stage(&ctx, 3_000).await?;
+			clear_prefix(&ctx.udb, branch_commit_stage_prefix(branch_id, stage_id)).await?;
+
+			let outcome = ctx
+				.db
+				.gc_expired_orphan_delta_objects(branch_id, 3_000 + 24 * 60 * 60 * 1_000 + 1)
+				.await?;
+
+			assert_eq!(outcome.orphan_objects_deleted, 1);
+			assert_eq!(
+				prefix_count(&ctx.udb, branch_delta_object_prefix(branch_id, object_id)).await?,
+				0
+			);
+			assert!(
+				read_value(&ctx.udb, commit_stage_lookup_key(stage_id))
+					.await?
+					.is_none()
+			);
+			Ok(())
+		})
+	})
+	.await
+}
+
+#[tokio::test]
+async fn expired_finalized_stage_gc_retains_committed_delta_object() -> Result<()> {
+	common::test_matrix("depot-gc-finalized-stage", |_tier, ctx| {
+		Box::pin(async move {
+			let (stage_id, branch_id, object_id) = complete_test_stage(&ctx, 4_000).await?;
+			let result = ctx.db.commit_stage_finalize(stage_id).await?;
+			let retry = ctx.db.commit_stage_finalize(stage_id).await?;
+			assert_eq!(retry.head_txid, result.head_txid);
+
+			let outcome = ctx
+				.db
+				.gc_expired_commit_stages(4_000 + 24 * 60 * 60 * 1_000 + 1)
+				.await?;
+
+			assert_eq!(outcome.finalized_tombstones_deleted, 1);
+			assert!(
+				read_value(&ctx.udb, commit_stage_lookup_key(stage_id))
+					.await?
+					.is_none()
+			);
+			assert_eq!(
+				prefix_count(&ctx.udb, branch_commit_stage_prefix(branch_id, stage_id)).await?,
+				0
+			);
+			assert!(
+				read_value(&ctx.udb, branch_delta_object_meta_key(branch_id, object_id))
+					.await?
+					.is_some()
+			);
+			assert!(
+				prefix_count(&ctx.udb, branch_delta_object_chunk_prefix(branch_id, object_id))
+					.await?
+					> 0
+			);
+			Ok(())
+		})
 	})
 	.await
 }

--- a/engine/packages/depot/tests/inline/workflows_compaction.rs
+++ b/engine/packages/depot/tests/inline/workflows_compaction.rs
@@ -1,33 +1,43 @@
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use anyhow::Result;
 use gas::prelude::Id;
+use rivet_pools::NodeId;
 use sha2::{Digest, Sha256};
 use tempfile::Builder;
 use universaldb::utils::IsolationLevel::Snapshot;
 use uuid::Uuid;
 
+use crate::DELTA_OBJECT_CHUNK_BYTES;
 use super::{
 	ActiveColdCompactionJob, ActiveHotCompactionJob, ActiveReclaimCompactionJob, BranchStopState,
 	ColdInputSnapshot, ColdJobFinished, ColdJobInputRange, ColdShardBlob, ColdShardRef,
-	CompactionJobKind, CompactionJobStatus, CompactionRoot, CompanionWorkflowIds, DatabaseBranchId,
-	DatabaseBranchRecord, DbManagerInput, DbManagerState, ForceCompaction, ForceCompactionTracker,
-	ForceCompactionWork, HotInputSnapshot, HotJobFinished, HotJobInputRange, HotShardOutputRef,
-	ManagerActiveJobs, ManagerEffect, ManagerFdbSnapshot, ManagerPlanningDeadlines,
+	CompactionInputFingerprint, CompactionJobKind, CompactionJobStatus, CompactionRoot,
+	CompanionWorkflowIds, DatabaseBranchId, DatabaseBranchRecord, DbManagerInput, DbManagerState,
+	ForceCompaction, ForceCompactionTracker, ForceCompactionWork, HotInputSnapshot,
+	HotJobFinished, HotJobInputRange, HotShardOutputRef, InstallHotJobInput, ManagerActiveJobs,
+	ManagerEffect, ManagerFdbSnapshot, ManagerPlanningDeadlines,
 	ManagerStopReason, PlannedColdCompactionJob, PlannedHotCompactionJob,
 	PlannedReclaimCompactionJob, ReclaimFdbJobInput, ReclaimInputSnapshot, ReclaimJobFinished,
-	ReclaimJobInputRange, RefreshManagerOutput, ShardCachePolicy, StagedHotShardCleanupRef,
-	TxidRange, cleanup_repair_fdb_outputs_tx, fingerprint_repair_reclaim_range,
+	ReclaimJobInputRange, RefreshManagerOutput, ShardCachePolicy, StageHotJobInput,
+	StagedHotShardCleanupRef, TxidRange, cleanup_repair_fdb_outputs_tx,
+	fingerprint_hot_inputs, fingerprint_reclaim_inputs, fingerprint_repair_reclaim_range,
 	manager_effect_for_requested_stop, manager_effects_after_refresh,
 	manager_effects_for_cold_job_finished, manager_effects_for_hot_job_finished,
-	manager_effects_for_reclaim_job_finished, plan_cold_job, plan_hot_job,
-	plan_orphan_cold_object_deletes_tx, read_reclaim_input_snapshot, repair_reclaim_input_range,
+	manager_effects_for_reclaim_job_finished, install_hot_job_tx, plan_cold_job, plan_hot_job,
+	plan_orphan_cold_object_deletes_tx, load_staged_hot_shard_blob, read_hot_input_snapshot,
+	read_reclaim_input_snapshot, reclaim_coverage_is_complete, reclaim_fdb_job_tx,
+	repair_reclaim_input_range, write_staged_hot_shards,
 };
 use crate::conveyer::{
-	keys,
+	Db, branch, keys,
+	ltx::{LtxEncoder, LtxHeader, decode_ltx_v3},
 	types::{
-		BranchState, BucketBranchId, CommitRow, DBHead, encode_commit_row, encode_compaction_root,
-		encode_database_branch_record,
+		BranchState, BucketBranchId, BucketId, CommitRow, DBHead, DeltaManifest,
+		DeltaObjectMeta, DeltaObjectState, DeltaPageIndexEntry, DirtyPage, decode_db_head,
+		encode_commit_row, encode_compaction_root, encode_database_branch_record,
+		encode_db_head, encode_delta_manifest, encode_delta_object_meta,
+		encode_delta_page_index_entry, PitrPolicy,
 	},
 };
 
@@ -116,6 +126,82 @@ fn update_expected_fingerprint(fingerprint: &mut Sha256, bytes: &[u8]) {
 	fingerprint.update(bytes);
 }
 
+fn patterned_page(pgno: u32) -> Vec<u8> {
+	let mut state = (pgno as u64)
+		.wrapping_mul(0x9e37_79b9_7f4a_7c15)
+		.wrapping_add(0xd1b5_4a32_d192_ed03);
+	let mut bytes = vec![0; keys::PAGE_SIZE as usize];
+	for byte in &mut bytes {
+		state ^= state << 13;
+		state ^= state >> 7;
+		state ^= state << 17;
+		*byte = (state >> 32) as u8;
+	}
+	bytes
+}
+
+fn patterned_dirty_page(pgno: u32) -> DirtyPage {
+	DirtyPage {
+		pgno,
+		bytes: patterned_page(pgno),
+	}
+}
+
+fn patterned_dirty_pages(count: u32) -> Vec<DirtyPage> {
+	(1..=count).map(patterned_dirty_page).collect()
+}
+
+async fn read_test_branch_id(
+	db: &universaldb::Database,
+	bucket_id: Id,
+	database_id: &str,
+) -> Result<DatabaseBranchId> {
+	let database_id = database_id.to_string();
+	db.run(move |tx| {
+		let database_id = database_id.clone();
+		async move {
+			branch::resolve_database_branch(
+				&tx,
+				BucketId::from_gas_id(bucket_id),
+				&database_id,
+				Snapshot,
+			)
+			.await?
+			.ok_or_else(|| anyhow::anyhow!("database branch should exist"))
+		}
+	})
+	.await
+}
+
+async fn read_test_head(
+	db: &universaldb::Database,
+	database_branch_id: DatabaseBranchId,
+) -> Result<DBHead> {
+	db.run(move |tx| async move {
+		let bytes = tx
+			.informal()
+			.get(&keys::branch_meta_head_key(database_branch_id), Snapshot)
+			.await?
+			.ok_or_else(|| anyhow::anyhow!("database head should exist"))?;
+		decode_db_head(&bytes)
+	})
+	.await
+}
+
+async fn read_test_value(db: &universaldb::Database, key: Vec<u8>) -> Result<Option<Vec<u8>>> {
+	db.run(move |tx| {
+		let key = key.clone();
+		async move {
+			Ok(tx
+				.informal()
+				.get(&key, Snapshot)
+				.await?
+				.map(Vec::<u8>::from))
+		}
+	})
+	.await
+}
+
 fn planned_hot_job(
 	database_branch_id: DatabaseBranchId,
 	job_id: Id,
@@ -189,6 +275,140 @@ fn reclaim_range() -> ReclaimJobInputRange {
 		max_keys: 10,
 		max_bytes: 4096,
 	}
+}
+
+struct SeededLargeDelta {
+	object_id: Uuid,
+	chunk_count: u32,
+	pages: Vec<DirtyPage>,
+}
+
+fn complete_large_delta_rows(
+	database_branch_id: DatabaseBranchId,
+	txid: u64,
+	pages: Vec<DirtyPage>,
+) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, SeededLargeDelta)> {
+	let object_id = Uuid::from_u128(0xfeed_0000_0000_0000_0000_0000_0000_0001);
+	let stage_id = Uuid::from_u128(0xfeed_0000_0000_0000_0000_0000_0000_0002);
+	let encoded = LtxEncoder::new(LtxHeader::delta(txid, 1, 1_000)).encode_with_index(&pages)?;
+	let object_hash = Sha256::digest(&encoded.bytes);
+	let mut object_hash_bytes = [0_u8; 32];
+	object_hash_bytes.copy_from_slice(&object_hash);
+	let chunks = encoded
+		.bytes
+		.chunks(DELTA_OBJECT_CHUNK_BYTES)
+		.map(Vec::from)
+		.collect::<Vec<_>>();
+	let chunk_count = u32::try_from(chunks.len())?;
+	let pages_by_pgno = pages
+		.iter()
+		.map(|page| (page.pgno, page.bytes.clone()))
+		.collect::<BTreeMap<_, _>>();
+	let db_size_pages = pages.iter().map(|page| page.pgno).max().unwrap_or(0);
+	let txid_bytes = txid.to_be_bytes().to_vec();
+	let versionstamp = [txid as u8; 16];
+	let root = root_with_watermarks(1, txid, 0);
+	let head = DBHead {
+		head_txid: txid,
+		db_size_pages,
+		post_apply_checksum: 0,
+		branch_id: database_branch_id,
+		#[cfg(debug_assertions)]
+		generation: 0,
+	};
+	let commit_row = CommitRow {
+		wall_clock_ms: 1_234,
+		versionstamp,
+		db_size_pages,
+		post_apply_checksum: 0,
+	};
+	let manifest = DeltaManifest {
+		txid,
+		object_id,
+		chunk_count,
+		encoded_len: encoded.bytes.len() as u64,
+		object_hash: object_hash_bytes,
+	};
+	let object_meta = DeltaObjectMeta {
+		object_id,
+		stage_id,
+		staged_txid: txid,
+		chunk_count,
+		encoded_len: encoded.bytes.len() as u64,
+		object_hash: object_hash_bytes,
+		state: DeltaObjectState::Committed { txid },
+		created_at_ms: 1_000,
+		expires_after_ms: 0,
+	};
+
+	let mut rows = vec![
+		(
+			keys::branches_list_key(database_branch_id),
+			encode_database_branch_record(branch_record(database_branch_id, 1))?,
+		),
+		(
+			keys::branch_compaction_root_key(database_branch_id),
+			encode_compaction_root(root)?,
+		),
+		(
+			keys::branch_meta_head_key(database_branch_id),
+			encode_db_head(head)?,
+		),
+		(
+			keys::branch_commit_key(database_branch_id, txid),
+			encode_commit_row(commit_row)?,
+		),
+		(keys::branch_vtx_key(database_branch_id, versionstamp), txid_bytes.clone()),
+		(
+			keys::branch_delta_manifest_key(database_branch_id, txid),
+			encode_delta_manifest(manifest)?,
+		),
+		(
+			keys::branch_delta_object_ref_key(database_branch_id, object_id),
+			txid_bytes,
+		),
+		(
+			keys::branch_delta_object_meta_key(database_branch_id, object_id),
+			encode_delta_object_meta(object_meta)?,
+		),
+		(
+			keys::branch_shard_key(database_branch_id, 0, txid),
+			encoded.bytes.clone(),
+		),
+	];
+	for (chunk_idx, chunk) in chunks.into_iter().enumerate() {
+		rows.push((
+			keys::branch_delta_object_chunk_key(database_branch_id, object_id, chunk_idx as u32),
+			chunk,
+		));
+	}
+	for page_index in encoded.page_index {
+		let page_bytes = pages_by_pgno
+			.get(&page_index.pgno)
+			.ok_or_else(|| anyhow::anyhow!("missing encoded page {}", page_index.pgno))?;
+		let page_hash = Sha256::digest(page_bytes);
+		let mut page_hash_bytes = [0_u8; 32];
+		page_hash_bytes.copy_from_slice(&page_hash);
+		rows.push((
+			keys::branch_delta_pageidx_key(database_branch_id, txid, page_index.pgno),
+			encode_delta_page_index_entry(DeltaPageIndexEntry {
+				txid,
+				object_id,
+				encoded_offset: page_index.offset,
+				encoded_size: u32::try_from(page_index.size)?,
+				page_hash: page_hash_bytes,
+			})?,
+		));
+	}
+
+	Ok((
+		rows,
+		SeededLargeDelta {
+			object_id,
+			chunk_count,
+			pages,
+		},
+	))
 }
 
 fn refresh_without_planned_work() -> RefreshManagerOutput {
@@ -651,6 +871,8 @@ fn hot_planning_uses_sha256_fingerprint_and_changes_with_inputs() {
 	let mut hot_inputs = HotInputSnapshot {
 		commits: vec![(1, commit(1)), (2, commit(2))],
 		delta_chunks: vec![(b"delta-key".to_vec(), b"delta-value".to_vec())],
+		large_delta_manifests: Vec::new(),
+		large_delta_pageidx_entries: Vec::new(),
 		pidx_entries: vec![(b"pidx-key".to_vec(), b"pidx-value".to_vec())],
 		pitr_interval_coverage: Vec::new(),
 		total_value_bytes: 24,
@@ -706,6 +928,156 @@ fn hot_planning_uses_sha256_fingerprint_and_changes_with_inputs() {
 	let changed_job = plan_hot_job(database_branch_id, &snapshot, Id::new_v1(3602), 1_002, true)
 		.expect("hot job should be planned");
 	assert_ne!(first_job.input_fingerprint, changed_job.input_fingerprint);
+}
+
+#[tokio::test]
+async fn hot_staging_loads_large_delta_pages_from_chunked_object() -> Result<()> {
+	let db = Arc::new(test_db().await?);
+	let bucket_id = Id::new_v1(4_600);
+	let database_id = "hot-staging-large-delta";
+	let database_db = Db::new(
+		Arc::clone(&db),
+		bucket_id,
+		database_id.to_string(),
+		NodeId::new(),
+	);
+	let dirty_pages = patterned_dirty_pages(2_049);
+	let expected_page = dirty_pages[127].bytes.clone();
+
+	database_db.commit(dirty_pages, 2_049, 1_000).await?;
+	let database_branch_id = read_test_branch_id(&db, bucket_id, database_id).await?;
+	let head = read_test_head(&db, database_branch_id).await?;
+	let root = root_with_watermarks(0, 0, 0);
+	let job_id = Id::new_v1(4_601);
+
+	let (output_refs, input_range, input_fingerprint): (
+		Vec<HotShardOutputRef>,
+		HotJobInputRange,
+		CompactionInputFingerprint,
+	) = db
+		.run({
+			let head = head.clone();
+			let root = root.clone();
+			move |tx| {
+				let head = head.clone();
+				let root = root.clone();
+				async move {
+					let hot_inputs = read_hot_input_snapshot(
+						&tx,
+						database_branch_id,
+						Some(&head),
+						&root,
+						Snapshot,
+						PitrPolicy::default(),
+						2_000,
+					)
+					.await?;
+					assert!(hot_inputs.delta_chunks.is_empty());
+					assert_eq!(hot_inputs.large_delta_manifests.len(), 1);
+					assert!(hot_inputs.large_delta_pageidx_entries.len() < 2_049);
+					assert!(hot_inputs.large_delta_pageidx_entries.len() >= 400);
+					assert!(hot_inputs.large_delta_manifests[0].3.chunk_count > 1);
+
+					let coverage_txids = vec![1];
+					let input_fingerprint = fingerprint_hot_inputs(
+						database_branch_id,
+						&root,
+						&head,
+						&coverage_txids,
+						&hot_inputs,
+					);
+					let input_range = HotJobInputRange {
+						txids: TxidRange {
+							min_txid: 1,
+							max_txid: 1,
+						},
+						coverage_txids,
+						max_pages: hot_inputs.large_delta_pageidx_entries.len() as u32,
+						max_bytes: hot_inputs.total_value_bytes,
+					};
+					let input = StageHotJobInput {
+						database_branch_id,
+						job_id,
+						job_kind: CompactionJobKind::Hot,
+						base_lifecycle_generation: 0,
+						base_manifest_generation: 0,
+						input_fingerprint,
+						input_range: input_range.clone(),
+					};
+					let output_refs = write_staged_hot_shards(&tx, &input, &head, &hot_inputs).await?;
+					Ok((output_refs, input_range, input_fingerprint))
+				}
+			}
+		})
+		.await?;
+
+	assert!(
+		output_refs.len() > 1,
+		"large delta should stage all touched shards"
+	);
+	let shard_two = output_refs
+		.iter()
+		.find(|output_ref| output_ref.shard_id == 2)
+		.expect("page 128 should land in staged shard 2");
+	let staged_blob = db
+		.run({
+			let shard_two = shard_two.clone();
+			move |tx| {
+				let shard_two = shard_two.clone();
+				async move {
+					load_staged_hot_shard_blob(&tx, database_branch_id, job_id, &shard_two, Snapshot)
+						.await
+				}
+			}
+		})
+		.await?
+		.expect("staged shard blob should exist");
+	let decoded = decode_ltx_v3(&staged_blob)?;
+	assert_eq!(decoded.get_page(128), Some(expected_page.as_slice()));
+
+	let install_input = InstallHotJobInput {
+		database_branch_id,
+		job_id,
+		job_kind: CompactionJobKind::Hot,
+		base_lifecycle_generation: 0,
+		base_manifest_generation: 0,
+		input_fingerprint,
+		input_range,
+		output_refs: output_refs.clone(),
+	};
+	let install_output = db
+		.run({
+			let install_input = install_input.clone();
+			move |tx| {
+				let install_input = install_input.clone();
+				async move { install_hot_job_tx(&tx, &install_input, 2_001).await }
+			}
+		})
+		.await?;
+	assert_eq!(install_output.status, CompactionJobStatus::Succeeded);
+	let published_row = read_test_value(
+		&db,
+		keys::branch_shard_key(database_branch_id, shard_two.shard_id, shard_two.as_of_txid),
+	)
+	.await?
+	.expect("published hot shard manifest should exist");
+	assert!(published_row.len() < staged_blob.len());
+	let published_chunk = read_test_value(
+		&db,
+		keys::branch_shard_chunk_key(
+			database_branch_id,
+			shard_two.shard_id,
+			shard_two.as_of_txid,
+			0,
+		),
+	)
+	.await?
+	.expect("published hot shard chunk should exist");
+	assert!(published_chunk.len() <= DELTA_OBJECT_CHUNK_BYTES);
+	let fetched = database_db.get_pages(vec![128]).await?;
+	assert_eq!(fetched[0].bytes.as_deref(), Some(expected_page.as_slice()));
+
+	Ok(())
 }
 
 #[test]
@@ -965,6 +1337,152 @@ async fn reclaim_input_snapshot_bounds_commit_scan_by_reclaim_ceiling() -> Resul
 		vec![10]
 	);
 	assert_eq!(snapshot.commits.len(), 1);
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn reclaim_fdb_job_removes_complete_large_delta_rows() -> Result<()> {
+	let db = test_db().await?;
+	let database_branch_id = database_branch_id(0x3701);
+	let txid = 1;
+	let root = root_with_watermarks(1, txid, 0);
+	let (rows, seeded) = complete_large_delta_rows(
+		database_branch_id,
+		txid,
+		patterned_dirty_pages(20),
+	)?;
+	assert!(
+		seeded.chunk_count > 1,
+		"test large delta object should span multiple chunks"
+	);
+
+	db.run({
+		let rows = rows.clone();
+		move |tx| {
+			let rows = rows.clone();
+			async move {
+				for (key, value) in rows {
+					tx.informal().set(&key, &value);
+				}
+				Ok(())
+			}
+		}
+	})
+	.await?;
+
+	let snapshot = db
+		.run({
+			let root = root.clone();
+			move |tx| {
+				let root = root.clone();
+				async move {
+					read_reclaim_input_snapshot(
+						&tx,
+						database_branch_id,
+						&root,
+						&[],
+						None,
+						ShardCachePolicy::default(),
+						Snapshot,
+						false,
+						2_000,
+					)
+					.await
+				}
+			}
+		})
+		.await?;
+	assert_eq!(snapshot.txid_refs.len(), 1);
+	assert_eq!(snapshot.large_delta_manifests.len(), 1);
+	assert_eq!(snapshot.large_delta_pageidx_entries.len(), seeded.pages.len());
+	assert_eq!(snapshot.large_delta_complete_txids, vec![txid]);
+	assert_eq!(
+		snapshot.large_delta_object_chunks.len(),
+		seeded.chunk_count as usize
+	);
+	assert!(reclaim_coverage_is_complete(&snapshot));
+
+	let input_range = ReclaimJobInputRange {
+		txids: TxidRange {
+			min_txid: txid,
+			max_txid: txid,
+		},
+		txid_refs: snapshot.txid_refs.clone(),
+		cold_objects: Vec::new(),
+		shard_cache_evictions: Vec::new(),
+		staged_hot_shards: Vec::new(),
+		orphan_cold_objects: Vec::new(),
+		max_keys: 500,
+		max_bytes: 2 * 1024 * 1024,
+	};
+	let input = ReclaimFdbJobInput {
+		database_branch_id,
+		job_id: Id::new_v1(3_701),
+		job_kind: CompactionJobKind::Reclaim,
+		base_lifecycle_generation: 1,
+		base_manifest_generation: root.manifest_generation,
+		input_fingerprint: fingerprint_reclaim_inputs(database_branch_id, &root, &snapshot),
+		input_range,
+	};
+	let output = db
+		.run({
+			let input = input.clone();
+			move |tx| {
+				let input = input.clone();
+				async move { reclaim_fdb_job_tx(&tx, &input, false, 2_000).await }
+			}
+		})
+		.await?;
+	assert_eq!(output.status, CompactionJobStatus::Succeeded);
+	assert_eq!(output.output_refs.len(), 1);
+
+	assert!(
+		read_test_value(&db, keys::branch_commit_key(database_branch_id, txid))
+			.await?
+			.is_none()
+	);
+	assert!(
+		read_test_value(&db, keys::branch_delta_manifest_key(database_branch_id, txid))
+			.await?
+			.is_none()
+	);
+	assert!(
+		read_test_value(
+			&db,
+			keys::branch_delta_object_ref_key(database_branch_id, seeded.object_id),
+		)
+		.await?
+		.is_none()
+	);
+	assert!(
+		read_test_value(
+			&db,
+			keys::branch_delta_object_meta_key(database_branch_id, seeded.object_id),
+		)
+		.await?
+		.is_none()
+	);
+	for chunk_idx in 0..seeded.chunk_count {
+		assert!(
+			read_test_value(
+				&db,
+				keys::branch_delta_object_chunk_key(database_branch_id, seeded.object_id, chunk_idx),
+			)
+			.await?
+			.is_none()
+		);
+	}
+	for page in &seeded.pages {
+		assert!(
+			read_test_value(
+				&db,
+				keys::branch_delta_pageidx_key(database_branch_id, txid, page.pgno),
+			)
+			.await?
+			.is_none()
+		);
+	}
 
 	Ok(())
 }

--- a/engine/packages/depot/tests/repro_fence_bypass_none.rs
+++ b/engine/packages/depot/tests/repro_fence_bypass_none.rs
@@ -1,0 +1,197 @@
+// Repro: when an actor instance commits or reads with `expected_head_txid: None`,
+// the depot head fence at `engine/packages/depot/src/conveyer/commit/apply.rs:179`
+// and `engine/packages/depot/src/conveyer/read.rs:134` is silently skipped.
+//
+// The depot-client VFS sends `expected_head_txid: state.head_txid` (vfs.rs:1346,
+// vfs.rs:1496). On a fresh actor instance (cold start, takeover, or post-crash
+// restart) `state.head_txid` is `None` until the first response from depot
+// populates it (vfs.rs:1357). When envoy breaks and a stale instance reconnects
+// before its replacement has populated `state.head_txid`, both can issue
+// commits with `expected_head_txid: None` and both pass the fence.
+//
+// This reproduction goes directly through the `Db` API (the same surface
+// `pegboard-envoy` calls), no VFS plumbing required.
+
+mod common;
+
+use anyhow::Result;
+use depot::{
+	keys::PAGE_SIZE,
+	types::{CommitOptions, DirtyPage, FetchedPage, GetPagesOptions},
+};
+use gas::prelude::Id;
+
+const TEST_DATABASE: &str = "test-database";
+
+fn test_bucket() -> Id {
+	Id::v1(uuid::Uuid::from_u128(0xfb01), 1)
+}
+
+fn page(pgno: u32, fill: u8) -> DirtyPage {
+	DirtyPage {
+		pgno,
+		bytes: vec![fill; PAGE_SIZE as usize],
+	}
+}
+
+fn fetched_page(pgno: u32, fill: u8) -> FetchedPage {
+	FetchedPage {
+		pgno,
+		bytes: Some(vec![fill; PAGE_SIZE as usize]),
+	}
+}
+
+#[tokio::test]
+async fn commit_fence_bypassed_when_expected_head_txid_is_none() -> Result<()> {
+	common::test_matrix("depot-fence-bypass-commit-none", |_tier, ctx| {
+		Box::pin(async move {
+			// Two Db handles on the same database. In production these would be
+			// two different actor instances writing through their own
+			// pegboard-envoy WS. Here they share UDB, mirroring the depot side
+			// of two concurrent envoys.
+			let db_a = ctx.make_db(test_bucket(), TEST_DATABASE);
+			let db_b = ctx.make_db(test_bucket(), TEST_DATABASE);
+
+			// Owner instance writes page 1 = 0xAA. expected=Some(0) is the
+			// well-behaved bootstrap fence.
+			let first = db_a
+				.commit_with_options(
+					vec![page(1, 0xAA)],
+					1,
+					1_000,
+					CommitOptions {
+						expected_head_txid: Some(0),
+					},
+				)
+				.await?;
+			assert_eq!(first.head_txid, 1);
+			assert_eq!(
+				db_a.get_pages(vec![1]).await?,
+				vec![fetched_page(1, 0xAA)]
+			);
+
+			// Stale instance comes back online. Its in-memory head_txid is
+			// None because it never finished a get_pages round-trip with the
+			// previous head. It commits page 1 = 0xBB with `None`.
+			//
+			// Apply path at apply.rs:179-194 only fences when
+			// `expected_head_txid` is `Some(_)`. With `None` the commit is
+			// accepted regardless of the current head.
+			let second = db_b
+				.commit_with_options(
+					vec![page(1, 0xBB)],
+					1,
+					1_001,
+					CommitOptions {
+						expected_head_txid: None,
+					},
+				)
+				.await
+				.expect(
+					"BUG: expected_head_txid=None bypasses the fence even though \
+					 db_a is the live writer and head is already at 1",
+				);
+			assert_eq!(
+				second.head_txid, 2,
+				"the second commit advanced head, proving the fence was bypassed"
+			);
+
+			// Corruption: db_a's content was silently overwritten. Verify via
+			// a fresh Db handle to avoid db_a's stale read-cache. (db_a's
+			// cache_snapshot still maps page 1 -> txid=1 from its own commit;
+			// it would also return stale 0xAA pages without a fence error.)
+			let db_verify = ctx.make_db(test_bucket(), TEST_DATABASE);
+			assert_eq!(
+				db_verify.get_pages(vec![1]).await?,
+				vec![fetched_page(1, 0xBB)],
+				"db_a's 0xAA was silently overwritten by db_b's 0xBB"
+			);
+
+			// And db_a still believes it owns the database at head=1, with
+			// page 1 = 0xAA, until its next properly-fenced operation.
+			assert_eq!(
+				db_a.get_pages(vec![1]).await?,
+				vec![fetched_page(1, 0xAA)],
+				"db_a's local read-cache still serves the stale (pre-overwrite) state"
+			);
+
+			Ok(())
+		})
+	})
+	.await
+}
+
+#[tokio::test]
+async fn read_fence_bypassed_when_expected_head_txid_is_none() -> Result<()> {
+	common::test_matrix("depot-fence-bypass-read-none", |_tier, ctx| {
+		Box::pin(async move {
+			let db_owner = ctx.make_db(test_bucket(), TEST_DATABASE);
+			let db_stale = ctx.make_db(test_bucket(), TEST_DATABASE);
+
+			// Owner advances the database to head_txid=2.
+			db_owner
+				.commit_with_options(
+					vec![page(1, 0xAA)],
+					1,
+					1_000,
+					CommitOptions {
+						expected_head_txid: Some(0),
+					},
+				)
+				.await?;
+			db_owner
+				.commit_with_options(
+					vec![page(1, 0xBB)],
+					1,
+					1_001,
+					CommitOptions {
+						expected_head_txid: Some(1),
+					},
+				)
+				.await?;
+
+			// Stale instance whose cached state.head_txid was 1 from before
+			// the owner's second commit. With a proper fence, it would learn
+			// of the takeover via HeadFenceMismatch.
+			let proper_fence = db_stale
+				.get_pages_with_options(
+					vec![1],
+					GetPagesOptions {
+						expected_head_txid: Some(1),
+					},
+				)
+				.await
+				.expect_err("Some(stale) must fence");
+			assert!(
+				proper_fence
+					.chain()
+					.any(|cause| cause.to_string().contains("head fence mismatch")),
+				"unexpected error: {proper_fence:#}"
+			);
+
+			// Same stale instance, but now its state.head_txid was reset to
+			// None by a process restart, an envoy reconnect, or any code path
+			// that constructs a fresh `Db` (which initializes
+			// cache_snapshot=None per db.rs:291).
+			//
+			// read.rs:134-149 only fences when expected is Some. With None the
+			// stale instance silently receives the latest content (0xBB at
+			// txid=2) without learning that another instance is the live
+			// writer. Any commit it builds on top of these pages will diverge
+			// from its own conceptual generation.
+			let bypassed = db_stale
+				.get_pages_with_options(
+					vec![1],
+					GetPagesOptions {
+						expected_head_txid: None,
+					},
+				)
+				.await?;
+			assert_eq!(bypassed.head_txid, 2);
+			assert_eq!(bypassed.pages, vec![fetched_page(1, 0xBB)]);
+
+			Ok(())
+		})
+	})
+	.await
+}

--- a/engine/packages/depot/tests/repro_stale_writer_post_restore.rs
+++ b/engine/packages/depot/tests/repro_stale_writer_post_restore.rs
@@ -1,0 +1,141 @@
+// Repro: a stale actor instance whose cached `state.head_txid` happens to
+// match the txid of a freshly-restored branch's `head_at_fork` can pass the
+// depot head fence and land writes on top of a rolled-back branch, silently
+// undoing the restore.
+//
+// The depot fence at `engine/packages/depot/src/conveyer/commit/apply.rs:154-194`
+// reads `actual_head_txid` from `previous_head_bytes = head_bytes.or(head_at_fork_bytes)`.
+// `engine/packages/depot/src/conveyer/branch/fork.rs:238-251` writes
+// `head_at_fork.head_txid = txid_at_versionstamp` when a branch is derived
+// for a restore/rollback. So a fresh branch B2 forked at txid=K reports
+// `actual_head_txid = K` to the next commit's fence check. Any stale writer
+// whose cached `state.head_txid == K` (e.g. because it went stale right
+// after the restore-point pin commit) passes the fence and overwrites the
+// restored state.
+//
+// When envoy breaks and a stale instance reconnects after an operator
+// restore, the fence does not protect the restored state from the stale
+// instance's pending dirty pages.
+
+mod common;
+
+use anyhow::Result;
+use depot::{
+	keys::PAGE_SIZE,
+	types::{CommitOptions, DirtyPage, FetchedPage, SnapshotSelector},
+};
+use gas::prelude::Id;
+
+const TEST_DATABASE: &str = "test-database";
+
+fn test_bucket() -> Id {
+	Id::v1(uuid::Uuid::from_u128(0xfb02), 1)
+}
+
+fn page(pgno: u32, fill: u8) -> DirtyPage {
+	DirtyPage {
+		pgno,
+		bytes: vec![fill; PAGE_SIZE as usize],
+	}
+}
+
+fn fetched_page(pgno: u32, fill: u8) -> FetchedPage {
+	FetchedPage {
+		pgno,
+		bytes: Some(vec![fill; PAGE_SIZE as usize]),
+	}
+}
+
+#[tokio::test]
+async fn stale_writer_lands_on_rolled_back_branch_via_head_at_fork() -> Result<()> {
+	common::test_matrix("depot-stale-writer-post-restore", |_tier, ctx| {
+		Box::pin(async move {
+			let db_owner = ctx.make_db(test_bucket(), TEST_DATABASE);
+
+			// Initial state: page 1 = 0xAA at head_txid=1.
+			db_owner
+				.commit_with_options(
+					vec![page(1, 0xAA)],
+					1,
+					1_000,
+					CommitOptions {
+						expected_head_txid: Some(0),
+					},
+				)
+				.await?;
+
+			// Operator pins this state with a restore point.
+			let restore_point = db_owner.create_restore_point(SnapshotSelector::Latest).await?;
+
+			// A second actor instance ("stale") was alive at this moment with
+			// state.head_txid cached as Some(1) and a pending dirty page
+			// (0xCC). It then loses its envoy connection.
+			let db_stale = ctx.make_db(test_bucket(), TEST_DATABASE);
+
+			// While stale is offline, the owner advances the database with
+			// 0xBB at txid=2.
+			db_owner
+				.commit_with_options(
+					vec![page(1, 0xBB)],
+					1,
+					1_001,
+					CommitOptions {
+						expected_head_txid: Some(1),
+					},
+				)
+				.await?;
+
+			// Operator decides the 0xBB write was a mistake and restores the
+			// database to the pinned restore point. This forks a new branch
+			// B2 with `head_at_fork.head_txid = 1` and swaps DBPTR onto it.
+			db_owner
+				.restore_database(SnapshotSelector::RestorePoint {
+					restore_point: restore_point.clone(),
+				})
+				.await?;
+
+			// Sanity: post-restore reads should reflect 0xAA.
+			assert_eq!(
+				db_owner.get_pages(vec![1]).await?,
+				vec![fetched_page(1, 0xAA)],
+				"post-restore baseline should be 0xAA"
+			);
+
+			// Stale instance reconnects through a working envoy. Its cached
+			// state.head_txid is still Some(1) (its last successful response
+			// from before going stale). It flushes its pending 0xCC page with
+			// `expected_head_txid=Some(1)`.
+			//
+			// On B2 there is no /META/head yet, so apply.rs reads
+			// /META/head_at_fork and finds head_txid=1. The fence check at
+			// apply.rs:179-194 sees expected==actual==1 and accepts the write.
+			let stale_commit = db_stale
+				.commit_with_options(
+					vec![page(1, 0xCC)],
+					1,
+					1_010,
+					CommitOptions {
+						expected_head_txid: Some(1),
+					},
+				)
+				.await
+				.expect(
+					"BUG: stale writer's cached head_txid matches the rolled-back \
+					 branch's head_at_fork, so the fence accepts a commit that \
+					 overwrites the restored state",
+				);
+			assert_eq!(stale_commit.head_txid, 2);
+
+			// The restore is silently undone. Reads now return 0xCC, not the
+			// 0xAA the operator restored to.
+			assert_eq!(
+				db_owner.get_pages(vec![1]).await?,
+				vec![fetched_page(1, 0xCC)],
+				"restored state was silently overwritten by a stale writer"
+			);
+
+			Ok(())
+		})
+	})
+	.await
+}

--- a/engine/packages/pegboard-envoy/Cargo.toml
+++ b/engine/packages/pegboard-envoy/Cargo.toml
@@ -43,6 +43,7 @@ tracing.workspace = true
 universaldb.workspace = true
 universalpubsub.workspace = true
 url.workspace = true
+uuid.workspace = true
 vbare.workspace = true
 rusqlite.workspace = true
 

--- a/engine/packages/pegboard-envoy/src/ws_to_tunnel_task.rs
+++ b/engine/packages/pegboard-envoy/src/ws_to_tunnel_task.rs
@@ -31,6 +31,7 @@ use tracing::Instrument;
 use universaldb::prelude::*;
 use universaldb::utils::end_of_key_range;
 use universalpubsub::PublishOpts;
+use uuid::Uuid;
 use vbare::OwnedVersionedData;
 
 use crate::{
@@ -410,6 +411,26 @@ async fn handle_message(
 			crate::metrics::SQLITE_COMMIT_ENVOY_RESPONSE_DURATION
 				.observe(timed_response.commit_completed_at.elapsed().as_secs_f64());
 		}
+		protocol::ToRivet::ToRivetSqliteCommitStageBeginRequest(req) => {
+			let response = handle_sqlite_commit_stage_begin_response(ctx, &conn, req.data).await;
+			send_sqlite_commit_stage_begin_response(&conn, req.request_id, response).await?;
+		}
+		protocol::ToRivet::ToRivetSqliteCommitStagePagesRequest(req) => {
+			let response = handle_sqlite_commit_stage_pages_response(ctx, &conn, req.data).await;
+			send_sqlite_commit_stage_pages_response(&conn, req.request_id, response).await?;
+		}
+		protocol::ToRivet::ToRivetSqliteCommitStageCompleteRequest(req) => {
+			let response = handle_sqlite_commit_stage_complete_response(ctx, &conn, req.data).await;
+			send_sqlite_commit_stage_complete_response(&conn, req.request_id, response).await?;
+		}
+		protocol::ToRivet::ToRivetSqliteCommitStageFinalizeRequest(req) => {
+			let response = handle_sqlite_commit_stage_finalize_response(ctx, &conn, req.data).await;
+			send_sqlite_commit_stage_finalize_response(&conn, req.request_id, response).await?;
+		}
+		protocol::ToRivet::ToRivetSqliteCommitStageAbortRequest(req) => {
+			let response = handle_sqlite_commit_stage_abort_response(ctx, &conn, req.data).await;
+			send_sqlite_commit_stage_abort_response(&conn, req.request_id, response).await?;
+		}
 		protocol::ToRivet::ToRivetSqliteExecRequest(req) => {
 			let response = handle_remote_sqlite_exec_response(ctx, &conn, req.data).await;
 			send_sqlite_exec_response(&conn, req.request_id, response).await?;
@@ -514,6 +535,81 @@ async fn handle_sqlite_commit_response(
 	TimedSqliteCommitResponse {
 		response,
 		commit_completed_at: Instant::now(),
+	}
+}
+
+async fn handle_sqlite_commit_stage_begin_response(
+	ctx: &StandaloneCtx,
+	conn: &Conn,
+	request: protocol::SqliteCommitStageBeginRequest,
+) -> protocol::SqliteCommitStageBeginResponse {
+	let actor_id = request.actor_id.clone();
+	match handle_sqlite_commit_stage_begin(ctx, conn, request).await {
+		Ok(response) => response,
+		Err(err) => {
+			tracing::error!(actor_id = %actor_id, ?err, "sqlite commit stage begin failed");
+			protocol::SqliteCommitStageBeginResponse::SqliteErrorResponse(sqlite_error_response(&err))
+		}
+	}
+}
+
+async fn handle_sqlite_commit_stage_pages_response(
+	ctx: &StandaloneCtx,
+	conn: &Conn,
+	request: protocol::SqliteCommitStagePagesRequest,
+) -> protocol::SqliteCommitStagePagesResponse {
+	let actor_id = request.actor_id.clone();
+	match handle_sqlite_commit_stage_pages(ctx, conn, request).await {
+		Ok(()) => protocol::SqliteCommitStagePagesResponse::SqliteCommitStagePagesOk,
+		Err(err) => {
+			tracing::error!(actor_id = %actor_id, ?err, "sqlite commit stage pages failed");
+			protocol::SqliteCommitStagePagesResponse::SqliteErrorResponse(sqlite_error_response(&err))
+		}
+	}
+}
+
+async fn handle_sqlite_commit_stage_complete_response(
+	ctx: &StandaloneCtx,
+	conn: &Conn,
+	request: protocol::SqliteCommitStageCompleteRequest,
+) -> protocol::SqliteCommitStageCompleteResponse {
+	let actor_id = request.actor_id.clone();
+	match handle_sqlite_commit_stage_complete(ctx, conn, request).await {
+		Ok(()) => protocol::SqliteCommitStageCompleteResponse::SqliteCommitStageCompleteOk,
+		Err(err) => {
+			tracing::error!(actor_id = %actor_id, ?err, "sqlite commit stage complete failed");
+			protocol::SqliteCommitStageCompleteResponse::SqliteErrorResponse(sqlite_error_response(&err))
+		}
+	}
+}
+
+async fn handle_sqlite_commit_stage_finalize_response(
+	ctx: &StandaloneCtx,
+	conn: &Conn,
+	request: protocol::SqliteCommitStageFinalizeRequest,
+) -> protocol::SqliteCommitResponse {
+	let actor_id = request.actor_id.clone();
+	match handle_sqlite_commit_stage_finalize(ctx, conn, request).await {
+		Ok(response) => response,
+		Err(err) => {
+			tracing::error!(actor_id = %actor_id, ?err, "sqlite commit stage finalize failed");
+			protocol::SqliteCommitResponse::SqliteErrorResponse(sqlite_error_response(&err))
+		}
+	}
+}
+
+async fn handle_sqlite_commit_stage_abort_response(
+	ctx: &StandaloneCtx,
+	conn: &Conn,
+	request: protocol::SqliteCommitStageAbortRequest,
+) -> protocol::SqliteCommitStageAbortResponse {
+	let actor_id = request.actor_id.clone();
+	match handle_sqlite_commit_stage_abort(ctx, conn, request).await {
+		Ok(()) => protocol::SqliteCommitStageAbortResponse::SqliteCommitStageAbortOk,
+		Err(err) => {
+			tracing::error!(actor_id = %actor_id, ?err, "sqlite commit stage abort failed");
+			protocol::SqliteCommitStageAbortResponse::SqliteErrorResponse(sqlite_error_response(&err))
+		}
 	}
 }
 
@@ -759,30 +855,101 @@ async fn handle_sqlite_commit(
 		.await;
 	let response_build_start = Instant::now();
 	let response = match engine_result {
-		Ok(result) => Ok(protocol::SqliteCommitResponse::SqliteCommitOk(
-			protocol::SqliteCommitOk {
-				head_txid: Some(result.head_txid),
-			},
-		)),
-		Err(err) => match depot_error(&err) {
-			Some(SqliteStorageError::CommitTooLarge {
-				actual_size_bytes,
-				max_size_bytes,
-			}) => Ok(protocol::SqliteCommitResponse::SqliteErrorResponse(
-				protocol::SqliteErrorResponse {
-					group: "depot".to_string(),
-					code: "commit_too_large".to_string(),
-					message: format!(
-						"sqlite commit too large: actual_size_bytes={actual_size_bytes}, max_size_bytes={max_size_bytes}"
-					),
-				},
-			)),
-			_ => Err(err),
-		},
-	}?;
+		Ok(result) => protocol::SqliteCommitResponse::SqliteCommitOk(protocol::SqliteCommitOk {
+			head_txid: Some(result.head_txid),
+		}),
+		Err(err) => protocol::SqliteCommitResponse::SqliteErrorResponse(sqlite_error_response(&err)),
+	};
 	crate::metrics::SQLITE_COMMIT_ENVOY_RESPONSE_DURATION
 		.observe(response_build_start.elapsed().as_secs_f64());
 	Ok(response)
+}
+
+async fn handle_sqlite_commit_stage_begin(
+	ctx: &StandaloneCtx,
+	conn: &Conn,
+	request: protocol::SqliteCommitStageBeginRequest,
+) -> Result<protocol::SqliteCommitStageBeginResponse> {
+	validate_sqlite_actor(ctx, conn, &request.actor_id).await?;
+	let actor_db = actor_db(ctx, conn, request.actor_id.clone()).await?;
+	let result = actor_db
+		.commit_stage_begin(
+			request.dirty_pgnos,
+			request.db_size_pages,
+			request.now_ms,
+			depot::types::CommitOptions {
+				expected_head_txid: request.expected_head_txid,
+			},
+		)
+		.await?;
+	Ok(
+		protocol::SqliteCommitStageBeginResponse::SqliteCommitStageBeginOk(
+			protocol::SqliteCommitStageBeginOk {
+				stage_id: *result.stage_id.as_bytes(),
+				max_pages_per_batch: result.max_pages_per_batch,
+				max_batch_bytes: result.max_batch_bytes,
+				observed_head_txid: result.observed_head_txid,
+				staged_txid: result.staged_txid,
+			},
+		),
+	)
+}
+
+async fn handle_sqlite_commit_stage_pages(
+	ctx: &StandaloneCtx,
+	conn: &Conn,
+	request: protocol::SqliteCommitStagePagesRequest,
+) -> Result<()> {
+	validate_sqlite_actor(ctx, conn, &request.actor_id).await?;
+	let actor_db = actor_db(ctx, conn, request.actor_id.clone()).await?;
+	actor_db
+		.commit_stage_pages(
+			stage_id_from_protocol(&request.stage_id)?,
+			request.batch_idx,
+			request.dirty_pages.into_iter().map(pump_dirty_page).collect(),
+		)
+		.await
+}
+
+async fn handle_sqlite_commit_stage_complete(
+	ctx: &StandaloneCtx,
+	conn: &Conn,
+	request: protocol::SqliteCommitStageCompleteRequest,
+) -> Result<()> {
+	validate_sqlite_actor(ctx, conn, &request.actor_id).await?;
+	let actor_db = actor_db(ctx, conn, request.actor_id.clone()).await?;
+	actor_db
+		.commit_stage_complete(stage_id_from_protocol(&request.stage_id)?, request.page_batch_count)
+		.await
+}
+
+async fn handle_sqlite_commit_stage_finalize(
+	ctx: &StandaloneCtx,
+	conn: &Conn,
+	request: protocol::SqliteCommitStageFinalizeRequest,
+) -> Result<protocol::SqliteCommitResponse> {
+	validate_sqlite_actor(ctx, conn, &request.actor_id).await?;
+	let actor_db = actor_db(ctx, conn, request.actor_id.clone()).await?;
+	let result = actor_db
+		.commit_stage_finalize(stage_id_from_protocol(&request.stage_id)?)
+		.await?;
+	Ok(protocol::SqliteCommitResponse::SqliteCommitOk(
+		protocol::SqliteCommitOk {
+			head_txid: Some(result.head_txid),
+		},
+	))
+}
+
+async fn handle_sqlite_commit_stage_abort(
+	ctx: &StandaloneCtx,
+	conn: &Conn,
+	request: protocol::SqliteCommitStageAbortRequest,
+) -> Result<()> {
+	validate_sqlite_actor(ctx, conn, &request.actor_id).await?;
+	let actor_db = actor_db(ctx, conn, request.actor_id.clone()).await?;
+	actor_db
+		.commit_stage_abort(stage_id_from_protocol(&request.stage_id)?)
+		.await
 }
 
 async fn handle_remote_sqlite_exec(
@@ -1019,6 +1186,10 @@ fn pump_dirty_page(page: protocol::SqliteDirtyPage) -> depot::types::DirtyPage {
 	}
 }
 
+fn stage_id_from_protocol(stage_id: &protocol::SqliteStageId) -> Result<Uuid> {
+	Uuid::from_slice(stage_id).context("invalid sqlite commit stage id")
+}
+
 fn bind_param_from_protocol(param: protocol::SqliteBindParam) -> BindParam {
 	match param {
 		protocol::SqliteBindParam::SqliteValueNull => BindParam::Null,
@@ -1165,6 +1336,7 @@ fn sqlite_error_response(err: &anyhow::Error) -> protocol::SqliteErrorResponse {
 		group: structured.group().to_string(),
 		code: structured.code().to_string(),
 		message: sqlite_error_reason(err),
+		metadata: structured.metadata().map(|metadata| metadata.to_string()),
 	}
 }
 
@@ -1237,6 +1409,81 @@ async fn send_sqlite_commit_response(
 			data,
 		}),
 		"sqlite commit response",
+	)
+	.await
+}
+
+async fn send_sqlite_commit_stage_begin_response(
+	conn: &Conn,
+	request_id: u32,
+	data: protocol::SqliteCommitStageBeginResponse,
+) -> Result<()> {
+	send_to_envoy(
+		conn,
+		protocol::ToEnvoy::ToEnvoySqliteCommitStageBeginResponse(
+			protocol::ToEnvoySqliteCommitStageBeginResponse { request_id, data },
+		),
+		"sqlite commit stage begin response",
+	)
+	.await
+}
+
+async fn send_sqlite_commit_stage_pages_response(
+	conn: &Conn,
+	request_id: u32,
+	data: protocol::SqliteCommitStagePagesResponse,
+) -> Result<()> {
+	send_to_envoy(
+		conn,
+		protocol::ToEnvoy::ToEnvoySqliteCommitStagePagesResponse(
+			protocol::ToEnvoySqliteCommitStagePagesResponse { request_id, data },
+		),
+		"sqlite commit stage pages response",
+	)
+	.await
+}
+
+async fn send_sqlite_commit_stage_complete_response(
+	conn: &Conn,
+	request_id: u32,
+	data: protocol::SqliteCommitStageCompleteResponse,
+) -> Result<()> {
+	send_to_envoy(
+		conn,
+		protocol::ToEnvoy::ToEnvoySqliteCommitStageCompleteResponse(
+			protocol::ToEnvoySqliteCommitStageCompleteResponse { request_id, data },
+		),
+		"sqlite commit stage complete response",
+	)
+	.await
+}
+
+async fn send_sqlite_commit_stage_finalize_response(
+	conn: &Conn,
+	request_id: u32,
+	data: protocol::SqliteCommitResponse,
+) -> Result<()> {
+	send_to_envoy(
+		conn,
+		protocol::ToEnvoy::ToEnvoySqliteCommitStageFinalizeResponse(
+			protocol::ToEnvoySqliteCommitStageFinalizeResponse { request_id, data },
+		),
+		"sqlite commit stage finalize response",
+	)
+	.await
+}
+
+async fn send_sqlite_commit_stage_abort_response(
+	conn: &Conn,
+	request_id: u32,
+	data: protocol::SqliteCommitStageAbortResponse,
+) -> Result<()> {
+	send_to_envoy(
+		conn,
+		protocol::ToEnvoy::ToEnvoySqliteCommitStageAbortResponse(
+			protocol::ToEnvoySqliteCommitStageAbortResponse { request_id, data },
+		),
+		"sqlite commit stage abort response",
 	)
 	.await
 }

--- a/engine/packages/pegboard-envoy/tests/actor_lifecycle.rs
+++ b/engine/packages/pegboard-envoy/tests/actor_lifecycle.rs
@@ -19,10 +19,15 @@ mod conn {
 	use std::sync::Arc;
 
 	use depot::conveyer::Db;
+	use depot_client::database::NativeDatabaseHandle;
 	use scc::HashMap;
+
+	pub type RemoteSqliteExecutors =
+		HashMap<(String, u64), Arc<tokio::sync::OnceCell<NativeDatabaseHandle>>>;
 
 	pub struct Conn {
 		pub actor_dbs: HashMap<String, Arc<Db>>,
+		pub remote_sqlite_executors: RemoteSqliteExecutors,
 	}
 }
 
@@ -98,13 +103,18 @@ fn new_actor_db(db: Arc<universaldb::Database>, namespace_label: u16, actor_id: 
 	))
 }
 
+fn new_conn() -> conn::Conn {
+	conn::Conn {
+		actor_dbs: HashMap::new(),
+		remote_sqlite_executors: HashMap::new(),
+	}
+}
+
 #[tokio::test]
 async fn stop_actor_evicts_cached_actor_db() -> Result<()> {
 	let db = Arc::new(test_db().await?);
 	let actor_db = new_actor_db(db, TEST_NAMESPACE_LABEL, TEST_ACTOR);
-	let conn = conn::Conn {
-		actor_dbs: HashMap::new(),
-	};
+	let conn = new_conn();
 
 	assert!(
 		conn.actor_dbs
@@ -120,12 +130,49 @@ async fn stop_actor_evicts_cached_actor_db() -> Result<()> {
 }
 
 #[tokio::test]
+async fn stop_actor_evicts_cached_remote_sqlite_executors() -> Result<()> {
+	let conn = new_conn();
+	assert!(
+		conn.remote_sqlite_executors
+			.insert_async(
+				(TEST_ACTOR.to_string(), 7),
+				Arc::new(tokio::sync::OnceCell::new()),
+			)
+			.await
+			.is_ok()
+	);
+	assert!(
+		conn.remote_sqlite_executors
+			.insert_async(
+				("other-actor".to_string(), 7),
+				Arc::new(tokio::sync::OnceCell::new()),
+			)
+			.await
+			.is_ok()
+	);
+
+	actor_lifecycle::stop_actor(&conn, &checkpoint(TEST_ACTOR)).await?;
+
+	assert!(
+		conn.remote_sqlite_executors
+			.read_async(&(TEST_ACTOR.to_string(), 7), |_, _| ())
+			.await
+			.is_none()
+	);
+	assert!(
+		conn.remote_sqlite_executors
+			.read_async(&("other-actor".to_string(), 7), |_, _| ())
+			.await
+			.is_some()
+	);
+	Ok(())
+}
+
+#[tokio::test]
 async fn stop_actor_does_not_touch_udb() -> Result<()> {
 	let db = Arc::new(test_db().await?);
 	let actor_db = new_actor_db(Arc::clone(&db), TEST_NAMESPACE_LABEL, TEST_ACTOR);
-	let conn = conn::Conn {
-		actor_dbs: HashMap::new(),
-	};
+	let conn = new_conn();
 	assert!(
 		conn.actor_dbs
 			.insert_async(TEST_ACTOR.to_string(), actor_db)
@@ -147,9 +194,7 @@ async fn stop_actor_does_not_touch_udb() -> Result<()> {
 
 #[tokio::test]
 async fn stop_actor_allows_missing_cache_entry() -> Result<()> {
-	let conn = conn::Conn {
-		actor_dbs: HashMap::new(),
-	};
+	let conn = new_conn();
 
 	actor_lifecycle::stop_actor(&conn, &checkpoint(TEST_ACTOR)).await?;
 
@@ -160,9 +205,7 @@ async fn stop_actor_allows_missing_cache_entry() -> Result<()> {
 #[tokio::test]
 async fn shutdown_conn_actors_evicts_all_cached_actor_dbs() -> Result<()> {
 	let db = Arc::new(test_db().await?);
-	let conn = conn::Conn {
-		actor_dbs: HashMap::new(),
-	};
+	let conn = new_conn();
 
 	for (idx, actor_id) in ["shutdown-actor-a", "shutdown-actor-b"]
 		.into_iter()
@@ -181,4 +224,24 @@ async fn shutdown_conn_actors_evicts_all_cached_actor_dbs() -> Result<()> {
 
 	assert!(conn.actor_dbs.is_empty());
 	Ok(())
+}
+
+#[tokio::test]
+async fn shutdown_conn_actors_evicts_all_cached_remote_sqlite_executors() {
+	let conn = new_conn();
+	for (actor_id, generation) in [("shutdown-actor-a", 7), ("shutdown-actor-b", 8)] {
+		assert!(
+			conn.remote_sqlite_executors
+				.insert_async(
+					(actor_id.to_string(), generation),
+					Arc::new(tokio::sync::OnceCell::new()),
+				)
+				.await
+				.is_ok()
+		);
+	}
+
+	actor_lifecycle::shutdown_conn_actors(&conn).await;
+
+	assert!(conn.remote_sqlite_executors.is_empty());
 }

--- a/engine/packages/pegboard-envoy/tests/support/ws_to_tunnel_task.rs
+++ b/engine/packages/pegboard-envoy/tests/support/ws_to_tunnel_task.rs
@@ -82,115 +82,23 @@
 // }
 
 use std::{
-	sync::{
-		Arc,
-		atomic::{AtomicBool, Ordering},
-	},
+	sync::Arc,
 	time::{SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::Result;
+use depot::conveyer::Db;
 use depot_client::types::{BindParam, ColumnValue};
-use sqlite_storage::{engine::SqliteEngine, error::SqliteStorageError, open::OpenConfig};
-use tokio::{
-	sync::{Notify, Semaphore},
-	time::{Duration, Instant, timeout},
-};
-use universaldb::{Subspace, driver::RocksDbDatabaseDriver};
+use gas::prelude::Id;
+use rivet_pools::NodeId;
+use universaldb::driver::RocksDbDatabaseDriver;
 
 use super::{
-	actor_lifecycle::{
-		ActiveActor, ActiveActorState, clear_remote_sqlite_executors,
-		remove_remote_sqlite_executor_generation, remove_remote_sqlite_executors_for_actor,
-	},
-	cached_active_sqlite_actor, cached_serverless_sqlite_generation, remote_sqlite_executor_cell,
-	remote_sqlite_executor_from_parts, spawn_tracked_remote_sqlite_task,
-	validate_remote_sqlite_params, validate_sqlite_get_page_range_request,
+	clear_remote_sqlite_executors, remote_sqlite_executor_cell, remote_sqlite_executor_from_parts,
+	remove_remote_sqlite_executor_generation, remove_remote_sqlite_executors_for_actor,
+	validate_remote_sqlite_params,
 };
-use crate::conn::{
-	RemoteSqliteExecutors, RemoteSqliteInflight, remote_sqlite_inflight_count,
-	remove_remote_sqlite_inflight_generation_if_idle, wait_remote_sqlite_inflight_generation,
-};
-
-#[tokio::test]
-async fn cached_active_sqlite_actor_accepts_running_actor_generation() {
-	let active_actors = scc::HashMap::new();
-	active_actors
-		.insert_async(
-			"actor-a".to_string(),
-			ActiveActor {
-				actor_generation: 1,
-				sqlite_generation: Some(7),
-				state: ActiveActorState::Running,
-			},
-		)
-		.await
-		.expect("insert active actor");
-
-	assert!(cached_active_sqlite_actor(&active_actors, "actor-a", 7).await);
-	assert!(!cached_active_sqlite_actor(&active_actors, "actor-a", 8).await);
-	assert!(!cached_active_sqlite_actor(&active_actors, "actor-b", 7).await);
-}
-
-#[tokio::test]
-async fn cached_active_sqlite_actor_rejects_starting_actor() {
-	let active_actors = scc::HashMap::new();
-	active_actors
-		.insert_async(
-			"actor-a".to_string(),
-			ActiveActor {
-				actor_generation: 1,
-				sqlite_generation: Some(7),
-				state: ActiveActorState::Starting,
-			},
-		)
-		.await
-		.expect("insert active actor");
-
-	assert!(!cached_active_sqlite_actor(&active_actors, "actor-a", 7).await);
-}
-
-#[tokio::test]
-async fn cached_serverless_sqlite_generation_accepts_matching_generation() {
-	let serverless_sqlite_actors = scc::HashMap::new();
-	serverless_sqlite_actors
-		.insert_async("actor-a".to_string(), 7)
-		.await
-		.expect("insert serverless actor");
-
-	assert!(
-		cached_serverless_sqlite_generation(&serverless_sqlite_actors, "actor-a", 7)
-			.await
-			.expect("matching cached generation succeeds")
-	);
-	assert!(
-		!cached_serverless_sqlite_generation(&serverless_sqlite_actors, "actor-b", 7)
-			.await
-			.expect("missing cached generation falls back")
-	);
-}
-
-#[tokio::test]
-async fn cached_serverless_sqlite_generation_reports_fence_mismatch() {
-	let serverless_sqlite_actors = scc::HashMap::new();
-	serverless_sqlite_actors
-		.insert_async("actor-a".to_string(), 7)
-		.await
-		.expect("insert serverless actor");
-
-	let err = cached_serverless_sqlite_generation(&serverless_sqlite_actors, "actor-a", 8)
-		.await
-		.expect_err("stale generation should be fenced");
-
-	assert!(matches!(
-		err.downcast_ref::<SqliteStorageError>(),
-		Some(SqliteStorageError::FenceMismatch { .. })
-	));
-	assert!(
-		err.to_string()
-			.contains("did not match cached generation 7")
-	);
-}
+use crate::conn::RemoteSqliteExecutors;
 
 #[tokio::test]
 async fn remote_sqlite_executor_cache_is_lazy_and_actor_generation_scoped() {
@@ -232,158 +140,18 @@ async fn remote_sqlite_executor_cleanup_removes_actor_scoped_entries() {
 }
 
 #[tokio::test]
-async fn tracked_remote_sqlite_tasks_are_bounded_and_visible_to_stop_waiters() {
-	let worker_permits = Arc::new(Semaphore::new(1));
-	let in_flight = RemoteSqliteInflight::new();
-	let first_started = Arc::new(Notify::new());
-	let first_release = Arc::new(Notify::new());
-	let second_started = Arc::new(Notify::new());
-	let second_release = Arc::new(Notify::new());
-	let second_ran = Arc::new(AtomicBool::new(false));
-
-	spawn_tracked_remote_sqlite_task(
-		worker_permits.clone(),
-		&in_flight,
-		"actor-a".to_string(),
-		7,
-		"test sqlite execute",
-		{
-			let first_started = first_started.clone();
-			let first_release = first_release.clone();
-			async move {
-				first_started.notify_waiters();
-				first_release.notified().await;
-			}
-		},
-	)
-	.await;
-	first_started.notified().await;
-
-	spawn_tracked_remote_sqlite_task(
-		worker_permits,
-		&in_flight,
-		"actor-a".to_string(),
-		7,
-		"test sqlite execute",
-		{
-			let second_started = second_started.clone();
-			let second_release = second_release.clone();
-			let second_ran = second_ran.clone();
-			async move {
-				second_ran.store(true, Ordering::SeqCst);
-				second_started.notify_waiters();
-				second_release.notified().await;
-			}
-		},
-	)
-	.await;
-
-	assert_eq!(
-		remote_sqlite_inflight_count(&in_flight, "actor-a", 7).await,
-		2
-	);
-	assert!(!second_ran.load(Ordering::SeqCst));
-	assert!(
-		!wait_remote_sqlite_inflight_generation(
-			&in_flight,
-			"actor-a",
-			7,
-			Instant::now() + Duration::from_millis(1),
-		)
-		.await
-	);
-
-	first_release.notify_waiters();
-	timeout(Duration::from_secs(1), second_started.notified())
-		.await
-		.expect("second task should start after the first releases its worker permit");
-	second_release.notify_waiters();
-	assert!(
-		wait_remote_sqlite_inflight_generation(
-			&in_flight,
-			"actor-a",
-			7,
-			Instant::now() + Duration::from_secs(1),
-		)
-		.await
-	);
-
-	remove_remote_sqlite_inflight_generation_if_idle(&in_flight, "actor-a", 7).await;
-	assert_eq!(
-		remote_sqlite_inflight_count(&in_flight, "actor-a", 7).await,
-		0
-	);
-}
-
-#[tokio::test]
-async fn remote_sqlite_stop_wait_does_not_finish_before_running_task() {
-	let worker_permits = Arc::new(Semaphore::new(1));
-	let in_flight = RemoteSqliteInflight::new();
-	let task_started = Arc::new(Notify::new());
-	let task_release = Arc::new(Notify::new());
-
-	spawn_tracked_remote_sqlite_task(
-		worker_permits,
-		&in_flight,
-		"actor-a".to_string(),
-		7,
-		"test sqlite execute",
-		{
-			let task_started = task_started.clone();
-			let task_release = task_release.clone();
-			async move {
-				task_started.notify_waiters();
-				task_release.notified().await;
-			}
-		},
-	)
-	.await;
-	task_started.notified().await;
-
-	assert!(
-		timeout(
-			Duration::from_millis(20),
-			wait_remote_sqlite_inflight_generation(
-				&in_flight,
-				"actor-a",
-				7,
-				Instant::now() + Duration::from_secs(1),
-			),
-		)
-		.await
-		.is_err()
-	);
-	task_release.notify_waiters();
-	assert!(
-		wait_remote_sqlite_inflight_generation(
-			&in_flight,
-			"actor-a",
-			7,
-			Instant::now() + Duration::from_secs(1),
-		)
-		.await
-	);
-}
-
-#[tokio::test]
 async fn remote_sqlite_executor_reopens_fresh_cell_with_persisted_contents() -> Result<()> {
 	let actor_id = unique_actor_id("remote-sqlite-lazy");
-	let db_dir = tempfile::tempdir()?;
-	let driver = RocksDbDatabaseDriver::new(db_dir.path().to_path_buf()).await?;
-	let db = universaldb::Database::new(Arc::new(driver));
-	let (engine, _compaction_rx) =
-		SqliteEngine::new(db, Subspace::new(&("remote-sqlite-lazy", &actor_id)));
-	let engine = Arc::new(engine);
+	let actor_db = test_actor_db(&actor_id).await?;
 	let executors = RemoteSqliteExecutors::new();
-	let opened = engine.open(&actor_id, OpenConfig::new(1)).await?;
 
 	assert_eq!(executors.len(), 0);
 
 	let handle = remote_sqlite_executor_from_parts(
 		&executors,
-		Arc::clone(&engine),
+		Arc::clone(&actor_db),
 		&actor_id,
-		opened.generation,
+		1,
 	)
 	.await?;
 	assert_eq!(executors.len(), 1);
@@ -400,15 +168,13 @@ async fn remote_sqlite_executor_reopens_fresh_cell_with_persisted_contents() -> 
 		)
 		.await?;
 	handle.close().await?;
-	remove_remote_sqlite_executor_generation(&executors, &actor_id, opened.generation).await;
-	engine.close(&actor_id, opened.generation).await?;
+	remove_remote_sqlite_executor_generation(&executors, &actor_id, 1).await;
 
-	let reopened = engine.open(&actor_id, OpenConfig::new(2)).await?;
 	let fresh_handle = remote_sqlite_executor_from_parts(
 		&executors,
-		Arc::clone(&engine),
+		Arc::clone(&actor_db),
 		&actor_id,
-		reopened.generation,
+		2,
 	)
 	.await?;
 	let result = fresh_handle
@@ -423,34 +189,8 @@ async fn remote_sqlite_executor_reopens_fresh_cell_with_persisted_contents() -> 
 	);
 
 	fresh_handle.close().await?;
-	remove_remote_sqlite_executor_generation(&executors, &actor_id, reopened.generation).await;
-	engine.close(&actor_id, reopened.generation).await?;
+	remove_remote_sqlite_executor_generation(&executors, &actor_id, 2).await;
 	Ok(())
-}
-
-#[test]
-fn validate_sqlite_get_page_range_request_rejects_empty_bounds() {
-	let valid = rivet_envoy_protocol::SqliteGetPageRangeRequest {
-		actor_id: "actor-a".to_string(),
-		generation: 7,
-		start_pgno: 1,
-		max_pages: 1,
-		max_bytes: 4096,
-	};
-
-	validate_sqlite_get_page_range_request(&valid).expect("valid range request");
-
-	let mut invalid = valid.clone();
-	invalid.start_pgno = 0;
-	assert!(validate_sqlite_get_page_range_request(&invalid).is_err());
-
-	let mut invalid = valid.clone();
-	invalid.max_pages = 0;
-	assert!(validate_sqlite_get_page_range_request(&invalid).is_err());
-
-	let mut invalid = valid;
-	invalid.max_bytes = 0;
-	assert!(validate_sqlite_get_page_range_request(&invalid).is_err());
 }
 
 #[test]
@@ -486,6 +226,18 @@ async fn has_remote_sqlite_executor(
 ) -> bool {
 	let key = (actor_id.to_string(), generation);
 	executors.read_async(&key, |_, _| ()).await.is_some()
+}
+
+async fn test_actor_db(actor_id: &str) -> Result<Arc<Db>> {
+	let db_dir = tempfile::tempdir()?.keep();
+	let driver = RocksDbDatabaseDriver::new(db_dir).await?;
+	let db = Arc::new(universaldb::Database::new(Arc::new(driver)));
+	Ok(Arc::new(Db::new(
+		db,
+		Id::new_v1(1),
+		actor_id.to_string(),
+		NodeId::new(),
+	)))
 }
 
 fn unique_actor_id(prefix: &str) -> String {

--- a/engine/packages/universaldb/src/driver/postgres/transaction.rs
+++ b/engine/packages/universaldb/src/driver/postgres/transaction.rs
@@ -13,7 +13,7 @@ use crate::{
 	key_selector::KeySelector,
 	options::{ConflictRangeType, MutationType},
 	range_option::RangeOption,
-	tx_ops::TransactionOperations,
+	tx_ops::{TransactionOperations, validate_commit_limits},
 	utils::IsolationLevel,
 	value::{Slice, Value, Values},
 };
@@ -219,6 +219,7 @@ impl TransactionDriver for PostgresTransactionDriver {
 			self.committed.store(true, Ordering::SeqCst);
 
 			let (operations, conflict_ranges) = self.operations.consume();
+			validate_commit_limits(&operations, &conflict_ranges)?;
 
 			let tx_sender = self.ensure_transaction().await?;
 
@@ -308,6 +309,7 @@ impl TransactionDriver for PostgresTransactionDriver {
 			self.committed.store(true, Ordering::SeqCst);
 
 			let (operations, conflict_ranges) = self.operations.consume();
+			validate_commit_limits(&operations, &conflict_ranges)?;
 
 			// We have operations but no transaction - create one just for commit
 			let tx_sender = self.ensure_transaction().await?;

--- a/engine/packages/universaldb/src/driver/rocksdb/transaction.rs
+++ b/engine/packages/universaldb/src/driver/rocksdb/transaction.rs
@@ -16,7 +16,7 @@ use crate::{
 	key_selector::KeySelector,
 	options::{ConflictRangeType, MutationType},
 	range_option::RangeOption,
-	tx_ops::TransactionOperations,
+	tx_ops::{TransactionOperations, validate_commit_limits},
 	utils::IsolationLevel,
 	value::{Slice, Value, Values},
 };
@@ -238,6 +238,7 @@ impl TransactionDriver for RocksDbTransactionDriver {
 			self.committed.store(true, Ordering::SeqCst);
 
 			let (operations, conflict_ranges) = self.operations.consume();
+			validate_commit_limits(&operations, &conflict_ranges)?;
 
 			let tx_sender = self.ensure_transaction().await?;
 
@@ -327,6 +328,7 @@ impl TransactionDriver for RocksDbTransactionDriver {
 			self.committed.store(true, Ordering::SeqCst);
 
 			let (operations, conflict_ranges) = self.operations.consume();
+			validate_commit_limits(&operations, &conflict_ranges)?;
 
 			// We have operations but no transaction - create one just for commit
 			let tx_sender = self.ensure_transaction().await?;

--- a/engine/packages/universaldb/src/error.rs
+++ b/engine/packages/universaldb/src/error.rs
@@ -7,6 +7,24 @@ pub enum DatabaseError {
 	#[error("transaction is too old to perform reads or be committed")]
 	TransactionTooOld,
 
+	#[error("transaction is too large: {actual_size_bytes} bytes, limit is {max_size_bytes} bytes")]
+	TransactionTooLarge {
+		actual_size_bytes: usize,
+		max_size_bytes: usize,
+	},
+
+	#[error("key is too large: {actual_size_bytes} bytes, limit is {max_size_bytes} bytes")]
+	KeyTooLarge {
+		actual_size_bytes: usize,
+		max_size_bytes: usize,
+	},
+
+	#[error("value is too large: {actual_size_bytes} bytes, limit is {max_size_bytes} bytes")]
+	ValueTooLarge {
+		actual_size_bytes: usize,
+		max_size_bytes: usize,
+	},
+
 	#[error("max number of transaction retries reached")]
 	MaxRetriesReached,
 

--- a/engine/packages/universaldb/src/tx_ops.rs
+++ b/engine/packages/universaldb/src/tx_ops.rs
@@ -7,12 +7,17 @@ use anyhow::Result;
 
 use crate::{
 	atomic::apply_atomic_op,
+	error::DatabaseError,
 	key_selector::KeySelector,
 	options::{ConflictRangeType, MutationType},
 	range_option::RangeOption,
 	utils::{IsolationLevel, end_of_key_range},
 	value::{KeyValue, Slice, Values},
 };
+
+pub const MAX_TRANSACTION_SIZE: usize = 10_000_000;
+pub const MAX_KEY_SIZE: usize = 10_000;
+pub const MAX_VALUE_SIZE: usize = 100_000;
 
 #[derive(Debug, Clone)]
 pub enum Operation {
@@ -422,4 +427,84 @@ impl TransactionOperations {
 			.unwrap()
 			.push((begin.to_vec(), end.to_vec(), conflict_type));
 	}
+}
+
+pub fn validate_commit_limits(
+	operations: &[Operation],
+	conflict_ranges: &[(Vec<u8>, Vec<u8>, ConflictRangeType)],
+) -> Result<()> {
+	let mut size = 0usize;
+
+	for op in operations {
+		match op {
+			Operation::SetValue { key, value } => {
+				validate_key(key)?;
+				validate_value(value)?;
+				add_size(&mut size, key.len())?;
+				add_size(&mut size, value.len())?;
+			}
+			Operation::Clear { key } => {
+				validate_key(key)?;
+				add_size(&mut size, key.len())?;
+			}
+			Operation::ClearRange { begin, end } => {
+				validate_key(begin)?;
+				validate_key(end)?;
+				add_size(&mut size, begin.len())?;
+				add_size(&mut size, end.len())?;
+			}
+			Operation::AtomicOp { key, param, .. } => {
+				validate_key(key)?;
+				validate_value(param)?;
+				add_size(&mut size, key.len())?;
+				add_size(&mut size, param.len())?;
+			}
+		}
+	}
+
+	for (begin, end, _) in conflict_ranges {
+		validate_key(begin)?;
+		validate_key(end)?;
+		add_size(&mut size, begin.len())?;
+		add_size(&mut size, end.len())?;
+	}
+
+	Ok(())
+}
+
+fn validate_key(key: &[u8]) -> Result<()> {
+	if key.len() > MAX_KEY_SIZE {
+		return Err(DatabaseError::KeyTooLarge {
+			actual_size_bytes: key.len(),
+			max_size_bytes: MAX_KEY_SIZE,
+		}
+		.into());
+	}
+
+	Ok(())
+}
+
+fn validate_value(value: &[u8]) -> Result<()> {
+	if value.len() > MAX_VALUE_SIZE {
+		return Err(DatabaseError::ValueTooLarge {
+			actual_size_bytes: value.len(),
+			max_size_bytes: MAX_VALUE_SIZE,
+		}
+		.into());
+	}
+
+	Ok(())
+}
+
+fn add_size(size: &mut usize, amount: usize) -> Result<()> {
+	*size = size.saturating_add(amount);
+	if *size > MAX_TRANSACTION_SIZE {
+		return Err(DatabaseError::TransactionTooLarge {
+			actual_size_bytes: *size,
+			max_size_bytes: MAX_TRANSACTION_SIZE,
+		}
+		.into());
+	}
+
+	Ok(())
 }

--- a/engine/packages/universaldb/src/utils/mod.rs
+++ b/engine/packages/universaldb/src/utils/mod.rs
@@ -1,4 +1,5 @@
 use crate::tuple::{PackError, PackResult};
+use crate::error::DatabaseError;
 
 mod cherry_pick;
 pub mod codes;
@@ -32,9 +33,13 @@ impl std::ops::Deref for MaybeCommitted {
 	}
 }
 
-pub fn error_is_transaction_too_large(_err: &anyhow::Error) -> bool {
-	// Only implemented with fdb
-	false
+pub fn error_is_transaction_too_large(err: &anyhow::Error) -> bool {
+	err.chain().any(|source| {
+		matches!(
+			source.downcast_ref::<DatabaseError>(),
+			Some(DatabaseError::TransactionTooLarge { .. })
+		)
+	})
 }
 
 /// Calculate exponential backoff based on attempt.

--- a/engine/packages/universaldb/tests/integration.rs
+++ b/engine/packages/universaldb/tests/integration.rs
@@ -131,6 +131,62 @@ async fn run_all_tests(db: universaldb::Database) {
 	// Test database options
 	test_database_options(&db).await;
 	clear_test_namespace(&db).await.unwrap();
+
+	// Test FoundationDB-style transaction limits.
+	test_transaction_limits(&db).await;
+	clear_test_namespace(&db).await.unwrap();
+}
+
+async fn test_transaction_limits(db: &Database) {
+	use universaldb::error::DatabaseError;
+
+	let err = db
+		.run(|tx| async move {
+			tx.set(&vec![b'k'; 10_001], b"value");
+			Ok(())
+		})
+		.await
+		.expect_err("oversized key should fail");
+	assert!(
+		err.chain().any(|source| matches!(
+			source.downcast_ref::<DatabaseError>(),
+			Some(DatabaseError::KeyTooLarge { .. })
+		)),
+		"unexpected oversized-key error: {err:#}"
+	);
+
+	let err = db
+		.run(|tx| async move {
+			tx.set(b"large-value", &vec![0; 100_001]);
+			Ok(())
+		})
+		.await
+		.expect_err("oversized value should fail");
+	assert!(
+		err.chain().any(|source| matches!(
+			source.downcast_ref::<DatabaseError>(),
+			Some(DatabaseError::ValueTooLarge { .. })
+		)),
+		"unexpected oversized-value error: {err:#}"
+	);
+
+	let err = db
+		.run(|tx| async move {
+			let value = vec![0; 100_000];
+			for i in 0..101 {
+				tx.set(format!("large-tx-{i:03}").as_bytes(), &value);
+			}
+			Ok(())
+		})
+		.await
+		.expect_err("oversized transaction should fail");
+	assert!(
+		err.chain().any(|source| matches!(
+			source.downcast_ref::<DatabaseError>(),
+			Some(DatabaseError::TransactionTooLarge { .. })
+		)),
+		"unexpected oversized-transaction error: {err:#}"
+	);
 }
 
 async fn test_database_options(db: &Database) {

--- a/engine/sdks/rust/envoy-client/src/envoy.rs
+++ b/engine/sdks/rust/envoy-client/src/envoy.rs
@@ -30,7 +30,10 @@ use crate::sqlite::{
 	fail_sent_remote_sqlite_requests_with_indeterminate_result, fail_sqlite_requests_with_shutdown,
 	handle_remote_sqlite_exec_response, handle_remote_sqlite_execute_response,
 	handle_remote_sqlite_request, handle_sqlite_commit_response, handle_sqlite_get_pages_response,
-	handle_sqlite_request, process_unsent_remote_sqlite_requests, process_unsent_sqlite_requests,
+	handle_sqlite_commit_stage_abort_response, handle_sqlite_commit_stage_begin_response,
+	handle_sqlite_commit_stage_complete_response, handle_sqlite_commit_stage_finalize_response,
+	handle_sqlite_commit_stage_pages_response, handle_sqlite_request,
+	process_unsent_remote_sqlite_requests, process_unsent_sqlite_requests,
 };
 use crate::tunnel::{
 	handle_tunnel_message, resend_buffered_tunnel_messages, send_hibernatable_ws_message_ack,
@@ -543,6 +546,21 @@ async fn handle_conn_message(
 		}
 		protocol::ToEnvoy::ToEnvoySqliteCommitResponse(response) => {
 			handle_sqlite_commit_response(ctx, response).await;
+		}
+		protocol::ToEnvoy::ToEnvoySqliteCommitStageBeginResponse(response) => {
+			handle_sqlite_commit_stage_begin_response(ctx, response).await;
+		}
+		protocol::ToEnvoy::ToEnvoySqliteCommitStagePagesResponse(response) => {
+			handle_sqlite_commit_stage_pages_response(ctx, response).await;
+		}
+		protocol::ToEnvoy::ToEnvoySqliteCommitStageCompleteResponse(response) => {
+			handle_sqlite_commit_stage_complete_response(ctx, response).await;
+		}
+		protocol::ToEnvoy::ToEnvoySqliteCommitStageFinalizeResponse(response) => {
+			handle_sqlite_commit_stage_finalize_response(ctx, response).await;
+		}
+		protocol::ToEnvoy::ToEnvoySqliteCommitStageAbortResponse(response) => {
+			handle_sqlite_commit_stage_abort_response(ctx, response).await;
 		}
 		protocol::ToEnvoy::ToEnvoySqliteExecResponse(response) => {
 			handle_remote_sqlite_exec_response(ctx, response).await;

--- a/engine/sdks/rust/envoy-client/src/handle.rs
+++ b/engine/sdks/rust/envoy-client/src/handle.rs
@@ -476,6 +476,71 @@ impl EnvoyHandle {
 		}
 	}
 
+	pub async fn sqlite_commit_stage_begin(
+		&self,
+		request: protocol::SqliteCommitStageBeginRequest,
+	) -> anyhow::Result<protocol::SqliteCommitStageBeginResponse> {
+		match self
+			.send_sqlite_request(SqliteRequest::CommitStageBegin(request))
+			.await?
+		{
+			SqliteResponse::CommitStageBegin(response) => Ok(response),
+			_ => anyhow::bail!("unexpected sqlite commit stage begin response type"),
+		}
+	}
+
+	pub async fn sqlite_commit_stage_pages(
+		&self,
+		request: protocol::SqliteCommitStagePagesRequest,
+	) -> anyhow::Result<protocol::SqliteCommitStagePagesResponse> {
+		match self
+			.send_sqlite_request(SqliteRequest::CommitStagePages(request))
+			.await?
+		{
+			SqliteResponse::CommitStagePages(response) => Ok(response),
+			_ => anyhow::bail!("unexpected sqlite commit stage pages response type"),
+		}
+	}
+
+	pub async fn sqlite_commit_stage_complete(
+		&self,
+		request: protocol::SqliteCommitStageCompleteRequest,
+	) -> anyhow::Result<protocol::SqliteCommitStageCompleteResponse> {
+		match self
+			.send_sqlite_request(SqliteRequest::CommitStageComplete(request))
+			.await?
+		{
+			SqliteResponse::CommitStageComplete(response) => Ok(response),
+			_ => anyhow::bail!("unexpected sqlite commit stage complete response type"),
+		}
+	}
+
+	pub async fn sqlite_commit_stage_finalize(
+		&self,
+		request: protocol::SqliteCommitStageFinalizeRequest,
+	) -> anyhow::Result<protocol::SqliteCommitResponse> {
+		match self
+			.send_sqlite_request(SqliteRequest::CommitStageFinalize(request))
+			.await?
+		{
+			SqliteResponse::CommitStageFinalize(response) => Ok(response),
+			_ => anyhow::bail!("unexpected sqlite commit stage finalize response type"),
+		}
+	}
+
+	pub async fn sqlite_commit_stage_abort(
+		&self,
+		request: protocol::SqliteCommitStageAbortRequest,
+	) -> anyhow::Result<protocol::SqliteCommitStageAbortResponse> {
+		match self
+			.send_sqlite_request(SqliteRequest::CommitStageAbort(request))
+			.await?
+		{
+			SqliteResponse::CommitStageAbort(response) => Ok(response),
+			_ => anyhow::bail!("unexpected sqlite commit stage abort response type"),
+		}
+	}
+
 	pub async fn remote_sqlite_exec(
 		&self,
 		request: protocol::SqliteExecRequest,

--- a/engine/sdks/rust/envoy-client/src/sqlite.rs
+++ b/engine/sdks/rust/envoy-client/src/sqlite.rs
@@ -10,11 +10,21 @@ use crate::utils::{EnvoyShutdownError, RemoteSqliteIndeterminateResultError};
 pub enum SqliteRequest {
 	GetPages(protocol::SqliteGetPagesRequest),
 	Commit(protocol::SqliteCommitRequest),
+	CommitStageBegin(protocol::SqliteCommitStageBeginRequest),
+	CommitStagePages(protocol::SqliteCommitStagePagesRequest),
+	CommitStageComplete(protocol::SqliteCommitStageCompleteRequest),
+	CommitStageFinalize(protocol::SqliteCommitStageFinalizeRequest),
+	CommitStageAbort(protocol::SqliteCommitStageAbortRequest),
 }
 
 pub enum SqliteResponse {
 	GetPages(protocol::SqliteGetPagesResponse),
 	Commit(protocol::SqliteCommitResponse),
+	CommitStageBegin(protocol::SqliteCommitStageBeginResponse),
+	CommitStagePages(protocol::SqliteCommitStagePagesResponse),
+	CommitStageComplete(protocol::SqliteCommitStageCompleteResponse),
+	CommitStageFinalize(protocol::SqliteCommitResponse),
+	CommitStageAbort(protocol::SqliteCommitStageAbortResponse),
 }
 
 #[derive(Clone, Debug)]
@@ -130,6 +140,66 @@ pub async fn handle_sqlite_commit_response(
 	);
 }
 
+pub async fn handle_sqlite_commit_stage_begin_response(
+	ctx: &mut EnvoyContext,
+	response: protocol::ToEnvoySqliteCommitStageBeginResponse,
+) {
+	handle_sqlite_response(
+		ctx,
+		response.request_id,
+		SqliteResponse::CommitStageBegin(response.data),
+		"sqlite_commit_stage_begin",
+	);
+}
+
+pub async fn handle_sqlite_commit_stage_pages_response(
+	ctx: &mut EnvoyContext,
+	response: protocol::ToEnvoySqliteCommitStagePagesResponse,
+) {
+	handle_sqlite_response(
+		ctx,
+		response.request_id,
+		SqliteResponse::CommitStagePages(response.data),
+		"sqlite_commit_stage_pages",
+	);
+}
+
+pub async fn handle_sqlite_commit_stage_complete_response(
+	ctx: &mut EnvoyContext,
+	response: protocol::ToEnvoySqliteCommitStageCompleteResponse,
+) {
+	handle_sqlite_response(
+		ctx,
+		response.request_id,
+		SqliteResponse::CommitStageComplete(response.data),
+		"sqlite_commit_stage_complete",
+	);
+}
+
+pub async fn handle_sqlite_commit_stage_finalize_response(
+	ctx: &mut EnvoyContext,
+	response: protocol::ToEnvoySqliteCommitStageFinalizeResponse,
+) {
+	handle_sqlite_response(
+		ctx,
+		response.request_id,
+		SqliteResponse::CommitStageFinalize(response.data),
+		"sqlite_commit_stage_finalize",
+	);
+}
+
+pub async fn handle_sqlite_commit_stage_abort_response(
+	ctx: &mut EnvoyContext,
+	response: protocol::ToEnvoySqliteCommitStageAbortResponse,
+) {
+	handle_sqlite_response(
+		ctx,
+		response.request_id,
+		SqliteResponse::CommitStageAbort(response.data),
+		"sqlite_commit_stage_abort",
+	);
+}
+
 pub async fn handle_remote_sqlite_exec_response(
 	ctx: &mut EnvoyContext,
 	response: protocol::ToEnvoySqliteExecResponse,
@@ -207,6 +277,31 @@ pub async fn send_single_sqlite_request(ctx: &mut EnvoyContext, request_id: u32)
 			SqliteRequest::Commit(data) => protocol::ToRivet::ToRivetSqliteCommitRequest(
 				protocol::ToRivetSqliteCommitRequest { request_id, data },
 			),
+			SqliteRequest::CommitStageBegin(data) => {
+				protocol::ToRivet::ToRivetSqliteCommitStageBeginRequest(
+					protocol::ToRivetSqliteCommitStageBeginRequest { request_id, data },
+				)
+			}
+			SqliteRequest::CommitStagePages(data) => {
+				protocol::ToRivet::ToRivetSqliteCommitStagePagesRequest(
+					protocol::ToRivetSqliteCommitStagePagesRequest { request_id, data },
+				)
+			}
+			SqliteRequest::CommitStageComplete(data) => {
+				protocol::ToRivet::ToRivetSqliteCommitStageCompleteRequest(
+					protocol::ToRivetSqliteCommitStageCompleteRequest { request_id, data },
+				)
+			}
+			SqliteRequest::CommitStageFinalize(data) => {
+				protocol::ToRivet::ToRivetSqliteCommitStageFinalizeRequest(
+					protocol::ToRivetSqliteCommitStageFinalizeRequest { request_id, data },
+				)
+			}
+			SqliteRequest::CommitStageAbort(data) => {
+				protocol::ToRivet::ToRivetSqliteCommitStageAbortRequest(
+					protocol::ToRivetSqliteCommitStageAbortRequest { request_id, data },
+				)
+			}
 		};
 
 	ws_send(&ctx.shared, message).await;
@@ -379,6 +474,7 @@ pub fn fail_sent_remote_sqlite_requests_with_indeterminate_result(ctx: &mut Envo
 mod tests {
 	use std::collections::HashMap;
 	use std::sync::Arc;
+	use std::time::Duration;
 
 	use vbare::OwnedVersionedData;
 
@@ -626,6 +722,47 @@ mod tests {
 			.downcast_ref::<RemoteSqliteIndeterminateResultError>()
 			.expect("error should describe indeterminate remote sqlite result");
 		assert_eq!(indeterminate.operation, "execute");
+		assert!(ctx.remote_sqlite_requests.is_empty());
+	}
+
+	#[tokio::test]
+	#[ignore = "repro for sent remote SQL timeout being reported as a generic timeout"]
+	async fn repro_sent_remote_sqlite_timeout_is_not_indeterminate() {
+		let mut ctx = new_envoy_context();
+		let (ws_tx, mut ws_rx) = tokio::sync::mpsc::unbounded_channel();
+		*ctx.shared.ws_tx.lock().await = Some(ws_tx);
+		let (tx, rx) = oneshot::channel();
+
+		handle_remote_sqlite_request(
+			&mut ctx,
+			RemoteSqliteRequest::Execute(execute_request()),
+			tx,
+		)
+		.await;
+		assert!(matches!(ws_rx.recv().await, Some(WsTxMessage::Send(_))));
+		let entry = ctx
+			.remote_sqlite_requests
+			.get_mut(&0)
+			.expect("request should be pending");
+		assert!(entry.sent);
+		entry.timestamp =
+			crate::time::Instant::now() - Duration::from_millis(KV_EXPIRE_MS + 1);
+
+		cleanup_old_remote_sqlite_requests(&mut ctx);
+
+		let err = rx
+			.await
+			.expect("response sender should complete")
+			.expect_err("sent remote SQL should time out");
+		assert!(
+			err.downcast_ref::<RemoteSqliteIndeterminateResultError>()
+				.is_none(),
+			"current cleanup reports a generic timeout instead of indeterminate"
+		);
+		assert!(
+			err.to_string().contains("remote sqlite request timed out"),
+			"unexpected timeout error: {err:#}"
+		);
 		assert!(ctx.remote_sqlite_requests.is_empty());
 	}
 

--- a/engine/sdks/rust/envoy-client/src/stringify.rs
+++ b/engine/sdks/rust/envoy-client/src/stringify.rs
@@ -275,6 +275,36 @@ pub fn stringify_to_rivet(message: &protocol::ToRivet) -> String {
 				val.request_id
 			)
 		}
+		protocol::ToRivet::ToRivetSqliteCommitStageBeginRequest(val) => {
+			format!(
+				"ToRivetSqliteCommitStageBeginRequest{{requestId: {}}}",
+				val.request_id
+			)
+		}
+		protocol::ToRivet::ToRivetSqliteCommitStagePagesRequest(val) => {
+			format!(
+				"ToRivetSqliteCommitStagePagesRequest{{requestId: {}}}",
+				val.request_id
+			)
+		}
+		protocol::ToRivet::ToRivetSqliteCommitStageCompleteRequest(val) => {
+			format!(
+				"ToRivetSqliteCommitStageCompleteRequest{{requestId: {}}}",
+				val.request_id
+			)
+		}
+		protocol::ToRivet::ToRivetSqliteCommitStageFinalizeRequest(val) => {
+			format!(
+				"ToRivetSqliteCommitStageFinalizeRequest{{requestId: {}}}",
+				val.request_id
+			)
+		}
+		protocol::ToRivet::ToRivetSqliteCommitStageAbortRequest(val) => {
+			format!(
+				"ToRivetSqliteCommitStageAbortRequest{{requestId: {}}}",
+				val.request_id
+			)
+		}
 		protocol::ToRivet::ToRivetSqliteExecRequest(val) => {
 			format!(
 				"ToRivetSqliteExecRequest{{requestId: {}, actorId: \"{}\", generation: {}}}",
@@ -336,6 +366,36 @@ pub fn stringify_to_envoy(message: &protocol::ToEnvoy) -> String {
 		protocol::ToEnvoy::ToEnvoySqliteCommitResponse(val) => {
 			format!(
 				"ToEnvoySqliteCommitResponse{{requestId: {}}}",
+				val.request_id
+			)
+		}
+		protocol::ToEnvoy::ToEnvoySqliteCommitStageBeginResponse(val) => {
+			format!(
+				"ToEnvoySqliteCommitStageBeginResponse{{requestId: {}}}",
+				val.request_id
+			)
+		}
+		protocol::ToEnvoy::ToEnvoySqliteCommitStagePagesResponse(val) => {
+			format!(
+				"ToEnvoySqliteCommitStagePagesResponse{{requestId: {}}}",
+				val.request_id
+			)
+		}
+		protocol::ToEnvoy::ToEnvoySqliteCommitStageCompleteResponse(val) => {
+			format!(
+				"ToEnvoySqliteCommitStageCompleteResponse{{requestId: {}}}",
+				val.request_id
+			)
+		}
+		protocol::ToEnvoy::ToEnvoySqliteCommitStageFinalizeResponse(val) => {
+			format!(
+				"ToEnvoySqliteCommitStageFinalizeResponse{{requestId: {}}}",
+				val.request_id
+			)
+		}
+		protocol::ToEnvoy::ToEnvoySqliteCommitStageAbortResponse(val) => {
+			format!(
+				"ToEnvoySqliteCommitStageAbortResponse{{requestId: {}}}",
 				val.request_id
 			)
 		}

--- a/engine/sdks/rust/envoy-protocol/src/lib.rs
+++ b/engine/sdks/rust/envoy-protocol/src/lib.rs
@@ -3,6 +3,6 @@ pub mod util;
 pub mod versioned;
 
 // Re-export latest
-pub use generated::v5::*;
+pub use generated::v6::*;
 
 pub use generated::PROTOCOL_VERSION;

--- a/engine/sdks/rust/envoy-protocol/src/versioned.rs
+++ b/engine/sdks/rust/envoy-protocol/src/versioned.rs
@@ -2,7 +2,7 @@ use anyhow::{Result, bail};
 use std::{error::Error, fmt};
 use vbare::OwnedVersionedData;
 
-use crate::generated::{v1, v2, v3, v4, v5};
+use crate::generated::{v1, v2, v3, v4, v5, v6};
 
 fn convert_same_bytes<T, U>(message: T) -> Result<U>
 where
@@ -26,6 +26,7 @@ pub enum ProtocolCompatibilityFeature {
 	SqlitePageIo,
 	SqlitePageRange,
 	RemoteSqliteExecution,
+	SqliteCommitStaging,
 }
 
 impl ProtocolCompatibilityFeature {
@@ -43,6 +44,10 @@ impl ProtocolCompatibilityFeature {
 			ProtocolCompatibilityFeature::RemoteSqliteExecution => match direction {
 				ProtocolCompatibilityDirection::ToEnvoy => "remote sqlite responses",
 				ProtocolCompatibilityDirection::ToRivet => "remote sqlite requests",
+			},
+			ProtocolCompatibilityFeature::SqliteCommitStaging => match direction {
+				ProtocolCompatibilityDirection::ToEnvoy => "sqlite commit staging responses",
+				ProtocolCompatibilityDirection::ToRivet => "sqlite commit staging requests",
 			},
 		}
 	}
@@ -68,7 +73,8 @@ impl fmt::Display for ProtocolCompatibilityError {
 			ProtocolCompatibilityFeature::SqliteStartupData => "requires",
 			ProtocolCompatibilityFeature::SqlitePageIo
 			| ProtocolCompatibilityFeature::SqlitePageRange
-			| ProtocolCompatibilityFeature::RemoteSqliteExecution => "require",
+			| ProtocolCompatibilityFeature::RemoteSqliteExecution
+			| ProtocolCompatibilityFeature::SqliteCommitStaging => "require",
 		};
 
 		write!(
@@ -100,154 +106,158 @@ fn incompatible(
 }
 
 pub enum ToEnvoy {
-	V5(v5::ToEnvoy),
+	V6(v6::ToEnvoy),
 }
 
 impl OwnedVersionedData for ToEnvoy {
-	type Latest = v5::ToEnvoy;
+	type Latest = v6::ToEnvoy;
 
 	fn wrap_latest(latest: Self::Latest) -> Self {
-		Self::V5(latest)
+		Self::V6(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
 		match self {
-			Self::V5(data) => Ok(data),
+			Self::V6(data) => Ok(data),
 		}
 	}
 
 	fn deserialize_version(payload: &[u8], version: u16) -> Result<Self> {
-		Ok(Self::V5(match version {
-			1 => convert_to_envoy_v4_to_v5(convert_to_envoy_v3_to_v4(convert_to_envoy_v2_to_v3(
+		Ok(Self::V6(match version {
+			1 => convert_to_envoy_v5_to_v6(convert_to_envoy_v4_to_v5(convert_to_envoy_v3_to_v4(convert_to_envoy_v2_to_v3(
 				convert_to_envoy_v1_to_v2(serde_bare::from_slice(payload)?)?,
-			)?)?)?,
-			2 => convert_to_envoy_v4_to_v5(convert_to_envoy_v3_to_v4(convert_to_envoy_v2_to_v3(
+			)?)?)?)?,
+			2 => convert_to_envoy_v5_to_v6(convert_to_envoy_v4_to_v5(convert_to_envoy_v3_to_v4(convert_to_envoy_v2_to_v3(
 				serde_bare::from_slice(payload)?,
-			)?)?)?,
-			3 => convert_to_envoy_v4_to_v5(convert_to_envoy_v3_to_v4(serde_bare::from_slice(
+			)?)?)?)?,
+			3 => convert_to_envoy_v5_to_v6(convert_to_envoy_v4_to_v5(convert_to_envoy_v3_to_v4(serde_bare::from_slice(
 				payload,
-			)?)?)?,
-			4 => convert_to_envoy_v4_to_v5(serde_bare::from_slice(payload)?)?,
-			5 => serde_bare::from_slice(payload)?,
+			)?)?)?)?,
+			4 => convert_to_envoy_v5_to_v6(convert_to_envoy_v4_to_v5(serde_bare::from_slice(payload)?)?)?,
+			5 => convert_to_envoy_v5_to_v6(serde_bare::from_slice(payload)?)?,
+			6 => serde_bare::from_slice(payload)?,
 			_ => bail!("invalid version: {version}"),
 		}))
 	}
 
 	fn serialize_version(self, version: u16) -> Result<Vec<u8>> {
-		let Self::V5(data) = self;
+		let Self::V6(data) = self;
 		match version {
 			1 => {
-				let data = convert_to_envoy_v5_to_v4(data)?;
+				let data = convert_to_envoy_v5_to_v4(convert_to_envoy_v6_to_v5(data, 1)?)?;
 				serde_bare::to_vec(&convert_to_envoy_v2_to_v1(convert_to_envoy_v3_to_v2(
 					convert_to_envoy_v4_to_v3(data, 1)?,
 				)?)?)
 				.map_err(Into::into)
 			}
 			2 => {
-				let data = convert_to_envoy_v5_to_v4(data)?;
+				let data = convert_to_envoy_v5_to_v4(convert_to_envoy_v6_to_v5(data, 2)?)?;
 				serde_bare::to_vec(&convert_to_envoy_v3_to_v2(convert_to_envoy_v4_to_v3(
 					data, 2,
 				)?)?)
 				.map_err(Into::into)
 			}
 			3 => {
-				let data = convert_to_envoy_v5_to_v4(data)?;
+				let data = convert_to_envoy_v5_to_v4(convert_to_envoy_v6_to_v5(data, 3)?)?;
 				serde_bare::to_vec(&convert_to_envoy_v4_to_v3(data, 3)?).map_err(Into::into)
 			}
-			4 => serde_bare::to_vec(&convert_to_envoy_v5_to_v4(data)?).map_err(Into::into),
-			5 => serde_bare::to_vec(&data).map_err(Into::into),
+			4 => serde_bare::to_vec(&convert_to_envoy_v5_to_v4(convert_to_envoy_v6_to_v5(data, 4)?)?).map_err(Into::into),
+			5 => serde_bare::to_vec(&convert_to_envoy_v6_to_v5(data, 5)?).map_err(Into::into),
+			6 => serde_bare::to_vec(&data).map_err(Into::into),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Ok]
+		vec![Ok, Ok, Ok, Ok, Ok]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Ok]
+		vec![Ok, Ok, Ok, Ok, Ok]
 	}
 }
 
 pub enum ToRivet {
-	V5(v5::ToRivet),
+	V6(v6::ToRivet),
 }
 
 impl OwnedVersionedData for ToRivet {
-	type Latest = v5::ToRivet;
+	type Latest = v6::ToRivet;
 
 	fn wrap_latest(latest: Self::Latest) -> Self {
-		Self::V5(latest)
+		Self::V6(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
 		match self {
-			Self::V5(data) => Ok(data),
+			Self::V6(data) => Ok(data),
 		}
 	}
 
 	fn deserialize_version(payload: &[u8], version: u16) -> Result<Self> {
-		Ok(Self::V5(match version {
-			1 | 2 => convert_to_rivet_v4_to_v5(convert_to_rivet_v3_to_v4(
+		Ok(Self::V6(match version {
+			1 | 2 => convert_to_rivet_v5_to_v6(convert_to_rivet_v4_to_v5(convert_to_rivet_v3_to_v4(
 				convert_to_rivet_v2_to_v3(serde_bare::from_slice(payload)?)?,
-			)?)?,
-			3 => convert_to_rivet_v4_to_v5(convert_to_rivet_v3_to_v4(serde_bare::from_slice(
-				payload,
 			)?)?)?,
-			4 => convert_to_rivet_v4_to_v5(serde_bare::from_slice(payload)?)?,
-			5 => serde_bare::from_slice(payload)?,
+			3 => convert_to_rivet_v5_to_v6(convert_to_rivet_v4_to_v5(convert_to_rivet_v3_to_v4(serde_bare::from_slice(
+				payload,
+			)?)?)?)?,
+			4 => convert_to_rivet_v5_to_v6(convert_to_rivet_v4_to_v5(serde_bare::from_slice(payload)?)?)?,
+			5 => convert_to_rivet_v5_to_v6(serde_bare::from_slice(payload)?)?,
+			6 => serde_bare::from_slice(payload)?,
 			_ => bail!("invalid version: {version}"),
 		}))
 	}
 
 	fn serialize_version(self, version: u16) -> Result<Vec<u8>> {
-		let Self::V5(data) = self;
+		let Self::V6(data) = self;
 		match version {
 			1 | 2 => {
-				let data = convert_to_rivet_v5_to_v4(data)?;
+				let data = convert_to_rivet_v5_to_v4(convert_to_rivet_v6_to_v5(data, version)?)?;
 				serde_bare::to_vec(&convert_to_rivet_v3_to_v2(convert_to_rivet_v4_to_v3(
 					data, version,
 				)?)?)
 				.map_err(Into::into)
 			}
 			3 => {
-				let data = convert_to_rivet_v5_to_v4(data)?;
+				let data = convert_to_rivet_v5_to_v4(convert_to_rivet_v6_to_v5(data, 3)?)?;
 				serde_bare::to_vec(&convert_to_rivet_v4_to_v3(data, 3)?).map_err(Into::into)
 			}
-			4 => serde_bare::to_vec(&convert_to_rivet_v5_to_v4(data)?).map_err(Into::into),
-			5 => serde_bare::to_vec(&data).map_err(Into::into),
+			4 => serde_bare::to_vec(&convert_to_rivet_v5_to_v4(convert_to_rivet_v6_to_v5(data, 4)?)?).map_err(Into::into),
+			5 => serde_bare::to_vec(&convert_to_rivet_v6_to_v5(data, 5)?).map_err(Into::into),
+			6 => serde_bare::to_vec(&data).map_err(Into::into),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Ok]
+		vec![Ok, Ok, Ok, Ok, Ok]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Ok]
+		vec![Ok, Ok, Ok, Ok, Ok]
 	}
 }
 
 pub enum ToEnvoyConn {
-	V5(v5::ToEnvoyConn),
+	V6(v6::ToEnvoyConn),
 }
 
 impl OwnedVersionedData for ToEnvoyConn {
-	type Latest = v5::ToEnvoyConn;
+	type Latest = v6::ToEnvoyConn;
 
 	fn wrap_latest(latest: Self::Latest) -> Self {
-		Self::V5(latest)
+		Self::V6(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
 		match self {
-			Self::V5(data) => Ok(data),
+			Self::V6(data) => Ok(data),
 		}
 	}
 
 	fn deserialize_version(payload: &[u8], version: u16) -> Result<Self> {
-		Ok(Self::V5(match version {
+		Ok(Self::V6(match version {
 			1 => convert_same_bytes(convert_to_envoy_conn_v1_to_v3(serde_bare::from_slice(
 				payload,
 			)?)?)?,
@@ -256,13 +266,14 @@ impl OwnedVersionedData for ToEnvoyConn {
 			)?)?)?,
 			3 => convert_same_bytes(serde_bare::from_slice::<v3::ToEnvoyConn>(payload)?)?,
 			4 => convert_same_bytes(serde_bare::from_slice::<v4::ToEnvoyConn>(payload)?)?,
-			5 => serde_bare::from_slice(payload)?,
+			5 => convert_same_bytes(serde_bare::from_slice::<v5::ToEnvoyConn>(payload)?)?,
+			6 => serde_bare::from_slice(payload)?,
 			_ => bail!("invalid version: {version}"),
 		}))
 	}
 
 	fn serialize_version(self, version: u16) -> Result<Vec<u8>> {
-		let Self::V5(data) = self;
+		let Self::V6(data) = self;
 		let data_v4 = || convert_same_bytes_ref::<_, v4::ToEnvoyConn>(&data);
 		match version {
 			1 => {
@@ -281,39 +292,41 @@ impl OwnedVersionedData for ToEnvoyConn {
 					.map_err(Into::into)
 			}
 			4 => serde_bare::to_vec(&data_v4()?).map_err(Into::into),
-			5 => serde_bare::to_vec(&data).map_err(Into::into),
+			5 => serde_bare::to_vec(&convert_same_bytes_ref::<_, v5::ToEnvoyConn>(&data)?)
+				.map_err(Into::into),
+			6 => serde_bare::to_vec(&data).map_err(Into::into),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Ok]
+		vec![Ok, Ok, Ok, Ok, Ok]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Ok]
+		vec![Ok, Ok, Ok, Ok, Ok]
 	}
 }
 
 pub enum ToGateway {
-	V5(v5::ToGateway),
+	V6(v6::ToGateway),
 }
 
 impl OwnedVersionedData for ToGateway {
-	type Latest = v5::ToGateway;
+	type Latest = v6::ToGateway;
 
 	fn wrap_latest(latest: Self::Latest) -> Self {
-		Self::V5(latest)
+		Self::V6(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
 		match self {
-			Self::V5(data) => Ok(data),
+			Self::V6(data) => Ok(data),
 		}
 	}
 
 	fn deserialize_version(payload: &[u8], version: u16) -> Result<Self> {
-		Ok(Self::V5(match version {
+		Ok(Self::V6(match version {
 			1 => convert_same_bytes(convert_to_gateway_v1_to_v3(serde_bare::from_slice(
 				payload,
 			)?))?,
@@ -322,13 +335,14 @@ impl OwnedVersionedData for ToGateway {
 			)?))?,
 			3 => convert_same_bytes(serde_bare::from_slice::<v3::ToGateway>(payload)?)?,
 			4 => convert_same_bytes(serde_bare::from_slice::<v4::ToGateway>(payload)?)?,
-			5 => serde_bare::from_slice(payload)?,
+			5 => convert_same_bytes(serde_bare::from_slice::<v5::ToGateway>(payload)?)?,
+			6 => serde_bare::from_slice(payload)?,
 			_ => bail!("invalid version: {version}"),
 		}))
 	}
 
 	fn serialize_version(self, version: u16) -> Result<Vec<u8>> {
-		let Self::V5(data) = self;
+		let Self::V6(data) = self;
 		let data_v4 = || convert_same_bytes_ref::<_, v4::ToGateway>(&data);
 		match version {
 			1 => {
@@ -347,39 +361,41 @@ impl OwnedVersionedData for ToGateway {
 					.map_err(Into::into)
 			}
 			4 => serde_bare::to_vec(&data_v4()?).map_err(Into::into),
-			5 => serde_bare::to_vec(&data).map_err(Into::into),
+			5 => serde_bare::to_vec(&convert_same_bytes_ref::<_, v5::ToGateway>(&data)?)
+				.map_err(Into::into),
+			6 => serde_bare::to_vec(&data).map_err(Into::into),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Ok]
+		vec![Ok, Ok, Ok, Ok, Ok]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Ok]
+		vec![Ok, Ok, Ok, Ok, Ok]
 	}
 }
 
 pub enum ToOutbound {
-	V5(v5::ToOutbound),
+	V6(v6::ToOutbound),
 }
 
 impl OwnedVersionedData for ToOutbound {
-	type Latest = v5::ToOutbound;
+	type Latest = v6::ToOutbound;
 
 	fn wrap_latest(latest: Self::Latest) -> Self {
-		Self::V5(latest)
+		Self::V6(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
 		match self {
-			Self::V5(data) => Ok(data),
+			Self::V6(data) => Ok(data),
 		}
 	}
 
 	fn deserialize_version(payload: &[u8], version: u16) -> Result<Self> {
-		Ok(Self::V5(match version {
+		Ok(Self::V6(match version {
 			1 => convert_same_bytes(convert_to_outbound_v1_to_v3(serde_bare::from_slice(
 				payload,
 			)?))?,
@@ -388,13 +404,14 @@ impl OwnedVersionedData for ToOutbound {
 			)?))?,
 			3 => convert_same_bytes(serde_bare::from_slice::<v3::ToOutbound>(payload)?)?,
 			4 => convert_same_bytes(serde_bare::from_slice::<v4::ToOutbound>(payload)?)?,
-			5 => serde_bare::from_slice(payload)?,
+			5 => convert_same_bytes(serde_bare::from_slice::<v5::ToOutbound>(payload)?)?,
+			6 => serde_bare::from_slice(payload)?,
 			_ => bail!("invalid version: {version}"),
 		}))
 	}
 
 	fn serialize_version(self, version: u16) -> Result<Vec<u8>> {
-		let Self::V5(data) = self;
+		let Self::V6(data) = self;
 		let data_v4 = || convert_same_bytes_ref::<_, v4::ToOutbound>(&data);
 		match version {
 			1 => {
@@ -413,39 +430,41 @@ impl OwnedVersionedData for ToOutbound {
 					.map_err(Into::into)
 			}
 			4 => serde_bare::to_vec(&data_v4()?).map_err(Into::into),
-			5 => serde_bare::to_vec(&data).map_err(Into::into),
+			5 => serde_bare::to_vec(&convert_same_bytes_ref::<_, v5::ToOutbound>(&data)?)
+				.map_err(Into::into),
+			6 => serde_bare::to_vec(&data).map_err(Into::into),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Ok]
+		vec![Ok, Ok, Ok, Ok, Ok]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Ok]
+		vec![Ok, Ok, Ok, Ok, Ok]
 	}
 }
 
 pub enum ActorCommandKeyData {
-	V5(v5::ActorCommandKeyData),
+	V6(v6::ActorCommandKeyData),
 }
 
 impl OwnedVersionedData for ActorCommandKeyData {
-	type Latest = v5::ActorCommandKeyData;
+	type Latest = v6::ActorCommandKeyData;
 
 	fn wrap_latest(latest: Self::Latest) -> Self {
-		Self::V5(latest)
+		Self::V6(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
 		match self {
-			Self::V5(data) => Ok(data),
+			Self::V6(data) => Ok(data),
 		}
 	}
 
 	fn deserialize_version(payload: &[u8], version: u16) -> Result<Self> {
-		Ok(Self::V5(match version {
+		Ok(Self::V6(match version {
 			1 => convert_same_bytes(convert_actor_command_key_data_v1_to_v3(
 				serde_bare::from_slice(payload)?,
 			))?,
@@ -454,13 +473,14 @@ impl OwnedVersionedData for ActorCommandKeyData {
 			))?,
 			3 => convert_same_bytes(serde_bare::from_slice::<v3::ActorCommandKeyData>(payload)?)?,
 			4 => convert_same_bytes(serde_bare::from_slice::<v4::ActorCommandKeyData>(payload)?)?,
-			5 => serde_bare::from_slice(payload)?,
+			5 => convert_same_bytes(serde_bare::from_slice::<v5::ActorCommandKeyData>(payload)?)?,
+			6 => serde_bare::from_slice(payload)?,
 			_ => bail!("invalid version: {version}"),
 		}))
 	}
 
 	fn serialize_version(self, version: u16) -> Result<Vec<u8>> {
-		let Self::V5(data) = self;
+		let Self::V6(data) = self;
 		let data_v4 = || convert_same_bytes_ref::<_, v4::ActorCommandKeyData>(&data);
 		match version {
 			1 => {
@@ -483,18 +503,292 @@ impl OwnedVersionedData for ActorCommandKeyData {
 				.map_err(Into::into)
 			}
 			4 => serde_bare::to_vec(&data_v4()?).map_err(Into::into),
-			5 => serde_bare::to_vec(&data).map_err(Into::into),
+			5 => serde_bare::to_vec(&convert_same_bytes_ref::<_, v5::ActorCommandKeyData>(&data)?)
+				.map_err(Into::into),
+			6 => serde_bare::to_vec(&data).map_err(Into::into),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Ok]
+		vec![Ok, Ok, Ok, Ok, Ok]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		vec![Ok, Ok, Ok, Ok]
+		vec![Ok, Ok, Ok, Ok, Ok]
 	}
+}
+
+fn convert_to_envoy_v5_to_v6(message: v5::ToEnvoy) -> Result<v6::ToEnvoy> {
+	Ok(match message {
+		v5::ToEnvoy::ToEnvoyInit(data) => v6::ToEnvoy::ToEnvoyInit(convert_same_bytes(data)?),
+		v5::ToEnvoy::ToEnvoyCommands(data) => {
+			v6::ToEnvoy::ToEnvoyCommands(convert_same_bytes(data)?)
+		}
+		v5::ToEnvoy::ToEnvoyAckEvents(data) => {
+			v6::ToEnvoy::ToEnvoyAckEvents(convert_same_bytes(data)?)
+		}
+		v5::ToEnvoy::ToEnvoyKvResponse(data) => {
+			v6::ToEnvoy::ToEnvoyKvResponse(convert_same_bytes(data)?)
+		}
+		v5::ToEnvoy::ToEnvoyTunnelMessage(data) => {
+			v6::ToEnvoy::ToEnvoyTunnelMessage(convert_same_bytes(data)?)
+		}
+		v5::ToEnvoy::ToEnvoyPing(data) => v6::ToEnvoy::ToEnvoyPing(convert_same_bytes(data)?),
+		v5::ToEnvoy::ToEnvoySqliteGetPagesResponse(data) => {
+			v6::ToEnvoy::ToEnvoySqliteGetPagesResponse(v6::ToEnvoySqliteGetPagesResponse {
+				request_id: data.request_id,
+				data: convert_sqlite_get_pages_response_v5_to_v6(data.data)?,
+			})
+		}
+		v5::ToEnvoy::ToEnvoySqliteCommitResponse(data) => {
+			v6::ToEnvoy::ToEnvoySqliteCommitResponse(v6::ToEnvoySqliteCommitResponse {
+				request_id: data.request_id,
+				data: convert_sqlite_commit_response_v5_to_v6(data.data)?,
+			})
+		}
+		v5::ToEnvoy::ToEnvoySqliteExecResponse(data) => {
+			v6::ToEnvoy::ToEnvoySqliteExecResponse(v6::ToEnvoySqliteExecResponse {
+				request_id: data.request_id,
+				data: convert_sqlite_exec_response_v5_to_v6(data.data)?,
+			})
+		}
+		v5::ToEnvoy::ToEnvoySqliteExecuteResponse(data) => {
+			v6::ToEnvoy::ToEnvoySqliteExecuteResponse(v6::ToEnvoySqliteExecuteResponse {
+				request_id: data.request_id,
+				data: convert_sqlite_execute_response_v5_to_v6(data.data)?,
+			})
+		}
+	})
+}
+
+fn convert_to_envoy_v6_to_v5(message: v6::ToEnvoy, target_version: u16) -> Result<v5::ToEnvoy> {
+	Ok(match message {
+		v6::ToEnvoy::ToEnvoyInit(data) => v5::ToEnvoy::ToEnvoyInit(convert_same_bytes(data)?),
+		v6::ToEnvoy::ToEnvoyCommands(data) => {
+			v5::ToEnvoy::ToEnvoyCommands(convert_same_bytes(data)?)
+		}
+		v6::ToEnvoy::ToEnvoyAckEvents(data) => {
+			v5::ToEnvoy::ToEnvoyAckEvents(convert_same_bytes(data)?)
+		}
+		v6::ToEnvoy::ToEnvoyKvResponse(data) => {
+			v5::ToEnvoy::ToEnvoyKvResponse(convert_same_bytes(data)?)
+		}
+		v6::ToEnvoy::ToEnvoyTunnelMessage(data) => {
+			v5::ToEnvoy::ToEnvoyTunnelMessage(convert_same_bytes(data)?)
+		}
+		v6::ToEnvoy::ToEnvoyPing(data) => v5::ToEnvoy::ToEnvoyPing(convert_same_bytes(data)?),
+		v6::ToEnvoy::ToEnvoySqliteGetPagesResponse(data) => {
+			v5::ToEnvoy::ToEnvoySqliteGetPagesResponse(v5::ToEnvoySqliteGetPagesResponse {
+				request_id: data.request_id,
+				data: convert_sqlite_get_pages_response_v6_to_v5(data.data)?,
+			})
+		}
+		v6::ToEnvoy::ToEnvoySqliteCommitResponse(data) => {
+			v5::ToEnvoy::ToEnvoySqliteCommitResponse(v5::ToEnvoySqliteCommitResponse {
+				request_id: data.request_id,
+				data: convert_sqlite_commit_response_v6_to_v5(data.data)?,
+			})
+		}
+		v6::ToEnvoy::ToEnvoySqliteExecResponse(data) => {
+			v5::ToEnvoy::ToEnvoySqliteExecResponse(v5::ToEnvoySqliteExecResponse {
+				request_id: data.request_id,
+				data: convert_sqlite_exec_response_v6_to_v5(data.data)?,
+			})
+		}
+		v6::ToEnvoy::ToEnvoySqliteExecuteResponse(data) => {
+			v5::ToEnvoy::ToEnvoySqliteExecuteResponse(v5::ToEnvoySqliteExecuteResponse {
+				request_id: data.request_id,
+				data: convert_sqlite_execute_response_v6_to_v5(data.data)?,
+			})
+		}
+		v6::ToEnvoy::ToEnvoySqliteCommitStageBeginResponse(_)
+		| v6::ToEnvoy::ToEnvoySqliteCommitStagePagesResponse(_)
+		| v6::ToEnvoy::ToEnvoySqliteCommitStageCompleteResponse(_)
+		| v6::ToEnvoy::ToEnvoySqliteCommitStageFinalizeResponse(_)
+		| v6::ToEnvoy::ToEnvoySqliteCommitStageAbortResponse(_) => {
+			return Err(incompatible(
+				ProtocolCompatibilityFeature::SqliteCommitStaging,
+				ProtocolCompatibilityDirection::ToEnvoy,
+				6,
+				target_version,
+			));
+		}
+	})
+}
+
+fn convert_sqlite_error_response_v5_to_v6(
+	error: v5::SqliteErrorResponse,
+) -> v6::SqliteErrorResponse {
+	v6::SqliteErrorResponse {
+		group: error.group,
+		code: error.code,
+		message: error.message,
+		metadata: None,
+	}
+}
+
+fn convert_sqlite_error_response_v6_to_v5(
+	error: v6::SqliteErrorResponse,
+) -> v5::SqliteErrorResponse {
+	v5::SqliteErrorResponse {
+		group: error.group,
+		code: error.code,
+		message: error.message,
+	}
+}
+
+fn convert_sqlite_get_pages_response_v5_to_v6(
+	message: v5::SqliteGetPagesResponse,
+) -> Result<v6::SqliteGetPagesResponse> {
+	Ok(match message {
+		v5::SqliteGetPagesResponse::SqliteGetPagesOk(ok) => {
+			v6::SqliteGetPagesResponse::SqliteGetPagesOk(convert_same_bytes(ok)?)
+		}
+		v5::SqliteGetPagesResponse::SqliteErrorResponse(error) => {
+			v6::SqliteGetPagesResponse::SqliteErrorResponse(convert_sqlite_error_response_v5_to_v6(
+				error,
+			))
+		}
+	})
+}
+
+fn convert_sqlite_get_pages_response_v6_to_v5(
+	message: v6::SqliteGetPagesResponse,
+) -> Result<v5::SqliteGetPagesResponse> {
+	Ok(match message {
+		v6::SqliteGetPagesResponse::SqliteGetPagesOk(ok) => {
+			v5::SqliteGetPagesResponse::SqliteGetPagesOk(convert_same_bytes(ok)?)
+		}
+		v6::SqliteGetPagesResponse::SqliteErrorResponse(error) => {
+			v5::SqliteGetPagesResponse::SqliteErrorResponse(convert_sqlite_error_response_v6_to_v5(
+				error,
+			))
+		}
+	})
+}
+
+fn convert_sqlite_commit_response_v5_to_v6(
+	message: v5::SqliteCommitResponse,
+) -> Result<v6::SqliteCommitResponse> {
+	Ok(match message {
+		v5::SqliteCommitResponse::SqliteCommitOk(ok) => {
+			v6::SqliteCommitResponse::SqliteCommitOk(convert_same_bytes(ok)?)
+		}
+		v5::SqliteCommitResponse::SqliteErrorResponse(error) => {
+			v6::SqliteCommitResponse::SqliteErrorResponse(convert_sqlite_error_response_v5_to_v6(
+				error,
+			))
+		}
+	})
+}
+
+fn convert_sqlite_commit_response_v6_to_v5(
+	message: v6::SqliteCommitResponse,
+) -> Result<v5::SqliteCommitResponse> {
+	Ok(match message {
+		v6::SqliteCommitResponse::SqliteCommitOk(ok) => {
+			v5::SqliteCommitResponse::SqliteCommitOk(convert_same_bytes(ok)?)
+		}
+		v6::SqliteCommitResponse::SqliteErrorResponse(error) => {
+			v5::SqliteCommitResponse::SqliteErrorResponse(convert_sqlite_error_response_v6_to_v5(
+				error,
+			))
+		}
+	})
+}
+
+fn convert_sqlite_exec_response_v5_to_v6(
+	message: v5::SqliteExecResponse,
+) -> Result<v6::SqliteExecResponse> {
+	Ok(match message {
+		v5::SqliteExecResponse::SqliteExecOk(ok) => {
+			v6::SqliteExecResponse::SqliteExecOk(convert_same_bytes(ok)?)
+		}
+		v5::SqliteExecResponse::SqliteErrorResponse(error) => {
+			v6::SqliteExecResponse::SqliteErrorResponse(convert_sqlite_error_response_v5_to_v6(
+				error,
+			))
+		}
+	})
+}
+
+fn convert_sqlite_exec_response_v6_to_v5(
+	message: v6::SqliteExecResponse,
+) -> Result<v5::SqliteExecResponse> {
+	Ok(match message {
+		v6::SqliteExecResponse::SqliteExecOk(ok) => {
+			v5::SqliteExecResponse::SqliteExecOk(convert_same_bytes(ok)?)
+		}
+		v6::SqliteExecResponse::SqliteErrorResponse(error) => {
+			v5::SqliteExecResponse::SqliteErrorResponse(convert_sqlite_error_response_v6_to_v5(
+				error,
+			))
+		}
+	})
+}
+
+fn convert_sqlite_execute_response_v5_to_v6(
+	message: v5::SqliteExecuteResponse,
+) -> Result<v6::SqliteExecuteResponse> {
+	Ok(match message {
+		v5::SqliteExecuteResponse::SqliteExecuteOk(ok) => {
+			v6::SqliteExecuteResponse::SqliteExecuteOk(convert_same_bytes(ok)?)
+		}
+		v5::SqliteExecuteResponse::SqliteErrorResponse(error) => {
+			v6::SqliteExecuteResponse::SqliteErrorResponse(convert_sqlite_error_response_v5_to_v6(
+				error,
+			))
+		}
+	})
+}
+
+fn convert_sqlite_execute_response_v6_to_v5(
+	message: v6::SqliteExecuteResponse,
+) -> Result<v5::SqliteExecuteResponse> {
+	Ok(match message {
+		v6::SqliteExecuteResponse::SqliteExecuteOk(ok) => {
+			v5::SqliteExecuteResponse::SqliteExecuteOk(convert_same_bytes(ok)?)
+		}
+		v6::SqliteExecuteResponse::SqliteErrorResponse(error) => {
+			v5::SqliteExecuteResponse::SqliteErrorResponse(convert_sqlite_error_response_v6_to_v5(
+				error,
+			))
+		}
+	})
+}
+
+fn convert_to_rivet_v5_to_v6(message: v5::ToRivet) -> Result<v6::ToRivet> {
+	convert_same_bytes(message)
+}
+
+fn convert_to_rivet_v6_to_v5(message: v6::ToRivet, target_version: u16) -> Result<v5::ToRivet> {
+	match &message {
+		v6::ToRivet::ToRivetSqliteCommitStageBeginRequest(_)
+		| v6::ToRivet::ToRivetSqliteCommitStagePagesRequest(_)
+		| v6::ToRivet::ToRivetSqliteCommitStageCompleteRequest(_)
+		| v6::ToRivet::ToRivetSqliteCommitStageFinalizeRequest(_)
+		| v6::ToRivet::ToRivetSqliteCommitStageAbortRequest(_) => {
+			return Err(incompatible(
+				ProtocolCompatibilityFeature::SqliteCommitStaging,
+				ProtocolCompatibilityDirection::ToRivet,
+				6,
+				target_version,
+			));
+		}
+		v6::ToRivet::ToRivetMetadata(_)
+		| v6::ToRivet::ToRivetEvents(_)
+		| v6::ToRivet::ToRivetAckCommands(_)
+		| v6::ToRivet::ToRivetStopping
+		| v6::ToRivet::ToRivetPong(_)
+		| v6::ToRivet::ToRivetKvRequest(_)
+		| v6::ToRivet::ToRivetTunnelMessage(_)
+		| v6::ToRivet::ToRivetSqliteGetPagesRequest(_)
+		| v6::ToRivet::ToRivetSqliteCommitRequest(_)
+		| v6::ToRivet::ToRivetSqliteExecRequest(_)
+		| v6::ToRivet::ToRivetSqliteExecuteRequest(_) => {}
+	}
+	convert_same_bytes(message)
 }
 
 fn convert_to_envoy_v4_to_v5(message: v4::ToEnvoy) -> Result<v5::ToEnvoy> {
@@ -1761,12 +2055,12 @@ mod tests {
 	use super::{ActorCommandKeyData, ToEnvoy};
 	use crate::{
 		PROTOCOL_VERSION,
-		generated::{v1, v2, v5},
+		generated::{v1, v2, v6},
 	};
 
 	#[test]
 	fn protocol_version_constant_matches_schema_version() {
-		assert_eq!(PROTOCOL_VERSION, 5);
+		assert_eq!(PROTOCOL_VERSION, 6);
 	}
 
 	#[test]
@@ -1791,10 +2085,10 @@ mod tests {
 			}]))?;
 
 		let decoded = ToEnvoy::deserialize_version(&payload, 1)?.unwrap_latest()?;
-		let v5::ToEnvoy::ToEnvoyCommands(commands) = decoded else {
+		let v6::ToEnvoy::ToEnvoyCommands(commands) = decoded else {
 			panic!("expected commands");
 		};
-		let v5::Command::CommandStartActor(start) = &commands[0].inner else {
+		let v6::Command::CommandStartActor(start) = &commands[0].inner else {
 			panic!("expected start actor");
 		};
 
@@ -1821,9 +2115,9 @@ mod tests {
 
 	#[test]
 	fn actor_command_key_data_round_trips_to_v1() -> Result<()> {
-		let encoded = ActorCommandKeyData::wrap_latest(v5::ActorCommandKeyData::CommandStartActor(
-			v5::CommandStartActor {
-				config: v5::ActorConfig {
+		let encoded = ActorCommandKeyData::wrap_latest(v6::ActorCommandKeyData::CommandStartActor(
+			v6::CommandStartActor {
+				config: v6::ActorConfig {
 					name: "demo".into(),
 					key: None,
 					create_ts: 7,
@@ -1836,7 +2130,7 @@ mod tests {
 		.serialize_version(1)?;
 
 		let decoded = ActorCommandKeyData::deserialize_version(&encoded, 1)?.unwrap_latest()?;
-		let v5::ActorCommandKeyData::CommandStartActor(start) = decoded else {
+		let v6::ActorCommandKeyData::CommandStartActor(start) = decoded else {
 			panic!("expected start actor");
 		};
 		assert_eq!(start.config.name, "demo");

--- a/engine/sdks/rust/envoy-protocol/tests/remote_sql_compat.rs
+++ b/engine/sdks/rust/envoy-protocol/tests/remote_sql_compat.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use rivet_envoy_protocol::{
-	generated::{v4, v5},
+	generated::{v4, v6},
 	versioned::{
 		ProtocolCompatibilityDirection, ProtocolCompatibilityError, ProtocolCompatibilityFeature,
 		ToEnvoy, ToRivet,
@@ -8,10 +8,10 @@ use rivet_envoy_protocol::{
 };
 use vbare::OwnedVersionedData;
 
-fn remote_sql_request_exec() -> v5::ToRivet {
-	v5::ToRivet::ToRivetSqliteExecRequest(v5::ToRivetSqliteExecRequest {
+fn remote_sql_request_exec() -> v6::ToRivet {
+	v6::ToRivet::ToRivetSqliteExecRequest(v6::ToRivetSqliteExecRequest {
 		request_id: 1,
-		data: v5::SqliteExecRequest {
+		data: v6::SqliteExecRequest {
 			namespace_id: "namespace".into(),
 			actor_id: "actor".into(),
 			generation: 7,
@@ -20,39 +20,41 @@ fn remote_sql_request_exec() -> v5::ToRivet {
 	})
 }
 
-fn remote_sql_request_execute() -> v5::ToRivet {
-	v5::ToRivet::ToRivetSqliteExecuteRequest(v5::ToRivetSqliteExecuteRequest {
+fn remote_sql_request_execute() -> v6::ToRivet {
+	v6::ToRivet::ToRivetSqliteExecuteRequest(v6::ToRivetSqliteExecuteRequest {
 		request_id: 2,
-		data: v5::SqliteExecuteRequest {
+		data: v6::SqliteExecuteRequest {
 			namespace_id: "namespace".into(),
 			actor_id: "actor".into(),
 			generation: 7,
 			sql: "select ?".into(),
-			params: Some(vec![v5::SqliteBindParam::SqliteValueInteger(
-				v5::SqliteValueInteger { value: 1 },
+			params: Some(vec![v6::SqliteBindParam::SqliteValueInteger(
+				v6::SqliteValueInteger { value: 1 },
 			)]),
 		},
 	})
 }
 
-fn remote_sql_response_exec() -> v5::ToEnvoy {
-	v5::ToEnvoy::ToEnvoySqliteExecResponse(v5::ToEnvoySqliteExecResponse {
+fn remote_sql_response_exec() -> v6::ToEnvoy {
+	v6::ToEnvoy::ToEnvoySqliteExecResponse(v6::ToEnvoySqliteExecResponse {
 		request_id: 1,
-		data: v5::SqliteExecResponse::SqliteErrorResponse(v5::SqliteErrorResponse {
+		data: v6::SqliteExecResponse::SqliteErrorResponse(v6::SqliteErrorResponse {
 			group: "sqlite".into(),
 			code: "remote_unavailable".into(),
 			message: "remote sql execution is unavailable".into(),
+			metadata: None,
 		}),
 	})
 }
 
-fn remote_sql_response_execute() -> v5::ToEnvoy {
-	v5::ToEnvoy::ToEnvoySqliteExecuteResponse(v5::ToEnvoySqliteExecuteResponse {
+fn remote_sql_response_execute() -> v6::ToEnvoy {
+	v6::ToEnvoy::ToEnvoySqliteExecuteResponse(v6::ToEnvoySqliteExecuteResponse {
 		request_id: 2,
-		data: v5::SqliteExecuteResponse::SqliteErrorResponse(v5::SqliteErrorResponse {
+		data: v6::SqliteExecuteResponse::SqliteErrorResponse(v6::SqliteErrorResponse {
 			group: "sqlite".into(),
 			code: "remote_unavailable".into(),
 			message: "remote sql execution is unavailable".into(),
+			metadata: None,
 		}),
 	})
 }
@@ -75,6 +77,54 @@ fn assert_compatibility_error(
 	assert_eq!(err.target_version, target_version);
 }
 
+fn staged_commit_request_begin() -> v6::ToRivet {
+	v6::ToRivet::ToRivetSqliteCommitStageBeginRequest(
+		v6::ToRivetSqliteCommitStageBeginRequest {
+			request_id: 3,
+			data: v6::SqliteCommitStageBeginRequest {
+				actor_id: "actor".into(),
+				db_size_pages: 64,
+				now_ms: 1_000,
+				expected_generation: Some(7),
+				expected_head_txid: Some(1),
+				dirty_pgnos: vec![1, 2, 3],
+			},
+		},
+	)
+}
+
+fn staged_commit_response_finalize() -> v6::ToEnvoy {
+	v6::ToEnvoy::ToEnvoySqliteCommitStageFinalizeResponse(
+		v6::ToEnvoySqliteCommitStageFinalizeResponse {
+			request_id: 3,
+			data: v6::SqliteCommitResponse::SqliteErrorResponse(v6::SqliteErrorResponse {
+				group: "depot".into(),
+				code: "sqlite_commit_page_limit_exceeded".into(),
+				message: "SQLite transaction touched too many pages.".into(),
+				metadata: Some(r#"{"max_dirty_pages":8192}"#.into()),
+			}),
+		},
+	)
+}
+
+fn assert_stage_compatibility_error(
+	err: anyhow::Error,
+	direction: ProtocolCompatibilityDirection,
+	target_version: u16,
+) {
+	let err = err
+		.downcast_ref::<ProtocolCompatibilityError>()
+		.expect("expected structured protocol compatibility error");
+
+	assert_eq!(
+		err.feature,
+		ProtocolCompatibilityFeature::SqliteCommitStaging
+	);
+	assert_eq!(err.direction, direction);
+	assert_eq!(err.required_version, 6);
+	assert_eq!(err.target_version, target_version);
+}
+
 #[test]
 fn old_core_new_pegboard_envoy_rejects_remote_sql_request() {
 	let err = ToRivet::wrap_latest(remote_sql_request_exec())
@@ -82,6 +132,35 @@ fn old_core_new_pegboard_envoy_rejects_remote_sql_request() {
 		.expect_err("remote SQL requests must not serialize below v4");
 
 	assert_compatibility_error(err, ProtocolCompatibilityDirection::ToRivet, 3);
+}
+
+#[test]
+fn staged_commit_messages_require_v6() {
+	let request_err = ToRivet::wrap_latest(staged_commit_request_begin())
+		.serialize(5)
+		.expect_err("staged commit requests must not serialize below v6");
+	let response_err = ToEnvoy::wrap_latest(staged_commit_response_finalize())
+		.serialize(5)
+		.expect_err("staged commit responses must not serialize below v6");
+
+	assert_stage_compatibility_error(request_err, ProtocolCompatibilityDirection::ToRivet, 5);
+	assert_stage_compatibility_error(response_err, ProtocolCompatibilityDirection::ToEnvoy, 5);
+}
+
+#[test]
+fn staged_commit_error_metadata_roundtrips_in_v6() -> Result<()> {
+	let response = ToEnvoy::wrap_latest(staged_commit_response_finalize()).serialize(6)?;
+	let v6::ToEnvoy::ToEnvoySqliteCommitStageFinalizeResponse(decoded) =
+		ToEnvoy::deserialize(&response, 6)?
+	else {
+		panic!("expected staged finalize response");
+	};
+	let v6::SqliteCommitResponse::SqliteErrorResponse(error) = decoded.data else {
+		panic!("expected staged finalize error response");
+	};
+	assert_eq!(error.metadata, Some(r#"{"max_dirty_pages":8192}"#.into()));
+
+	Ok(())
 }
 
 #[test]
@@ -113,11 +192,11 @@ fn new_core_new_pegboard_envoy_allows_remote_sql_both_directions() -> Result<()>
 
 	assert!(matches!(
 		ToRivet::deserialize(&request, 4)?,
-		v5::ToRivet::ToRivetSqliteExecRequest(_)
+		v6::ToRivet::ToRivetSqliteExecRequest(_)
 	));
 	assert!(matches!(
 		ToEnvoy::deserialize(&response, 4)?,
-		v5::ToEnvoy::ToEnvoySqliteExecResponse(_)
+		v6::ToEnvoy::ToEnvoySqliteExecResponse(_)
 	));
 
 	Ok(())

--- a/engine/sdks/rust/envoy-protocol/tests/stateless_sqlite_v3.rs
+++ b/engine/sdks/rust/envoy-protocol/tests/stateless_sqlite_v3.rs
@@ -108,6 +108,7 @@ fn commit_response_ok_and_err_roundtrip() -> anyhow::Result<()> {
 					group: "depot".into(),
 					code: "quota_exceeded".into(),
 					message: "quota exceeded".into(),
+					metadata: None,
 				},
 			),
 		},
@@ -168,7 +169,7 @@ fn expected_generation_optional_present_and_absent() -> anyhow::Result<()> {
 
 #[test]
 fn protocol_version_constant_matches_schema_version() {
-	assert_eq!(PROTOCOL_VERSION, 5);
+	assert_eq!(PROTOCOL_VERSION, 6);
 }
 
 #[test]

--- a/engine/sdks/schemas/envoy-protocol/v6.bare
+++ b/engine/sdks/schemas/envoy-protocol/v6.bare
@@ -1,0 +1,774 @@
+# MARK: Core Primitives
+
+type Id str
+type Json str
+
+type GatewayId data[4]
+type RequestId data[4]
+type MessageIndex u16
+
+# MARK: KV
+
+# Basic types
+type KvKey data
+type KvValue data
+type KvMetadata struct {
+	version: data
+	updateTs: i64
+}
+
+# Query types
+type KvListAllQuery void
+type KvListRangeQuery struct {
+	start: KvKey
+	end: KvKey
+	exclusive: bool
+}
+
+type KvListPrefixQuery struct {
+	key: KvKey
+}
+
+type KvListQuery union {
+	KvListAllQuery |
+	KvListRangeQuery |
+	KvListPrefixQuery
+}
+
+# Request types
+type KvGetRequest struct {
+	keys: list<KvKey>
+}
+
+type KvListRequest struct {
+	query: KvListQuery
+	reverse: optional<bool>
+	limit: optional<u64>
+}
+
+type KvPutRequest struct {
+	keys: list<KvKey>
+	values: list<KvValue>
+}
+
+type KvDeleteRequest struct {
+	keys: list<KvKey>
+}
+
+type KvDeleteRangeRequest struct {
+	start: KvKey
+	end: KvKey
+}
+
+type KvDropRequest void
+
+# Response types
+type KvErrorResponse struct {
+	message: str
+}
+
+type KvGetResponse struct {
+	keys: list<KvKey>
+	values: list<KvValue>
+	metadata: list<KvMetadata>
+}
+
+type KvListResponse struct {
+	keys: list<KvKey>
+	values: list<KvValue>
+	metadata: list<KvMetadata>
+}
+
+type KvPutResponse void
+type KvDeleteResponse void
+type KvDropResponse void
+
+# Request/Response unions
+type KvRequestData union {
+	KvGetRequest |
+	KvListRequest |
+	KvPutRequest |
+	KvDeleteRequest |
+	KvDeleteRangeRequest |
+	KvDropRequest
+}
+
+type KvResponseData union {
+	KvErrorResponse |
+	KvGetResponse |
+	KvListResponse |
+	KvPutResponse |
+	KvDeleteResponse |
+	KvDropResponse
+}
+
+# MARK: SQLite
+
+type SqlitePgno u32
+type SqliteGeneration u64
+type SqlitePageBytes data
+type SqliteStageId data[16]
+
+type SqliteDirtyPage struct {
+	pgno: SqlitePgno
+	bytes: SqlitePageBytes
+}
+
+type SqliteFetchedPage struct {
+	pgno: SqlitePgno
+	bytes: optional<SqlitePageBytes>
+}
+
+type SqliteGetPagesRequest struct {
+	actorId: Id
+	pgnos: list<SqlitePgno>
+	expectedGeneration: optional<u64>
+	expectedHeadTxid: optional<u64>
+}
+
+type SqliteGetPagesOk struct {
+	pages: list<SqliteFetchedPage>
+	headTxid: optional<u64>
+}
+
+type SqliteErrorResponse struct {
+	group: str
+	code: str
+	message: str
+	metadata: optional<Json>
+}
+
+type SqliteGetPagesResponse union {
+	SqliteGetPagesOk |
+	SqliteErrorResponse
+}
+
+type SqliteCommitRequest struct {
+	actorId: Id
+	dirtyPages: list<SqliteDirtyPage>
+	dbSizePages: u32
+	nowMs: i64
+	expectedGeneration: optional<u64>
+	expectedHeadTxid: optional<u64>
+}
+
+type SqliteCommitOk struct {
+	headTxid: optional<u64>
+}
+
+type SqliteCommitResponse union {
+	SqliteCommitOk |
+	SqliteErrorResponse
+}
+
+type SqliteCommitStageBeginRequest struct {
+	actorId: Id
+	dbSizePages: u32
+	nowMs: i64
+	expectedGeneration: optional<u64>
+	expectedHeadTxid: optional<u64>
+	dirtyPgnos: list<SqlitePgno>
+}
+
+type SqliteCommitStageBeginOk struct {
+	stageId: SqliteStageId
+	maxPagesPerBatch: u32
+	maxBatchBytes: u32
+	observedHeadTxid: u64
+	stagedTxid: u64
+}
+
+type SqliteCommitStageBeginResponse union {
+	SqliteCommitStageBeginOk |
+	SqliteErrorResponse
+}
+
+type SqliteCommitStagePagesRequest struct {
+	actorId: Id
+	stageId: SqliteStageId
+	batchIdx: u32
+	dirtyPages: list<SqliteDirtyPage>
+	expectedGeneration: optional<u64>
+}
+
+type SqliteCommitStagePagesOk void
+
+type SqliteCommitStagePagesResponse union {
+	SqliteCommitStagePagesOk |
+	SqliteErrorResponse
+}
+
+type SqliteCommitStageCompleteRequest struct {
+	actorId: Id
+	stageId: SqliteStageId
+	pageBatchCount: u32
+	expectedGeneration: optional<u64>
+}
+
+type SqliteCommitStageCompleteOk void
+
+type SqliteCommitStageCompleteResponse union {
+	SqliteCommitStageCompleteOk |
+	SqliteErrorResponse
+}
+
+type SqliteCommitStageFinalizeRequest struct {
+	actorId: Id
+	stageId: SqliteStageId
+	expectedGeneration: optional<u64>
+}
+
+type SqliteCommitStageAbortRequest struct {
+	actorId: Id
+	stageId: SqliteStageId
+	expectedGeneration: optional<u64>
+}
+
+type SqliteCommitStageAbortOk void
+
+type SqliteCommitStageAbortResponse union {
+	SqliteCommitStageAbortOk |
+	SqliteErrorResponse
+}
+
+# MARK: SQLite Remote Execution
+
+type SqliteValueNull void
+
+type SqliteValueInteger struct {
+	value: i64
+}
+
+type SqliteValueFloat struct {
+	value: data[8]
+}
+
+type SqliteValueText struct {
+	value: str
+}
+
+type SqliteValueBlob struct {
+	value: data
+}
+
+type SqliteBindParam union {
+	SqliteValueNull |
+	SqliteValueInteger |
+	SqliteValueFloat |
+	SqliteValueText |
+	SqliteValueBlob
+}
+
+type SqliteColumnValue union {
+	SqliteValueNull |
+	SqliteValueInteger |
+	SqliteValueFloat |
+	SqliteValueText |
+	SqliteValueBlob
+}
+
+type SqliteQueryResult struct {
+	columns: list<str>
+	rows: list<list<SqliteColumnValue>>
+}
+
+type SqliteExecuteResult struct {
+	columns: list<str>
+	rows: list<list<SqliteColumnValue>>
+	changes: i64
+	lastInsertRowId: optional<i64>
+}
+
+type SqliteExecRequest struct {
+	namespaceId: Id
+	actorId: Id
+	generation: SqliteGeneration
+	sql: str
+}
+
+type SqliteExecuteRequest struct {
+	namespaceId: Id
+	actorId: Id
+	generation: SqliteGeneration
+	sql: str
+	params: optional<list<SqliteBindParam>>
+}
+
+type SqliteExecOk struct {
+	result: SqliteQueryResult
+}
+
+type SqliteExecuteOk struct {
+	result: SqliteExecuteResult
+}
+
+type SqliteExecResponse union {
+	SqliteExecOk |
+	SqliteErrorResponse
+}
+
+type SqliteExecuteResponse union {
+	SqliteExecuteOk |
+	SqliteErrorResponse
+}
+
+# MARK: Actor
+
+# Core
+type StopCode enum {
+	OK
+	ERROR
+}
+
+type ActorName struct {
+	metadata: Json
+}
+
+type ActorConfig struct {
+	name: str
+	key: optional<str>
+	createTs: i64
+	input: optional<data>
+}
+
+type ActorCheckpoint struct {
+	actorId: Id
+	generation: u32
+	index: i64
+}
+
+# Intent
+type ActorIntentSleep void
+
+type ActorIntentStop void
+
+type ActorIntent union {
+	ActorIntentSleep |
+	ActorIntentStop
+}
+
+# State
+type ActorStateRunning void
+
+type ActorStateStopped struct {
+	code: StopCode
+	message: optional<str>
+}
+
+type ActorState union {
+	ActorStateRunning |
+	ActorStateStopped
+}
+
+# MARK: Events
+type EventActorIntent struct {
+	intent: ActorIntent
+}
+
+type EventActorStateUpdate struct {
+	state: ActorState
+}
+
+type EventActorSetAlarm struct {
+	alarmTs: optional<i64>
+}
+
+type Event union {
+	EventActorIntent |
+	EventActorStateUpdate |
+	EventActorSetAlarm
+}
+
+type EventWrapper struct {
+	checkpoint: ActorCheckpoint
+	inner: Event
+}
+
+# MARK: Preloaded KV
+
+type PreloadedKvEntry struct {
+	key: KvKey
+	value: KvValue
+	metadata: KvMetadata
+}
+
+type PreloadedKv struct {
+	entries: list<PreloadedKvEntry>
+	requestedGetKeys: list<KvKey>
+	requestedPrefixes: list<KvKey>
+}
+
+# MARK: Commands
+
+type HibernatingRequest struct {
+	gatewayId: GatewayId
+	requestId: RequestId
+}
+
+type CommandStartActor struct {
+	config: ActorConfig
+	hibernatingRequests: list<HibernatingRequest>
+	preloadedKv: optional<PreloadedKv>
+}
+
+type StopActorReason enum {
+	SLEEP_INTENT
+	STOP_INTENT
+	DESTROY
+	GOING_AWAY
+	LOST
+}
+
+type CommandStopActor struct {
+	reason: StopActorReason
+}
+
+type Command union {
+	CommandStartActor |
+	CommandStopActor
+}
+
+type CommandWrapper struct {
+	checkpoint: ActorCheckpoint
+	inner: Command
+}
+
+# We redeclare this so its top level
+type ActorCommandKeyData union {
+	CommandStartActor |
+	CommandStopActor
+}
+
+# MARK: Tunnel
+
+# Message ID
+
+type MessageId struct {
+	# Globally unique ID
+	gatewayId: GatewayId
+	# Unique ID to the gateway
+	requestId: RequestId
+	# Unique ID to the request
+	messageIndex: MessageIndex
+}
+
+# HTTP
+type ToEnvoyRequestStart struct {
+	actorId: Id
+	method: str
+	path: str
+	headers: map<str><str>
+	body: optional<data>
+	stream: bool
+}
+
+type ToEnvoyRequestChunk struct {
+	body: data
+	finish: bool
+}
+
+type ToEnvoyRequestAbort void
+
+type ToRivetResponseStart struct {
+	status: u16
+	headers: map<str><str>
+	body: optional<data>
+	stream: bool
+}
+
+type ToRivetResponseChunk struct {
+	body: data
+	finish: bool
+}
+
+type ToRivetResponseAbort void
+
+# WebSocket
+type ToEnvoyWebSocketOpen struct {
+	actorId: Id
+	path: str
+	headers: map<str><str>
+}
+
+type ToEnvoyWebSocketMessage struct {
+	data: data
+	binary: bool
+}
+
+type ToEnvoyWebSocketClose struct {
+	code: optional<u16>
+	reason: optional<str>
+}
+
+type ToRivetWebSocketOpen struct {
+	canHibernate: bool
+}
+
+type ToRivetWebSocketMessage struct {
+	data: data
+	binary: bool
+}
+
+type ToRivetWebSocketMessageAck struct {
+	index: MessageIndex
+}
+
+type ToRivetWebSocketClose struct {
+	code: optional<u16>
+	reason: optional<str>
+	hibernate: bool
+}
+
+# To Rivet
+type ToRivetTunnelMessageKind union {
+	# HTTP
+	ToRivetResponseStart |
+	ToRivetResponseChunk |
+	ToRivetResponseAbort |
+
+	# WebSocket
+	ToRivetWebSocketOpen |
+	ToRivetWebSocketMessage |
+	ToRivetWebSocketMessageAck |
+	ToRivetWebSocketClose
+}
+
+type ToRivetTunnelMessage struct {
+	messageId: MessageId
+	messageKind: ToRivetTunnelMessageKind
+}
+
+# To Envoy
+type ToEnvoyTunnelMessageKind union {
+	# HTTP
+	ToEnvoyRequestStart |
+	ToEnvoyRequestChunk |
+	ToEnvoyRequestAbort |
+
+	# WebSocket
+	ToEnvoyWebSocketOpen |
+	ToEnvoyWebSocketMessage |
+	ToEnvoyWebSocketClose
+}
+
+type ToEnvoyTunnelMessage struct {
+	messageId: MessageId
+	messageKind: ToEnvoyTunnelMessageKind
+}
+
+type ToEnvoyPing struct {
+	ts: i64
+}
+
+# MARK: To Rivet
+type ToRivetMetadata struct {
+	prepopulateActorNames: optional<map<str><ActorName>>
+	metadata: optional<Json>
+}
+
+type ToRivetEvents list<EventWrapper>
+
+type ToRivetAckCommands struct {
+	lastCommandCheckpoints: list<ActorCheckpoint>
+}
+
+type ToRivetStopping void
+
+type ToRivetPong struct {
+	ts: i64
+}
+
+type ToRivetKvRequest struct {
+	actorId: Id
+	requestId: u32
+	data: KvRequestData
+}
+
+type ToRivetSqliteGetPagesRequest struct {
+	requestId: u32
+	data: SqliteGetPagesRequest
+}
+
+type ToRivetSqliteCommitRequest struct {
+	requestId: u32
+	data: SqliteCommitRequest
+}
+
+type ToRivetSqliteCommitStageBeginRequest struct {
+	requestId: u32
+	data: SqliteCommitStageBeginRequest
+}
+
+type ToRivetSqliteCommitStagePagesRequest struct {
+	requestId: u32
+	data: SqliteCommitStagePagesRequest
+}
+
+type ToRivetSqliteCommitStageCompleteRequest struct {
+	requestId: u32
+	data: SqliteCommitStageCompleteRequest
+}
+
+type ToRivetSqliteCommitStageFinalizeRequest struct {
+	requestId: u32
+	data: SqliteCommitStageFinalizeRequest
+}
+
+type ToRivetSqliteCommitStageAbortRequest struct {
+	requestId: u32
+	data: SqliteCommitStageAbortRequest
+}
+
+type ToRivetSqliteExecRequest struct {
+	requestId: u32
+	data: SqliteExecRequest
+}
+
+type ToRivetSqliteExecuteRequest struct {
+	requestId: u32
+	data: SqliteExecuteRequest
+}
+
+type ToRivet union {
+	ToRivetMetadata |
+	ToRivetEvents |
+	ToRivetAckCommands |
+	ToRivetStopping |
+	ToRivetPong |
+	ToRivetKvRequest |
+	ToRivetTunnelMessage |
+	ToRivetSqliteGetPagesRequest |
+	ToRivetSqliteCommitRequest |
+	ToRivetSqliteExecRequest |
+	ToRivetSqliteExecuteRequest |
+	ToRivetSqliteCommitStageBeginRequest |
+	ToRivetSqliteCommitStagePagesRequest |
+	ToRivetSqliteCommitStageCompleteRequest |
+	ToRivetSqliteCommitStageFinalizeRequest |
+	ToRivetSqliteCommitStageAbortRequest
+}
+
+# MARK: To Envoy
+type ProtocolMetadata struct {
+	envoyLostThreshold: i64
+	actorStopThreshold: i64
+	maxResponsePayloadSize: u64
+}
+
+type ToEnvoyInit struct {
+	metadata: ProtocolMetadata
+}
+
+type ToEnvoyCommands list<CommandWrapper>
+
+type ToEnvoyAckEvents struct {
+	lastEventCheckpoints: list<ActorCheckpoint>
+}
+
+type ToEnvoyKvResponse struct {
+	requestId: u32
+	data: KvResponseData
+}
+
+type ToEnvoySqliteGetPagesResponse struct {
+	requestId: u32
+	data: SqliteGetPagesResponse
+}
+
+type ToEnvoySqliteCommitResponse struct {
+	requestId: u32
+	data: SqliteCommitResponse
+}
+
+type ToEnvoySqliteCommitStageBeginResponse struct {
+	requestId: u32
+	data: SqliteCommitStageBeginResponse
+}
+
+type ToEnvoySqliteCommitStagePagesResponse struct {
+	requestId: u32
+	data: SqliteCommitStagePagesResponse
+}
+
+type ToEnvoySqliteCommitStageCompleteResponse struct {
+	requestId: u32
+	data: SqliteCommitStageCompleteResponse
+}
+
+type ToEnvoySqliteCommitStageFinalizeResponse struct {
+	requestId: u32
+	data: SqliteCommitResponse
+}
+
+type ToEnvoySqliteCommitStageAbortResponse struct {
+	requestId: u32
+	data: SqliteCommitStageAbortResponse
+}
+
+type ToEnvoySqliteExecResponse struct {
+	requestId: u32
+	data: SqliteExecResponse
+}
+
+type ToEnvoySqliteExecuteResponse struct {
+	requestId: u32
+	data: SqliteExecuteResponse
+}
+
+type ToEnvoy union {
+	ToEnvoyInit |
+	ToEnvoyCommands |
+	ToEnvoyAckEvents |
+	ToEnvoyKvResponse |
+	ToEnvoyTunnelMessage |
+	ToEnvoyPing |
+	ToEnvoySqliteGetPagesResponse |
+	ToEnvoySqliteCommitResponse |
+	ToEnvoySqliteExecResponse |
+	ToEnvoySqliteExecuteResponse |
+	ToEnvoySqliteCommitStageBeginResponse |
+	ToEnvoySqliteCommitStagePagesResponse |
+	ToEnvoySqliteCommitStageCompleteResponse |
+	ToEnvoySqliteCommitStageFinalizeResponse |
+	ToEnvoySqliteCommitStageAbortResponse
+}
+
+# MARK: To Envoy Conn
+type ToEnvoyConnPing struct {
+	gatewayId: GatewayId
+	requestId: RequestId
+	ts: i64
+}
+
+type ToEnvoyConnClose void
+
+type ToEnvoyConn union {
+	ToEnvoyConnPing |
+	ToEnvoyConnClose |
+	ToEnvoyCommands |
+	ToEnvoyAckEvents |
+	ToEnvoyTunnelMessage
+}
+
+# MARK: To Gateway
+type ToGatewayPong struct {
+	requestId: RequestId
+	ts: i64
+}
+
+type ToGateway union {
+	ToGatewayPong |
+	ToRivetTunnelMessage
+}
+
+# MARK: To Outbound
+type ToOutboundActorStart struct {
+	namespaceId: Id
+	poolName: str
+	checkpoint: ActorCheckpoint
+	actorConfig: ActorConfig
+}
+
+type ToOutbound union {
+	ToOutboundActorStart
+}

--- a/engine/sdks/typescript/envoy-protocol/src/index.ts
+++ b/engine/sdks/typescript/envoy-protocol/src/index.ts
@@ -571,6 +571,17 @@ export function writeSqlitePageBytes(bc: bare.ByteCursor, x: SqlitePageBytes): v
     bare.writeData(bc, x)
 }
 
+export type SqliteStageId = ArrayBuffer
+
+export function readSqliteStageId(bc: bare.ByteCursor): SqliteStageId {
+    return bare.readFixedData(bc, 16)
+}
+
+export function writeSqliteStageId(bc: bare.ByteCursor, x: SqliteStageId): void {
+    assert(x.byteLength === 16)
+    bare.writeFixedData(bc, x)
+}
+
 export type SqliteDirtyPage = {
     readonly pgno: SqlitePgno
     readonly bytes: SqlitePageBytes
@@ -694,10 +705,22 @@ export function writeSqliteGetPagesOk(bc: bare.ByteCursor, x: SqliteGetPagesOk):
     write2(bc, x.headTxid)
 }
 
+function read8(bc: bare.ByteCursor): Json | null {
+    return bare.readBool(bc) ? readJson(bc) : null
+}
+
+function write8(bc: bare.ByteCursor, x: Json | null): void {
+    bare.writeBool(bc, x != null)
+    if (x != null) {
+        writeJson(bc, x)
+    }
+}
+
 export type SqliteErrorResponse = {
     readonly group: string
     readonly code: string
     readonly message: string
+    readonly metadata: Json | null
 }
 
 export function readSqliteErrorResponse(bc: bare.ByteCursor): SqliteErrorResponse {
@@ -705,6 +728,7 @@ export function readSqliteErrorResponse(bc: bare.ByteCursor): SqliteErrorRespons
         group: bare.readString(bc),
         code: bare.readString(bc),
         message: bare.readString(bc),
+        metadata: read8(bc),
     }
 }
 
@@ -712,6 +736,7 @@ export function writeSqliteErrorResponse(bc: bare.ByteCursor, x: SqliteErrorResp
     bare.writeString(bc, x.group)
     bare.writeString(bc, x.code)
     bare.writeString(bc, x.message)
+    write8(bc, x.metadata)
 }
 
 export type SqliteGetPagesResponse =
@@ -748,7 +773,7 @@ export function writeSqliteGetPagesResponse(bc: bare.ByteCursor, x: SqliteGetPag
     }
 }
 
-function read8(bc: bare.ByteCursor): readonly SqliteDirtyPage[] {
+function read9(bc: bare.ByteCursor): readonly SqliteDirtyPage[] {
     const len = bare.readUintSafe(bc)
     if (len === 0) {
         return []
@@ -760,7 +785,7 @@ function read8(bc: bare.ByteCursor): readonly SqliteDirtyPage[] {
     return result
 }
 
-function write8(bc: bare.ByteCursor, x: readonly SqliteDirtyPage[]): void {
+function write9(bc: bare.ByteCursor, x: readonly SqliteDirtyPage[]): void {
     bare.writeUintSafe(bc, x.length)
     for (let i = 0; i < x.length; i++) {
         writeSqliteDirtyPage(bc, x[i])
@@ -779,7 +804,7 @@ export type SqliteCommitRequest = {
 export function readSqliteCommitRequest(bc: bare.ByteCursor): SqliteCommitRequest {
     return {
         actorId: readId(bc),
-        dirtyPages: read8(bc),
+        dirtyPages: read9(bc),
         dbSizePages: bare.readU32(bc),
         nowMs: bare.readI64(bc),
         expectedGeneration: read2(bc),
@@ -789,7 +814,7 @@ export function readSqliteCommitRequest(bc: bare.ByteCursor): SqliteCommitReques
 
 export function writeSqliteCommitRequest(bc: bare.ByteCursor, x: SqliteCommitRequest): void {
     writeId(bc, x.actorId)
-    write8(bc, x.dirtyPages)
+    write9(bc, x.dirtyPages)
     bare.writeU32(bc, x.dbSizePages)
     bare.writeI64(bc, x.nowMs)
     write2(bc, x.expectedGeneration)
@@ -834,6 +859,289 @@ export function writeSqliteCommitResponse(bc: bare.ByteCursor, x: SqliteCommitRe
         case "SqliteCommitOk": {
             bare.writeU8(bc, 0)
             writeSqliteCommitOk(bc, x.val)
+            break
+        }
+        case "SqliteErrorResponse": {
+            bare.writeU8(bc, 1)
+            writeSqliteErrorResponse(bc, x.val)
+            break
+        }
+    }
+}
+
+export type SqliteCommitStageBeginRequest = {
+    readonly actorId: Id
+    readonly dbSizePages: u32
+    readonly nowMs: i64
+    readonly expectedGeneration: u64 | null
+    readonly expectedHeadTxid: u64 | null
+    readonly dirtyPgnos: readonly SqlitePgno[]
+}
+
+export function readSqliteCommitStageBeginRequest(bc: bare.ByteCursor): SqliteCommitStageBeginRequest {
+    return {
+        actorId: readId(bc),
+        dbSizePages: bare.readU32(bc),
+        nowMs: bare.readI64(bc),
+        expectedGeneration: read2(bc),
+        expectedHeadTxid: read2(bc),
+        dirtyPgnos: read6(bc),
+    }
+}
+
+export function writeSqliteCommitStageBeginRequest(bc: bare.ByteCursor, x: SqliteCommitStageBeginRequest): void {
+    writeId(bc, x.actorId)
+    bare.writeU32(bc, x.dbSizePages)
+    bare.writeI64(bc, x.nowMs)
+    write2(bc, x.expectedGeneration)
+    write2(bc, x.expectedHeadTxid)
+    write6(bc, x.dirtyPgnos)
+}
+
+export type SqliteCommitStageBeginOk = {
+    readonly stageId: SqliteStageId
+    readonly maxPagesPerBatch: u32
+    readonly maxBatchBytes: u32
+    readonly observedHeadTxid: u64
+    readonly stagedTxid: u64
+}
+
+export function readSqliteCommitStageBeginOk(bc: bare.ByteCursor): SqliteCommitStageBeginOk {
+    return {
+        stageId: readSqliteStageId(bc),
+        maxPagesPerBatch: bare.readU32(bc),
+        maxBatchBytes: bare.readU32(bc),
+        observedHeadTxid: bare.readU64(bc),
+        stagedTxid: bare.readU64(bc),
+    }
+}
+
+export function writeSqliteCommitStageBeginOk(bc: bare.ByteCursor, x: SqliteCommitStageBeginOk): void {
+    writeSqliteStageId(bc, x.stageId)
+    bare.writeU32(bc, x.maxPagesPerBatch)
+    bare.writeU32(bc, x.maxBatchBytes)
+    bare.writeU64(bc, x.observedHeadTxid)
+    bare.writeU64(bc, x.stagedTxid)
+}
+
+export type SqliteCommitStageBeginResponse =
+    | { readonly tag: "SqliteCommitStageBeginOk"; readonly val: SqliteCommitStageBeginOk }
+    | { readonly tag: "SqliteErrorResponse"; readonly val: SqliteErrorResponse }
+
+export function readSqliteCommitStageBeginResponse(bc: bare.ByteCursor): SqliteCommitStageBeginResponse {
+    const offset = bc.offset
+    const tag = bare.readU8(bc)
+    switch (tag) {
+        case 0:
+            return { tag: "SqliteCommitStageBeginOk", val: readSqliteCommitStageBeginOk(bc) }
+        case 1:
+            return { tag: "SqliteErrorResponse", val: readSqliteErrorResponse(bc) }
+        default: {
+            bc.offset = offset
+            throw new bare.BareError(offset, "invalid tag")
+        }
+    }
+}
+
+export function writeSqliteCommitStageBeginResponse(bc: bare.ByteCursor, x: SqliteCommitStageBeginResponse): void {
+    switch (x.tag) {
+        case "SqliteCommitStageBeginOk": {
+            bare.writeU8(bc, 0)
+            writeSqliteCommitStageBeginOk(bc, x.val)
+            break
+        }
+        case "SqliteErrorResponse": {
+            bare.writeU8(bc, 1)
+            writeSqliteErrorResponse(bc, x.val)
+            break
+        }
+    }
+}
+
+export type SqliteCommitStagePagesRequest = {
+    readonly actorId: Id
+    readonly stageId: SqliteStageId
+    readonly batchIdx: u32
+    readonly dirtyPages: readonly SqliteDirtyPage[]
+    readonly expectedGeneration: u64 | null
+}
+
+export function readSqliteCommitStagePagesRequest(bc: bare.ByteCursor): SqliteCommitStagePagesRequest {
+    return {
+        actorId: readId(bc),
+        stageId: readSqliteStageId(bc),
+        batchIdx: bare.readU32(bc),
+        dirtyPages: read9(bc),
+        expectedGeneration: read2(bc),
+    }
+}
+
+export function writeSqliteCommitStagePagesRequest(bc: bare.ByteCursor, x: SqliteCommitStagePagesRequest): void {
+    writeId(bc, x.actorId)
+    writeSqliteStageId(bc, x.stageId)
+    bare.writeU32(bc, x.batchIdx)
+    write9(bc, x.dirtyPages)
+    write2(bc, x.expectedGeneration)
+}
+
+export type SqliteCommitStagePagesOk = null
+
+export type SqliteCommitStagePagesResponse =
+    | { readonly tag: "SqliteCommitStagePagesOk"; readonly val: SqliteCommitStagePagesOk }
+    | { readonly tag: "SqliteErrorResponse"; readonly val: SqliteErrorResponse }
+
+export function readSqliteCommitStagePagesResponse(bc: bare.ByteCursor): SqliteCommitStagePagesResponse {
+    const offset = bc.offset
+    const tag = bare.readU8(bc)
+    switch (tag) {
+        case 0:
+            return { tag: "SqliteCommitStagePagesOk", val: null }
+        case 1:
+            return { tag: "SqliteErrorResponse", val: readSqliteErrorResponse(bc) }
+        default: {
+            bc.offset = offset
+            throw new bare.BareError(offset, "invalid tag")
+        }
+    }
+}
+
+export function writeSqliteCommitStagePagesResponse(bc: bare.ByteCursor, x: SqliteCommitStagePagesResponse): void {
+    switch (x.tag) {
+        case "SqliteCommitStagePagesOk": {
+            bare.writeU8(bc, 0)
+            break
+        }
+        case "SqliteErrorResponse": {
+            bare.writeU8(bc, 1)
+            writeSqliteErrorResponse(bc, x.val)
+            break
+        }
+    }
+}
+
+export type SqliteCommitStageCompleteRequest = {
+    readonly actorId: Id
+    readonly stageId: SqliteStageId
+    readonly pageBatchCount: u32
+    readonly expectedGeneration: u64 | null
+}
+
+export function readSqliteCommitStageCompleteRequest(bc: bare.ByteCursor): SqliteCommitStageCompleteRequest {
+    return {
+        actorId: readId(bc),
+        stageId: readSqliteStageId(bc),
+        pageBatchCount: bare.readU32(bc),
+        expectedGeneration: read2(bc),
+    }
+}
+
+export function writeSqliteCommitStageCompleteRequest(bc: bare.ByteCursor, x: SqliteCommitStageCompleteRequest): void {
+    writeId(bc, x.actorId)
+    writeSqliteStageId(bc, x.stageId)
+    bare.writeU32(bc, x.pageBatchCount)
+    write2(bc, x.expectedGeneration)
+}
+
+export type SqliteCommitStageCompleteOk = null
+
+export type SqliteCommitStageCompleteResponse =
+    | { readonly tag: "SqliteCommitStageCompleteOk"; readonly val: SqliteCommitStageCompleteOk }
+    | { readonly tag: "SqliteErrorResponse"; readonly val: SqliteErrorResponse }
+
+export function readSqliteCommitStageCompleteResponse(bc: bare.ByteCursor): SqliteCommitStageCompleteResponse {
+    const offset = bc.offset
+    const tag = bare.readU8(bc)
+    switch (tag) {
+        case 0:
+            return { tag: "SqliteCommitStageCompleteOk", val: null }
+        case 1:
+            return { tag: "SqliteErrorResponse", val: readSqliteErrorResponse(bc) }
+        default: {
+            bc.offset = offset
+            throw new bare.BareError(offset, "invalid tag")
+        }
+    }
+}
+
+export function writeSqliteCommitStageCompleteResponse(bc: bare.ByteCursor, x: SqliteCommitStageCompleteResponse): void {
+    switch (x.tag) {
+        case "SqliteCommitStageCompleteOk": {
+            bare.writeU8(bc, 0)
+            break
+        }
+        case "SqliteErrorResponse": {
+            bare.writeU8(bc, 1)
+            writeSqliteErrorResponse(bc, x.val)
+            break
+        }
+    }
+}
+
+export type SqliteCommitStageFinalizeRequest = {
+    readonly actorId: Id
+    readonly stageId: SqliteStageId
+    readonly expectedGeneration: u64 | null
+}
+
+export function readSqliteCommitStageFinalizeRequest(bc: bare.ByteCursor): SqliteCommitStageFinalizeRequest {
+    return {
+        actorId: readId(bc),
+        stageId: readSqliteStageId(bc),
+        expectedGeneration: read2(bc),
+    }
+}
+
+export function writeSqliteCommitStageFinalizeRequest(bc: bare.ByteCursor, x: SqliteCommitStageFinalizeRequest): void {
+    writeId(bc, x.actorId)
+    writeSqliteStageId(bc, x.stageId)
+    write2(bc, x.expectedGeneration)
+}
+
+export type SqliteCommitStageAbortRequest = {
+    readonly actorId: Id
+    readonly stageId: SqliteStageId
+    readonly expectedGeneration: u64 | null
+}
+
+export function readSqliteCommitStageAbortRequest(bc: bare.ByteCursor): SqliteCommitStageAbortRequest {
+    return {
+        actorId: readId(bc),
+        stageId: readSqliteStageId(bc),
+        expectedGeneration: read2(bc),
+    }
+}
+
+export function writeSqliteCommitStageAbortRequest(bc: bare.ByteCursor, x: SqliteCommitStageAbortRequest): void {
+    writeId(bc, x.actorId)
+    writeSqliteStageId(bc, x.stageId)
+    write2(bc, x.expectedGeneration)
+}
+
+export type SqliteCommitStageAbortOk = null
+
+export type SqliteCommitStageAbortResponse =
+    | { readonly tag: "SqliteCommitStageAbortOk"; readonly val: SqliteCommitStageAbortOk }
+    | { readonly tag: "SqliteErrorResponse"; readonly val: SqliteErrorResponse }
+
+export function readSqliteCommitStageAbortResponse(bc: bare.ByteCursor): SqliteCommitStageAbortResponse {
+    const offset = bc.offset
+    const tag = bare.readU8(bc)
+    switch (tag) {
+        case 0:
+            return { tag: "SqliteCommitStageAbortOk", val: null }
+        case 1:
+            return { tag: "SqliteErrorResponse", val: readSqliteErrorResponse(bc) }
+        default: {
+            bc.offset = offset
+            throw new bare.BareError(offset, "invalid tag")
+        }
+    }
+}
+
+export function writeSqliteCommitStageAbortResponse(bc: bare.ByteCursor, x: SqliteCommitStageAbortResponse): void {
+    switch (x.tag) {
+        case "SqliteCommitStageAbortOk": {
+            bare.writeU8(bc, 0)
             break
         }
         case "SqliteErrorResponse": {
@@ -1019,7 +1327,7 @@ export function writeSqliteColumnValue(bc: bare.ByteCursor, x: SqliteColumnValue
     }
 }
 
-function read9(bc: bare.ByteCursor): readonly string[] {
+function read10(bc: bare.ByteCursor): readonly string[] {
     const len = bare.readUintSafe(bc)
     if (len === 0) {
         return []
@@ -1031,14 +1339,14 @@ function read9(bc: bare.ByteCursor): readonly string[] {
     return result
 }
 
-function write9(bc: bare.ByteCursor, x: readonly string[]): void {
+function write10(bc: bare.ByteCursor, x: readonly string[]): void {
     bare.writeUintSafe(bc, x.length)
     for (let i = 0; i < x.length; i++) {
         bare.writeString(bc, x[i])
     }
 }
 
-function read10(bc: bare.ByteCursor): readonly SqliteColumnValue[] {
+function read11(bc: bare.ByteCursor): readonly SqliteColumnValue[] {
     const len = bare.readUintSafe(bc)
     if (len === 0) {
         return []
@@ -1050,29 +1358,29 @@ function read10(bc: bare.ByteCursor): readonly SqliteColumnValue[] {
     return result
 }
 
-function write10(bc: bare.ByteCursor, x: readonly SqliteColumnValue[]): void {
+function write11(bc: bare.ByteCursor, x: readonly SqliteColumnValue[]): void {
     bare.writeUintSafe(bc, x.length)
     for (let i = 0; i < x.length; i++) {
         writeSqliteColumnValue(bc, x[i])
     }
 }
 
-function read11(bc: bare.ByteCursor): readonly (readonly SqliteColumnValue[])[] {
+function read12(bc: bare.ByteCursor): readonly (readonly SqliteColumnValue[])[] {
     const len = bare.readUintSafe(bc)
     if (len === 0) {
         return []
     }
-    const result = [read10(bc)]
+    const result = [read11(bc)]
     for (let i = 1; i < len; i++) {
-        result[i] = read10(bc)
+        result[i] = read11(bc)
     }
     return result
 }
 
-function write11(bc: bare.ByteCursor, x: readonly (readonly SqliteColumnValue[])[]): void {
+function write12(bc: bare.ByteCursor, x: readonly (readonly SqliteColumnValue[])[]): void {
     bare.writeUintSafe(bc, x.length)
     for (let i = 0; i < x.length; i++) {
-        write10(bc, x[i])
+        write11(bc, x[i])
     }
 }
 
@@ -1083,21 +1391,21 @@ export type SqliteQueryResult = {
 
 export function readSqliteQueryResult(bc: bare.ByteCursor): SqliteQueryResult {
     return {
-        columns: read9(bc),
-        rows: read11(bc),
+        columns: read10(bc),
+        rows: read12(bc),
     }
 }
 
 export function writeSqliteQueryResult(bc: bare.ByteCursor, x: SqliteQueryResult): void {
-    write9(bc, x.columns)
-    write11(bc, x.rows)
+    write10(bc, x.columns)
+    write12(bc, x.rows)
 }
 
-function read12(bc: bare.ByteCursor): i64 | null {
+function read13(bc: bare.ByteCursor): i64 | null {
     return bare.readBool(bc) ? bare.readI64(bc) : null
 }
 
-function write12(bc: bare.ByteCursor, x: i64 | null): void {
+function write13(bc: bare.ByteCursor, x: i64 | null): void {
     bare.writeBool(bc, x != null)
     if (x != null) {
         bare.writeI64(bc, x)
@@ -1113,18 +1421,18 @@ export type SqliteExecuteResult = {
 
 export function readSqliteExecuteResult(bc: bare.ByteCursor): SqliteExecuteResult {
     return {
-        columns: read9(bc),
-        rows: read11(bc),
+        columns: read10(bc),
+        rows: read12(bc),
         changes: bare.readI64(bc),
-        lastInsertRowId: read12(bc),
+        lastInsertRowId: read13(bc),
     }
 }
 
 export function writeSqliteExecuteResult(bc: bare.ByteCursor, x: SqliteExecuteResult): void {
-    write9(bc, x.columns)
-    write11(bc, x.rows)
+    write10(bc, x.columns)
+    write12(bc, x.rows)
     bare.writeI64(bc, x.changes)
-    write12(bc, x.lastInsertRowId)
+    write13(bc, x.lastInsertRowId)
 }
 
 export type SqliteExecRequest = {
@@ -1150,7 +1458,7 @@ export function writeSqliteExecRequest(bc: bare.ByteCursor, x: SqliteExecRequest
     bare.writeString(bc, x.sql)
 }
 
-function read13(bc: bare.ByteCursor): readonly SqliteBindParam[] {
+function read14(bc: bare.ByteCursor): readonly SqliteBindParam[] {
     const len = bare.readUintSafe(bc)
     if (len === 0) {
         return []
@@ -1162,21 +1470,21 @@ function read13(bc: bare.ByteCursor): readonly SqliteBindParam[] {
     return result
 }
 
-function write13(bc: bare.ByteCursor, x: readonly SqliteBindParam[]): void {
+function write14(bc: bare.ByteCursor, x: readonly SqliteBindParam[]): void {
     bare.writeUintSafe(bc, x.length)
     for (let i = 0; i < x.length; i++) {
         writeSqliteBindParam(bc, x[i])
     }
 }
 
-function read14(bc: bare.ByteCursor): readonly SqliteBindParam[] | null {
-    return bare.readBool(bc) ? read13(bc) : null
+function read15(bc: bare.ByteCursor): readonly SqliteBindParam[] | null {
+    return bare.readBool(bc) ? read14(bc) : null
 }
 
-function write14(bc: bare.ByteCursor, x: readonly SqliteBindParam[] | null): void {
+function write15(bc: bare.ByteCursor, x: readonly SqliteBindParam[] | null): void {
     bare.writeBool(bc, x != null)
     if (x != null) {
-        write13(bc, x)
+        write14(bc, x)
     }
 }
 
@@ -1194,7 +1502,7 @@ export function readSqliteExecuteRequest(bc: bare.ByteCursor): SqliteExecuteRequ
         actorId: readId(bc),
         generation: readSqliteGeneration(bc),
         sql: bare.readString(bc),
-        params: read14(bc),
+        params: read15(bc),
     }
 }
 
@@ -1203,7 +1511,7 @@ export function writeSqliteExecuteRequest(bc: bare.ByteCursor, x: SqliteExecuteR
     writeId(bc, x.actorId)
     writeSqliteGeneration(bc, x.generation)
     bare.writeString(bc, x.sql)
-    write14(bc, x.params)
+    write15(bc, x.params)
 }
 
 export type SqliteExecOk = {
@@ -1352,22 +1660,22 @@ export function writeActorName(bc: bare.ByteCursor, x: ActorName): void {
     writeJson(bc, x.metadata)
 }
 
-function read15(bc: bare.ByteCursor): string | null {
+function read16(bc: bare.ByteCursor): string | null {
     return bare.readBool(bc) ? bare.readString(bc) : null
 }
 
-function write15(bc: bare.ByteCursor, x: string | null): void {
+function write16(bc: bare.ByteCursor, x: string | null): void {
     bare.writeBool(bc, x != null)
     if (x != null) {
         bare.writeString(bc, x)
     }
 }
 
-function read16(bc: bare.ByteCursor): ArrayBuffer | null {
+function read17(bc: bare.ByteCursor): ArrayBuffer | null {
     return bare.readBool(bc) ? bare.readData(bc) : null
 }
 
-function write16(bc: bare.ByteCursor, x: ArrayBuffer | null): void {
+function write17(bc: bare.ByteCursor, x: ArrayBuffer | null): void {
     bare.writeBool(bc, x != null)
     if (x != null) {
         bare.writeData(bc, x)
@@ -1384,17 +1692,17 @@ export type ActorConfig = {
 export function readActorConfig(bc: bare.ByteCursor): ActorConfig {
     return {
         name: bare.readString(bc),
-        key: read15(bc),
+        key: read16(bc),
         createTs: bare.readI64(bc),
-        input: read16(bc),
+        input: read17(bc),
     }
 }
 
 export function writeActorConfig(bc: bare.ByteCursor, x: ActorConfig): void {
     bare.writeString(bc, x.name)
-    write15(bc, x.key)
+    write16(bc, x.key)
     bare.writeI64(bc, x.createTs)
-    write16(bc, x.input)
+    write17(bc, x.input)
 }
 
 export type ActorCheckpoint = {
@@ -1469,13 +1777,13 @@ export type ActorStateStopped = {
 export function readActorStateStopped(bc: bare.ByteCursor): ActorStateStopped {
     return {
         code: readStopCode(bc),
-        message: read15(bc),
+        message: read16(bc),
     }
 }
 
 export function writeActorStateStopped(bc: bare.ByteCursor, x: ActorStateStopped): void {
     writeStopCode(bc, x.code)
-    write15(bc, x.message)
+    write16(bc, x.message)
 }
 
 export type ActorState =
@@ -1548,12 +1856,12 @@ export type EventActorSetAlarm = {
 
 export function readEventActorSetAlarm(bc: bare.ByteCursor): EventActorSetAlarm {
     return {
-        alarmTs: read12(bc),
+        alarmTs: read13(bc),
     }
 }
 
 export function writeEventActorSetAlarm(bc: bare.ByteCursor, x: EventActorSetAlarm): void {
-    write12(bc, x.alarmTs)
+    write13(bc, x.alarmTs)
 }
 
 export type Event =
@@ -1635,7 +1943,7 @@ export function writePreloadedKvEntry(bc: bare.ByteCursor, x: PreloadedKvEntry):
     writeKvMetadata(bc, x.metadata)
 }
 
-function read17(bc: bare.ByteCursor): readonly PreloadedKvEntry[] {
+function read18(bc: bare.ByteCursor): readonly PreloadedKvEntry[] {
     const len = bare.readUintSafe(bc)
     if (len === 0) {
         return []
@@ -1647,7 +1955,7 @@ function read17(bc: bare.ByteCursor): readonly PreloadedKvEntry[] {
     return result
 }
 
-function write17(bc: bare.ByteCursor, x: readonly PreloadedKvEntry[]): void {
+function write18(bc: bare.ByteCursor, x: readonly PreloadedKvEntry[]): void {
     bare.writeUintSafe(bc, x.length)
     for (let i = 0; i < x.length; i++) {
         writePreloadedKvEntry(bc, x[i])
@@ -1662,14 +1970,14 @@ export type PreloadedKv = {
 
 export function readPreloadedKv(bc: bare.ByteCursor): PreloadedKv {
     return {
-        entries: read17(bc),
+        entries: read18(bc),
         requestedGetKeys: read0(bc),
         requestedPrefixes: read0(bc),
     }
 }
 
 export function writePreloadedKv(bc: bare.ByteCursor, x: PreloadedKv): void {
-    write17(bc, x.entries)
+    write18(bc, x.entries)
     write0(bc, x.requestedGetKeys)
     write0(bc, x.requestedPrefixes)
 }
@@ -1691,7 +1999,7 @@ export function writeHibernatingRequest(bc: bare.ByteCursor, x: HibernatingReque
     writeRequestId(bc, x.requestId)
 }
 
-function read18(bc: bare.ByteCursor): readonly HibernatingRequest[] {
+function read19(bc: bare.ByteCursor): readonly HibernatingRequest[] {
     const len = bare.readUintSafe(bc)
     if (len === 0) {
         return []
@@ -1703,18 +2011,18 @@ function read18(bc: bare.ByteCursor): readonly HibernatingRequest[] {
     return result
 }
 
-function write18(bc: bare.ByteCursor, x: readonly HibernatingRequest[]): void {
+function write19(bc: bare.ByteCursor, x: readonly HibernatingRequest[]): void {
     bare.writeUintSafe(bc, x.length)
     for (let i = 0; i < x.length; i++) {
         writeHibernatingRequest(bc, x[i])
     }
 }
 
-function read19(bc: bare.ByteCursor): PreloadedKv | null {
+function read20(bc: bare.ByteCursor): PreloadedKv | null {
     return bare.readBool(bc) ? readPreloadedKv(bc) : null
 }
 
-function write19(bc: bare.ByteCursor, x: PreloadedKv | null): void {
+function write20(bc: bare.ByteCursor, x: PreloadedKv | null): void {
     bare.writeBool(bc, x != null)
     if (x != null) {
         writePreloadedKv(bc, x)
@@ -1730,15 +2038,15 @@ export type CommandStartActor = {
 export function readCommandStartActor(bc: bare.ByteCursor): CommandStartActor {
     return {
         config: readActorConfig(bc),
-        hibernatingRequests: read18(bc),
-        preloadedKv: read19(bc),
+        hibernatingRequests: read19(bc),
+        preloadedKv: read20(bc),
     }
 }
 
 export function writeCommandStartActor(bc: bare.ByteCursor, x: CommandStartActor): void {
     writeActorConfig(bc, x.config)
-    write18(bc, x.hibernatingRequests)
-    write19(bc, x.preloadedKv)
+    write19(bc, x.hibernatingRequests)
+    write20(bc, x.preloadedKv)
 }
 
 export enum StopActorReason {
@@ -1945,7 +2253,7 @@ export function writeMessageId(bc: bare.ByteCursor, x: MessageId): void {
     writeMessageIndex(bc, x.messageIndex)
 }
 
-function read20(bc: bare.ByteCursor): ReadonlyMap<string, string> {
+function read21(bc: bare.ByteCursor): ReadonlyMap<string, string> {
     const len = bare.readUintSafe(bc)
     const result = new Map<string, string>()
     for (let i = 0; i < len; i++) {
@@ -1960,7 +2268,7 @@ function read20(bc: bare.ByteCursor): ReadonlyMap<string, string> {
     return result
 }
 
-function write20(bc: bare.ByteCursor, x: ReadonlyMap<string, string>): void {
+function write21(bc: bare.ByteCursor, x: ReadonlyMap<string, string>): void {
     bare.writeUintSafe(bc, x.size)
     for (const kv of x) {
         bare.writeString(bc, kv[0])
@@ -1985,8 +2293,8 @@ export function readToEnvoyRequestStart(bc: bare.ByteCursor): ToEnvoyRequestStar
         actorId: readId(bc),
         method: bare.readString(bc),
         path: bare.readString(bc),
-        headers: read20(bc),
-        body: read16(bc),
+        headers: read21(bc),
+        body: read17(bc),
         stream: bare.readBool(bc),
     }
 }
@@ -1995,8 +2303,8 @@ export function writeToEnvoyRequestStart(bc: bare.ByteCursor, x: ToEnvoyRequestS
     writeId(bc, x.actorId)
     bare.writeString(bc, x.method)
     bare.writeString(bc, x.path)
-    write20(bc, x.headers)
-    write16(bc, x.body)
+    write21(bc, x.headers)
+    write17(bc, x.body)
     bare.writeBool(bc, x.stream)
 }
 
@@ -2029,16 +2337,16 @@ export type ToRivetResponseStart = {
 export function readToRivetResponseStart(bc: bare.ByteCursor): ToRivetResponseStart {
     return {
         status: bare.readU16(bc),
-        headers: read20(bc),
-        body: read16(bc),
+        headers: read21(bc),
+        body: read17(bc),
         stream: bare.readBool(bc),
     }
 }
 
 export function writeToRivetResponseStart(bc: bare.ByteCursor, x: ToRivetResponseStart): void {
     bare.writeU16(bc, x.status)
-    write20(bc, x.headers)
-    write16(bc, x.body)
+    write21(bc, x.headers)
+    write17(bc, x.body)
     bare.writeBool(bc, x.stream)
 }
 
@@ -2074,14 +2382,14 @@ export function readToEnvoyWebSocketOpen(bc: bare.ByteCursor): ToEnvoyWebSocketO
     return {
         actorId: readId(bc),
         path: bare.readString(bc),
-        headers: read20(bc),
+        headers: read21(bc),
     }
 }
 
 export function writeToEnvoyWebSocketOpen(bc: bare.ByteCursor, x: ToEnvoyWebSocketOpen): void {
     writeId(bc, x.actorId)
     bare.writeString(bc, x.path)
-    write20(bc, x.headers)
+    write21(bc, x.headers)
 }
 
 export type ToEnvoyWebSocketMessage = {
@@ -2101,11 +2409,11 @@ export function writeToEnvoyWebSocketMessage(bc: bare.ByteCursor, x: ToEnvoyWebS
     bare.writeBool(bc, x.binary)
 }
 
-function read21(bc: bare.ByteCursor): u16 | null {
+function read22(bc: bare.ByteCursor): u16 | null {
     return bare.readBool(bc) ? bare.readU16(bc) : null
 }
 
-function write21(bc: bare.ByteCursor, x: u16 | null): void {
+function write22(bc: bare.ByteCursor, x: u16 | null): void {
     bare.writeBool(bc, x != null)
     if (x != null) {
         bare.writeU16(bc, x)
@@ -2119,14 +2427,14 @@ export type ToEnvoyWebSocketClose = {
 
 export function readToEnvoyWebSocketClose(bc: bare.ByteCursor): ToEnvoyWebSocketClose {
     return {
-        code: read21(bc),
-        reason: read15(bc),
+        code: read22(bc),
+        reason: read16(bc),
     }
 }
 
 export function writeToEnvoyWebSocketClose(bc: bare.ByteCursor, x: ToEnvoyWebSocketClose): void {
-    write21(bc, x.code)
-    write15(bc, x.reason)
+    write22(bc, x.code)
+    write16(bc, x.reason)
 }
 
 export type ToRivetWebSocketOpen = {
@@ -2182,15 +2490,15 @@ export type ToRivetWebSocketClose = {
 
 export function readToRivetWebSocketClose(bc: bare.ByteCursor): ToRivetWebSocketClose {
     return {
-        code: read21(bc),
-        reason: read15(bc),
+        code: read22(bc),
+        reason: read16(bc),
         hibernate: bare.readBool(bc),
     }
 }
 
 export function writeToRivetWebSocketClose(bc: bare.ByteCursor, x: ToRivetWebSocketClose): void {
-    write21(bc, x.code)
-    write15(bc, x.reason)
+    write22(bc, x.code)
+    write16(bc, x.reason)
     bare.writeBool(bc, x.hibernate)
 }
 
@@ -2398,7 +2706,7 @@ export function writeToEnvoyPing(bc: bare.ByteCursor, x: ToEnvoyPing): void {
     bare.writeI64(bc, x.ts)
 }
 
-function read22(bc: bare.ByteCursor): ReadonlyMap<string, ActorName> {
+function read23(bc: bare.ByteCursor): ReadonlyMap<string, ActorName> {
     const len = bare.readUintSafe(bc)
     const result = new Map<string, ActorName>()
     for (let i = 0; i < len; i++) {
@@ -2413,7 +2721,7 @@ function read22(bc: bare.ByteCursor): ReadonlyMap<string, ActorName> {
     return result
 }
 
-function write22(bc: bare.ByteCursor, x: ReadonlyMap<string, ActorName>): void {
+function write23(bc: bare.ByteCursor, x: ReadonlyMap<string, ActorName>): void {
     bare.writeUintSafe(bc, x.size)
     for (const kv of x) {
         bare.writeString(bc, kv[0])
@@ -2421,25 +2729,14 @@ function write22(bc: bare.ByteCursor, x: ReadonlyMap<string, ActorName>): void {
     }
 }
 
-function read23(bc: bare.ByteCursor): ReadonlyMap<string, ActorName> | null {
-    return bare.readBool(bc) ? read22(bc) : null
+function read24(bc: bare.ByteCursor): ReadonlyMap<string, ActorName> | null {
+    return bare.readBool(bc) ? read23(bc) : null
 }
 
-function write23(bc: bare.ByteCursor, x: ReadonlyMap<string, ActorName> | null): void {
+function write24(bc: bare.ByteCursor, x: ReadonlyMap<string, ActorName> | null): void {
     bare.writeBool(bc, x != null)
     if (x != null) {
-        write22(bc, x)
-    }
-}
-
-function read24(bc: bare.ByteCursor): Json | null {
-    return bare.readBool(bc) ? readJson(bc) : null
-}
-
-function write24(bc: bare.ByteCursor, x: Json | null): void {
-    bare.writeBool(bc, x != null)
-    if (x != null) {
-        writeJson(bc, x)
+        write23(bc, x)
     }
 }
 
@@ -2453,14 +2750,14 @@ export type ToRivetMetadata = {
 
 export function readToRivetMetadata(bc: bare.ByteCursor): ToRivetMetadata {
     return {
-        prepopulateActorNames: read23(bc),
-        metadata: read24(bc),
+        prepopulateActorNames: read24(bc),
+        metadata: read8(bc),
     }
 }
 
 export function writeToRivetMetadata(bc: bare.ByteCursor, x: ToRivetMetadata): void {
-    write23(bc, x.prepopulateActorNames)
-    write24(bc, x.metadata)
+    write24(bc, x.prepopulateActorNames)
+    write8(bc, x.metadata)
 }
 
 export type ToRivetEvents = readonly EventWrapper[]
@@ -2587,6 +2884,91 @@ export function writeToRivetSqliteCommitRequest(bc: bare.ByteCursor, x: ToRivetS
     writeSqliteCommitRequest(bc, x.data)
 }
 
+export type ToRivetSqliteCommitStageBeginRequest = {
+    readonly requestId: u32
+    readonly data: SqliteCommitStageBeginRequest
+}
+
+export function readToRivetSqliteCommitStageBeginRequest(bc: bare.ByteCursor): ToRivetSqliteCommitStageBeginRequest {
+    return {
+        requestId: bare.readU32(bc),
+        data: readSqliteCommitStageBeginRequest(bc),
+    }
+}
+
+export function writeToRivetSqliteCommitStageBeginRequest(bc: bare.ByteCursor, x: ToRivetSqliteCommitStageBeginRequest): void {
+    bare.writeU32(bc, x.requestId)
+    writeSqliteCommitStageBeginRequest(bc, x.data)
+}
+
+export type ToRivetSqliteCommitStagePagesRequest = {
+    readonly requestId: u32
+    readonly data: SqliteCommitStagePagesRequest
+}
+
+export function readToRivetSqliteCommitStagePagesRequest(bc: bare.ByteCursor): ToRivetSqliteCommitStagePagesRequest {
+    return {
+        requestId: bare.readU32(bc),
+        data: readSqliteCommitStagePagesRequest(bc),
+    }
+}
+
+export function writeToRivetSqliteCommitStagePagesRequest(bc: bare.ByteCursor, x: ToRivetSqliteCommitStagePagesRequest): void {
+    bare.writeU32(bc, x.requestId)
+    writeSqliteCommitStagePagesRequest(bc, x.data)
+}
+
+export type ToRivetSqliteCommitStageCompleteRequest = {
+    readonly requestId: u32
+    readonly data: SqliteCommitStageCompleteRequest
+}
+
+export function readToRivetSqliteCommitStageCompleteRequest(bc: bare.ByteCursor): ToRivetSqliteCommitStageCompleteRequest {
+    return {
+        requestId: bare.readU32(bc),
+        data: readSqliteCommitStageCompleteRequest(bc),
+    }
+}
+
+export function writeToRivetSqliteCommitStageCompleteRequest(bc: bare.ByteCursor, x: ToRivetSqliteCommitStageCompleteRequest): void {
+    bare.writeU32(bc, x.requestId)
+    writeSqliteCommitStageCompleteRequest(bc, x.data)
+}
+
+export type ToRivetSqliteCommitStageFinalizeRequest = {
+    readonly requestId: u32
+    readonly data: SqliteCommitStageFinalizeRequest
+}
+
+export function readToRivetSqliteCommitStageFinalizeRequest(bc: bare.ByteCursor): ToRivetSqliteCommitStageFinalizeRequest {
+    return {
+        requestId: bare.readU32(bc),
+        data: readSqliteCommitStageFinalizeRequest(bc),
+    }
+}
+
+export function writeToRivetSqliteCommitStageFinalizeRequest(bc: bare.ByteCursor, x: ToRivetSqliteCommitStageFinalizeRequest): void {
+    bare.writeU32(bc, x.requestId)
+    writeSqliteCommitStageFinalizeRequest(bc, x.data)
+}
+
+export type ToRivetSqliteCommitStageAbortRequest = {
+    readonly requestId: u32
+    readonly data: SqliteCommitStageAbortRequest
+}
+
+export function readToRivetSqliteCommitStageAbortRequest(bc: bare.ByteCursor): ToRivetSqliteCommitStageAbortRequest {
+    return {
+        requestId: bare.readU32(bc),
+        data: readSqliteCommitStageAbortRequest(bc),
+    }
+}
+
+export function writeToRivetSqliteCommitStageAbortRequest(bc: bare.ByteCursor, x: ToRivetSqliteCommitStageAbortRequest): void {
+    bare.writeU32(bc, x.requestId)
+    writeSqliteCommitStageAbortRequest(bc, x.data)
+}
+
 export type ToRivetSqliteExecRequest = {
     readonly requestId: u32
     readonly data: SqliteExecRequest
@@ -2633,6 +3015,11 @@ export type ToRivet =
     | { readonly tag: "ToRivetSqliteCommitRequest"; readonly val: ToRivetSqliteCommitRequest }
     | { readonly tag: "ToRivetSqliteExecRequest"; readonly val: ToRivetSqliteExecRequest }
     | { readonly tag: "ToRivetSqliteExecuteRequest"; readonly val: ToRivetSqliteExecuteRequest }
+    | { readonly tag: "ToRivetSqliteCommitStageBeginRequest"; readonly val: ToRivetSqliteCommitStageBeginRequest }
+    | { readonly tag: "ToRivetSqliteCommitStagePagesRequest"; readonly val: ToRivetSqliteCommitStagePagesRequest }
+    | { readonly tag: "ToRivetSqliteCommitStageCompleteRequest"; readonly val: ToRivetSqliteCommitStageCompleteRequest }
+    | { readonly tag: "ToRivetSqliteCommitStageFinalizeRequest"; readonly val: ToRivetSqliteCommitStageFinalizeRequest }
+    | { readonly tag: "ToRivetSqliteCommitStageAbortRequest"; readonly val: ToRivetSqliteCommitStageAbortRequest }
 
 export function readToRivet(bc: bare.ByteCursor): ToRivet {
     const offset = bc.offset
@@ -2660,6 +3047,16 @@ export function readToRivet(bc: bare.ByteCursor): ToRivet {
             return { tag: "ToRivetSqliteExecRequest", val: readToRivetSqliteExecRequest(bc) }
         case 10:
             return { tag: "ToRivetSqliteExecuteRequest", val: readToRivetSqliteExecuteRequest(bc) }
+        case 11:
+            return { tag: "ToRivetSqliteCommitStageBeginRequest", val: readToRivetSqliteCommitStageBeginRequest(bc) }
+        case 12:
+            return { tag: "ToRivetSqliteCommitStagePagesRequest", val: readToRivetSqliteCommitStagePagesRequest(bc) }
+        case 13:
+            return { tag: "ToRivetSqliteCommitStageCompleteRequest", val: readToRivetSqliteCommitStageCompleteRequest(bc) }
+        case 14:
+            return { tag: "ToRivetSqliteCommitStageFinalizeRequest", val: readToRivetSqliteCommitStageFinalizeRequest(bc) }
+        case 15:
+            return { tag: "ToRivetSqliteCommitStageAbortRequest", val: readToRivetSqliteCommitStageAbortRequest(bc) }
         default: {
             bc.offset = offset
             throw new bare.BareError(offset, "invalid tag")
@@ -2721,6 +3118,31 @@ export function writeToRivet(bc: bare.ByteCursor, x: ToRivet): void {
         case "ToRivetSqliteExecuteRequest": {
             bare.writeU8(bc, 10)
             writeToRivetSqliteExecuteRequest(bc, x.val)
+            break
+        }
+        case "ToRivetSqliteCommitStageBeginRequest": {
+            bare.writeU8(bc, 11)
+            writeToRivetSqliteCommitStageBeginRequest(bc, x.val)
+            break
+        }
+        case "ToRivetSqliteCommitStagePagesRequest": {
+            bare.writeU8(bc, 12)
+            writeToRivetSqliteCommitStagePagesRequest(bc, x.val)
+            break
+        }
+        case "ToRivetSqliteCommitStageCompleteRequest": {
+            bare.writeU8(bc, 13)
+            writeToRivetSqliteCommitStageCompleteRequest(bc, x.val)
+            break
+        }
+        case "ToRivetSqliteCommitStageFinalizeRequest": {
+            bare.writeU8(bc, 14)
+            writeToRivetSqliteCommitStageFinalizeRequest(bc, x.val)
+            break
+        }
+        case "ToRivetSqliteCommitStageAbortRequest": {
+            bare.writeU8(bc, 15)
+            writeToRivetSqliteCommitStageAbortRequest(bc, x.val)
             break
         }
     }
@@ -2868,6 +3290,91 @@ export function writeToEnvoySqliteCommitResponse(bc: bare.ByteCursor, x: ToEnvoy
     writeSqliteCommitResponse(bc, x.data)
 }
 
+export type ToEnvoySqliteCommitStageBeginResponse = {
+    readonly requestId: u32
+    readonly data: SqliteCommitStageBeginResponse
+}
+
+export function readToEnvoySqliteCommitStageBeginResponse(bc: bare.ByteCursor): ToEnvoySqliteCommitStageBeginResponse {
+    return {
+        requestId: bare.readU32(bc),
+        data: readSqliteCommitStageBeginResponse(bc),
+    }
+}
+
+export function writeToEnvoySqliteCommitStageBeginResponse(bc: bare.ByteCursor, x: ToEnvoySqliteCommitStageBeginResponse): void {
+    bare.writeU32(bc, x.requestId)
+    writeSqliteCommitStageBeginResponse(bc, x.data)
+}
+
+export type ToEnvoySqliteCommitStagePagesResponse = {
+    readonly requestId: u32
+    readonly data: SqliteCommitStagePagesResponse
+}
+
+export function readToEnvoySqliteCommitStagePagesResponse(bc: bare.ByteCursor): ToEnvoySqliteCommitStagePagesResponse {
+    return {
+        requestId: bare.readU32(bc),
+        data: readSqliteCommitStagePagesResponse(bc),
+    }
+}
+
+export function writeToEnvoySqliteCommitStagePagesResponse(bc: bare.ByteCursor, x: ToEnvoySqliteCommitStagePagesResponse): void {
+    bare.writeU32(bc, x.requestId)
+    writeSqliteCommitStagePagesResponse(bc, x.data)
+}
+
+export type ToEnvoySqliteCommitStageCompleteResponse = {
+    readonly requestId: u32
+    readonly data: SqliteCommitStageCompleteResponse
+}
+
+export function readToEnvoySqliteCommitStageCompleteResponse(bc: bare.ByteCursor): ToEnvoySqliteCommitStageCompleteResponse {
+    return {
+        requestId: bare.readU32(bc),
+        data: readSqliteCommitStageCompleteResponse(bc),
+    }
+}
+
+export function writeToEnvoySqliteCommitStageCompleteResponse(bc: bare.ByteCursor, x: ToEnvoySqliteCommitStageCompleteResponse): void {
+    bare.writeU32(bc, x.requestId)
+    writeSqliteCommitStageCompleteResponse(bc, x.data)
+}
+
+export type ToEnvoySqliteCommitStageFinalizeResponse = {
+    readonly requestId: u32
+    readonly data: SqliteCommitResponse
+}
+
+export function readToEnvoySqliteCommitStageFinalizeResponse(bc: bare.ByteCursor): ToEnvoySqliteCommitStageFinalizeResponse {
+    return {
+        requestId: bare.readU32(bc),
+        data: readSqliteCommitResponse(bc),
+    }
+}
+
+export function writeToEnvoySqliteCommitStageFinalizeResponse(bc: bare.ByteCursor, x: ToEnvoySqliteCommitStageFinalizeResponse): void {
+    bare.writeU32(bc, x.requestId)
+    writeSqliteCommitResponse(bc, x.data)
+}
+
+export type ToEnvoySqliteCommitStageAbortResponse = {
+    readonly requestId: u32
+    readonly data: SqliteCommitStageAbortResponse
+}
+
+export function readToEnvoySqliteCommitStageAbortResponse(bc: bare.ByteCursor): ToEnvoySqliteCommitStageAbortResponse {
+    return {
+        requestId: bare.readU32(bc),
+        data: readSqliteCommitStageAbortResponse(bc),
+    }
+}
+
+export function writeToEnvoySqliteCommitStageAbortResponse(bc: bare.ByteCursor, x: ToEnvoySqliteCommitStageAbortResponse): void {
+    bare.writeU32(bc, x.requestId)
+    writeSqliteCommitStageAbortResponse(bc, x.data)
+}
+
 export type ToEnvoySqliteExecResponse = {
     readonly requestId: u32
     readonly data: SqliteExecResponse
@@ -2913,6 +3420,11 @@ export type ToEnvoy =
     | { readonly tag: "ToEnvoySqliteCommitResponse"; readonly val: ToEnvoySqliteCommitResponse }
     | { readonly tag: "ToEnvoySqliteExecResponse"; readonly val: ToEnvoySqliteExecResponse }
     | { readonly tag: "ToEnvoySqliteExecuteResponse"; readonly val: ToEnvoySqliteExecuteResponse }
+    | { readonly tag: "ToEnvoySqliteCommitStageBeginResponse"; readonly val: ToEnvoySqliteCommitStageBeginResponse }
+    | { readonly tag: "ToEnvoySqliteCommitStagePagesResponse"; readonly val: ToEnvoySqliteCommitStagePagesResponse }
+    | { readonly tag: "ToEnvoySqliteCommitStageCompleteResponse"; readonly val: ToEnvoySqliteCommitStageCompleteResponse }
+    | { readonly tag: "ToEnvoySqliteCommitStageFinalizeResponse"; readonly val: ToEnvoySqliteCommitStageFinalizeResponse }
+    | { readonly tag: "ToEnvoySqliteCommitStageAbortResponse"; readonly val: ToEnvoySqliteCommitStageAbortResponse }
 
 export function readToEnvoy(bc: bare.ByteCursor): ToEnvoy {
     const offset = bc.offset
@@ -2938,6 +3450,16 @@ export function readToEnvoy(bc: bare.ByteCursor): ToEnvoy {
             return { tag: "ToEnvoySqliteExecResponse", val: readToEnvoySqliteExecResponse(bc) }
         case 9:
             return { tag: "ToEnvoySqliteExecuteResponse", val: readToEnvoySqliteExecuteResponse(bc) }
+        case 10:
+            return { tag: "ToEnvoySqliteCommitStageBeginResponse", val: readToEnvoySqliteCommitStageBeginResponse(bc) }
+        case 11:
+            return { tag: "ToEnvoySqliteCommitStagePagesResponse", val: readToEnvoySqliteCommitStagePagesResponse(bc) }
+        case 12:
+            return { tag: "ToEnvoySqliteCommitStageCompleteResponse", val: readToEnvoySqliteCommitStageCompleteResponse(bc) }
+        case 13:
+            return { tag: "ToEnvoySqliteCommitStageFinalizeResponse", val: readToEnvoySqliteCommitStageFinalizeResponse(bc) }
+        case 14:
+            return { tag: "ToEnvoySqliteCommitStageAbortResponse", val: readToEnvoySqliteCommitStageAbortResponse(bc) }
         default: {
             bc.offset = offset
             throw new bare.BareError(offset, "invalid tag")
@@ -2995,6 +3517,31 @@ export function writeToEnvoy(bc: bare.ByteCursor, x: ToEnvoy): void {
         case "ToEnvoySqliteExecuteResponse": {
             bare.writeU8(bc, 9)
             writeToEnvoySqliteExecuteResponse(bc, x.val)
+            break
+        }
+        case "ToEnvoySqliteCommitStageBeginResponse": {
+            bare.writeU8(bc, 10)
+            writeToEnvoySqliteCommitStageBeginResponse(bc, x.val)
+            break
+        }
+        case "ToEnvoySqliteCommitStagePagesResponse": {
+            bare.writeU8(bc, 11)
+            writeToEnvoySqliteCommitStagePagesResponse(bc, x.val)
+            break
+        }
+        case "ToEnvoySqliteCommitStageCompleteResponse": {
+            bare.writeU8(bc, 12)
+            writeToEnvoySqliteCommitStageCompleteResponse(bc, x.val)
+            break
+        }
+        case "ToEnvoySqliteCommitStageFinalizeResponse": {
+            bare.writeU8(bc, 13)
+            writeToEnvoySqliteCommitStageFinalizeResponse(bc, x.val)
+            break
+        }
+        case "ToEnvoySqliteCommitStageAbortResponse": {
+            bare.writeU8(bc, 14)
+            writeToEnvoySqliteCommitStageAbortResponse(bc, x.val)
             break
         }
     }
@@ -3269,4 +3816,4 @@ function assert(condition: boolean, message?: string): asserts condition {
     if (!condition) throw new Error(message ?? "Assertion failed")
 }
 
-export const VERSION = 5;
+export const VERSION = 6;

--- a/rivetkit-rust/packages/rivetkit-core/src/actor/context.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/actor/context.rs
@@ -412,7 +412,8 @@ impl ActorContext {
 			};
 		}
 		if self.0.sleep_requested.swap(true, Ordering::SeqCst) {
-			return Ok(());
+			return Err(ActorLifecycleError::Stopping.build())
+				.context("sleep already requested for this generation");
 		}
 		self.cancel_sleep_timer();
 		if Handle::try_current().is_ok() {

--- a/rivetkit-rust/packages/rivetkit-core/src/actor/sqlite/envoy_sqlite_transport.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/actor/sqlite/envoy_sqlite_transport.rs
@@ -28,4 +28,39 @@ impl SqliteTransport for EnvoySqliteTransport {
 	) -> Result<protocol::SqliteCommitResponse> {
 		self.handle.sqlite_commit(request).await
 	}
+
+	async fn commit_stage_begin(
+		&self,
+		request: protocol::SqliteCommitStageBeginRequest,
+	) -> Result<protocol::SqliteCommitStageBeginResponse> {
+		self.handle.sqlite_commit_stage_begin(request).await
+	}
+
+	async fn commit_stage_pages(
+		&self,
+		request: protocol::SqliteCommitStagePagesRequest,
+	) -> Result<protocol::SqliteCommitStagePagesResponse> {
+		self.handle.sqlite_commit_stage_pages(request).await
+	}
+
+	async fn commit_stage_complete(
+		&self,
+		request: protocol::SqliteCommitStageCompleteRequest,
+	) -> Result<protocol::SqliteCommitStageCompleteResponse> {
+		self.handle.sqlite_commit_stage_complete(request).await
+	}
+
+	async fn commit_stage_finalize(
+		&self,
+		request: protocol::SqliteCommitStageFinalizeRequest,
+	) -> Result<protocol::SqliteCommitResponse> {
+		self.handle.sqlite_commit_stage_finalize(request).await
+	}
+
+	async fn commit_stage_abort(
+		&self,
+		request: protocol::SqliteCommitStageAbortRequest,
+	) -> Result<protocol::SqliteCommitStageAbortResponse> {
+		self.handle.sqlite_commit_stage_abort(request).await
+	}
 }

--- a/rivetkit-rust/packages/rivetkit-core/tests/sleep.rs
+++ b/rivetkit-rust/packages/rivetkit-core/tests/sleep.rs
@@ -155,7 +155,7 @@ mod moved_tests {
 	}
 
 	#[tokio::test(start_paused = true)]
-	async fn teardown_aborts_tracked_shutdown_tasks() {
+	async fn deadline_teardown_aborts_tracked_shutdown_tasks() {
 		let ctx = ActorContext::new_for_sleep_tests("actor-shutdown-teardown");
 		let (drop_tx, drop_rx) = oneshot::channel();
 		let (_never_tx, never_rx) = oneshot::channel::<()>();
@@ -168,6 +168,7 @@ mod moved_tests {
 
 		assert_eq!(ctx.shutdown_task_count(), 1);
 
+		ctx.mark_shutdown_deadline_reached();
 		ctx.teardown_sleep_state().await;
 		advance(Duration::from_millis(1)).await;
 

--- a/rivetkit-rust/packages/rivetkit-core/tests/sqlite.rs
+++ b/rivetkit-rust/packages/rivetkit-core/tests/sqlite.rs
@@ -224,6 +224,7 @@ fn remote_head_fence_mismatch_stops_actor_once() {
 		group: HEAD_FENCE_MISMATCH_GROUP.to_string(),
 		code: HEAD_FENCE_MISMATCH_CODE.to_string(),
 		message: "head fence mismatch in remote sqlite".to_string(),
+		metadata: None,
 	});
 	let structured = rivet_error::RivetError::extract(&mapped);
 	assert_eq!(structured.group(), "sqlite");
@@ -252,6 +253,7 @@ fn remote_head_fence_mismatch_stops_actor_once() {
 		group: HEAD_FENCE_MISMATCH_GROUP.to_string(),
 		code: HEAD_FENCE_MISMATCH_CODE.to_string(),
 		message: "second head fence mismatch".to_string(),
+		metadata: None,
 	});
 	assert!(envoy_rx.try_recv().is_err());
 }

--- a/rivetkit-typescript/packages/rivetkit/src/common/database/native-database.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/common/database/native-database.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { BRIDGE_RIVET_ERROR_PREFIX, RivetError } from "../../actor/errors";
 import {
 	type JsNativeDatabaseLike,
 	wrapJsNativeDatabase,
@@ -21,6 +22,7 @@ class FakeNativeDatabase implements JsNativeDatabaseLike {
 	active = 0;
 	maxActive = 0;
 	closed = false;
+	kvError: string | null = null;
 	executeCalls: { sql: string; params?: NativeParams; write: boolean }[] = [];
 	#pending: ReturnType<typeof deferred<NativeExecuteResult>>[] = [];
 
@@ -43,7 +45,7 @@ class FakeNativeDatabase implements JsNativeDatabaseLike {
 	}
 
 	takeLastKvError() {
-		return null;
+		return this.kvError;
 	}
 
 	async close() {
@@ -62,6 +64,14 @@ class FakeNativeDatabase implements JsNativeDatabaseLike {
 			lastInsertRowId: null,
 			...result,
 		});
+	}
+
+	rejectNext(error: unknown) {
+		const pending = this.#pending.shift();
+		if (!pending) {
+			throw new Error("no pending native execute call");
+		}
+		pending.reject(error);
 	}
 
 	async #startExecute(
@@ -152,6 +162,36 @@ describe("wrapJsNativeDatabase", () => {
 		await expect(fallback).resolves.toMatchObject({
 			rows: [[7]],
 		});
+	});
+
+	test("throws structured RivetError from native kv last error", async () => {
+		const native = new FakeNativeDatabase();
+		native.kvError = `${BRIDGE_RIVET_ERROR_PREFIX}${JSON.stringify({
+			group: "depot",
+			code: "sqlite_commit_page_limit_exceeded",
+			message: "SQLite transaction touched too many pages.",
+			metadata: {
+				dirty_page_count: 8193,
+				max_dirty_pages: 8192,
+				page_size_bytes: 4096,
+			},
+			public: true,
+		})}`;
+		const db = wrapJsNativeDatabase(native);
+
+		const query = db.query("SELECT 1");
+		native.rejectNext(new Error("disk I/O error"));
+
+		await expect(query).rejects.toMatchObject({
+			group: "depot",
+			code: "sqlite_commit_page_limit_exceeded",
+			metadata: {
+				dirty_page_count: 8193,
+				max_dirty_pages: 8192,
+				page_size_bytes: 4096,
+			},
+		});
+		await expect(query).rejects.toBeInstanceOf(RivetError);
 	});
 
 	test("close waits for admitted native calls and rejects new work", async () => {

--- a/rivetkit-typescript/packages/rivetkit/src/common/database/native-database.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/common/database/native-database.ts
@@ -103,6 +103,11 @@ function enrichNativeDatabaseError(
 	}
 
 	const kvError = database.takeLastKvError?.();
+	const bridgedKvError =
+		typeof kvError === "string" ? decodeBridgeRivetError(kvError) : undefined;
+	if (bridgedKvError) {
+		throw bridgedKvError;
+	}
 	if (
 		error instanceof Error &&
 		kvError &&

--- a/website/src/content/docs/actors/limits.mdx
+++ b/website/src/content/docs/actors/limits.mdx
@@ -90,6 +90,7 @@ These limits apply to the [SQLite database](/docs/actors/state#sqlite-database) 
 | Name | Soft Limit | Hard Limit | Description |
 |------|------------|------------|-------------|
 | Max storage size per actor | — | 10 GiB | Maximum total storage size for a single actor. This limit is shared with KV storage. |
+| Max SQLite dirty pages per transaction | — | 8,192 pages and 32 MiB of dirty page bytes | Large SQLite transactions below this page count may change more than 10 MB of data. Depot stages those page bytes internally and publishes the commit atomically. Transactions above the page-count limit, or transactions whose final metadata publish would exceed infrastructure limits, fail with a SQLite storage limit error. The dirty-page limit error code is `depot.sqlite_commit_page_limit_exceeded`. |
 
 ### KV Preloading
 


### PR DESCRIPTION
## Stack Context

This stack fixes SQLite oversized transaction handling by making UniversalDB enforce the same core transaction payload limits expected from FoundationDB-backed commits.

## What?

- Enforces a 10,000,000 byte transaction limit in UDB commit paths.
- Enforces 10,000 byte keys and 100,000 byte values or atomic params.
- Maps oversized UDB commits to Depot SQLite CommitTooLarge errors.
- Updates focused UDB and SQLite VFS tests.

## Why?

Local RocksDB-backed UDB previously allowed SQLite transactions that production FDB would reject with transaction_too_large. That meant local tests could pass while production failed later as an internal SQLite/FDB commit error.
