### PR TITLE
fix(frontend): polish actors list ui

### DIFF
--- a/frontend/src/components/actors/actors-list-row.tsx
+++ b/frontend/src/components/actors/actors-list-row.tsx
@@ -107,7 +107,7 @@ function Id({ actorId }: { actorId: ActorId }) {
 		: actorId.substring(0, 8);
 	return (
 		<CopyTrigger value={actorId}>
-			<span className="group/id inline-flex items-center gap-1 min-w-0 max-w-full cursor-pointer text-muted-foreground hover:text-foreground tabular-nums font-mono-console transition-colors">
+			<span className="group/id inline-flex items-center gap-1 min-w-0 max-w-full justify-self-start cursor-pointer text-muted-foreground hover:text-foreground tabular-nums font-mono-console transition-colors">
 				<span className="truncate min-w-0">{shortId}</span>
 				<Icon
 					icon={faCopy}
@@ -159,7 +159,7 @@ function Tags({ actorId }: { actorId: ActorId }) {
 
 	return (
 		<CopyTrigger value={data}>
-			<span className="group/key inline-flex items-center gap-1 min-w-0 max-w-full cursor-pointer text-foreground transition-colors">
+			<span className="group/key inline-flex items-center gap-1 min-w-0 max-w-full justify-self-start cursor-pointer text-foreground transition-colors">
 				<span className="truncate min-w-0">{data}</span>
 				<Icon
 					icon={faCopy}
@@ -180,7 +180,7 @@ function Timestamp({ actorId }: { actorId: ActorId }) {
 	const timestamp = ts ? new Date(ts) : null;
 
 	return (
-		<SmallText className="text-right text-muted-foreground justify-end inline-flex tabular-nums">
+		<SmallText className="text-right text-xs text-muted-foreground justify-end inline-flex tabular-nums">
 			{isLoading ? (
 				<Skeleton className="h-5 w-10" />
 			) : timestamp ? (
@@ -205,7 +205,7 @@ export function ActorsListHeader() {
 				className="bg-foreground/[0.04] grid items-center gap-3 px-3 h-8 text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
 				style={{ gridTemplateColumns: template }}
 			>
-				<div>Status</div>
+				<div />
 				{showIds ? <div>ID</div> : null}
 				{showDatacenter ? <div>Region</div> : null}
 				<div>Key</div>

--- a/frontend/src/components/actors/actors-list.tsx
+++ b/frontend/src/components/actors/actors-list.tsx
@@ -174,7 +174,7 @@ function InstanceSearchTrigger() {
 			<WithTooltip
 				trigger={
 					<Button
-						variant="outline"
+						variant="ghost"
 						size="icon-sm"
 						onClick={() => setOpen(true)}
 						aria-label="Open Actor by ID"

--- a/frontend/src/components/ui/filters.tsx
+++ b/frontend/src/components/ui/filters.tsx
@@ -1407,7 +1407,7 @@ export function FiltersDisplay({
 		<Popover>
 			<PopoverTrigger asChild>
 				<Button
-					variant="outline"
+					variant="ghost"
 					size="sm"
 					startIcon={<Icon icon={faSliders} />}
 				>


### PR DESCRIPTION
## What?

Small visual polish to the Actors instance list.

- **Display + search buttons** now use the `ghost` variant so they match the muted `+` (create) button instead of rendering as dark bordered `outline` buttons.
- **Created timestamp** drops from `text-sm` to `text-xs` so it matches the rest of the row text (`SmallText` was forcing the larger size).
- **STATUS column header** label removed (empty cell kept so the status-dot column stays aligned). The colored dot is self-explanatory.
- **Copy click target** on the ID and Key cells is now scoped to the text + copy icon via `justify-self-start`, instead of stretching across the whole grid cell. Long values still truncate within the column.

## Why?

These are follow-up UI tweaks on the actors list flagged during review: the Display/search controls looked inconsistent with the create button, the timestamp was visually oversized, the STATUS header was redundant, and the full-width copy hit area made it easy to copy a key by accident when clicking anywhere in the row.
