### PR TITLE
fix(frontend): restore engine flavor actor navigation after top bar redesign

### DIFF
--- a/frontend/src/app/actors-grid.tsx
+++ b/frontend/src/app/actors-grid.tsx
@@ -70,27 +70,10 @@ function ActorGridCardSkeleton() {
 
 export function ActorsGrid({ namespaceLabel }: { namespaceLabel?: string }) {
 	const dataProvider = useDataProvider();
-	const nsDataProvider = useCloudNamespaceDataProvider();
-	const { organization, project, namespace } = useParams({
-		strict: false,
-	}) as {
-		organization: string;
-		project: string;
-		namespace: string;
-	};
 	const navigate = useNavigate();
 	const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
 		useInfiniteQuery(dataProvider.buildsQueryOptions());
 
-	const { data: managedPool } = useQuery({
-		...nsDataProvider.currentProjectManagedPoolQueryOptions({
-			namespace,
-			pool: "default",
-			safe: true,
-		}),
-		enabled: features.compute,
-	});
-	const hasCompute = features.compute && managedPool != null;
 	const { data: runnerNamesCount = 0 } = useInfiniteQuery({
 		...dataProvider.runnerNamesQueryOptions(),
 		select: (data) => data.pages.flatMap((page) => page.names).length,
@@ -115,24 +98,7 @@ export function ActorsGrid({ namespaceLabel }: { namespaceLabel?: string }) {
 					<header className="flex items-center justify-between gap-4 pb-6 border-b border-foreground/10">
 						<H1 className="text-2xl truncate">{namespaceName}</H1>
 						<div className="flex items-center gap-2">
-							{hasCompute ? (
-								<Link
-									to="/orgs/$organization/projects/$project/ns/$namespace/logs"
-									params={{
-										organization,
-										project,
-										namespace,
-									}}
-								>
-									<Button
-										variant="outline"
-										size="sm"
-										startIcon={<Icon icon={faLogs} />}
-									>
-										Logs
-									</Button>
-								</Link>
-							) : null}
+							{features.compute ? <NamespaceLogsButton /> : null}
 							<WithTooltip
 								content="Namespace settings"
 								trigger={
@@ -333,7 +299,58 @@ export function NamespaceLandingPending() {
 	);
 }
 
+function NamespaceLogsButton() {
+	const { organization, project, namespace } = useParams({
+		strict: false,
+	}) as {
+		organization: string;
+		project: string;
+		namespace: string;
+	};
+	const dataProvider = useCloudNamespaceDataProvider();
+	const { data: managedPool } = useQuery(
+		dataProvider.currentProjectManagedPoolQueryOptions({
+			namespace,
+			pool: "default",
+			safe: true,
+		}),
+	);
+
+	if (managedPool == null) {
+		return null;
+	}
+
+	return (
+		<Link
+			to="/orgs/$organization/projects/$project/ns/$namespace/logs"
+			params={{
+				organization,
+				project,
+				namespace,
+			}}
+		>
+			<Button
+				variant="outline"
+				size="sm"
+				startIcon={<Icon icon={faLogs} />}
+			>
+				Logs
+			</Button>
+		</Link>
+	);
+}
+
+// The deployments section consumes cloud-namespace data providers, which only
+// exist in the cloud route tree. The wrapper keeps the engine flavor from
+// mounting those hooks at all.
 function DeploymentsSection() {
+	if (!features.compute) {
+		return null;
+	}
+	return <DeploymentsSectionInner />;
+}
+
+function DeploymentsSectionInner() {
 	const { organization, project, namespace } = useParams({
 		strict: false,
 	}) as {
@@ -351,12 +368,11 @@ function DeploymentsSection() {
 			pool: "default",
 			safe: true,
 		}),
-		enabled: features.compute,
 		refetchInterval: (query) => (query.state.data === null ? false : 5_000),
 		refetchOnWindowFocus: (query) => query.state.data !== null,
 	});
 
-	const hasPool = features.compute && managedPool != null;
+	const hasPool = managedPool != null;
 
 	const {
 		data: images,

--- a/frontend/src/app/context-switcher.tsx
+++ b/frontend/src/app/context-switcher.tsx
@@ -139,6 +139,20 @@ function ContextSwitcherInner({
 		);
 	}
 
+	// Engine flavor (/ns/$namespace): a namespace segment plus the actor
+	// segment. The legacy popover below requires an organization param, so it
+	// renders an empty dropdown on engine routes.
+	if (inline && match && "namespace" in match && !("project" in match)) {
+		return (
+			<div className="flex items-center min-w-0">
+				<EngineNamespaceSegmentPopover
+					currentNamespace={match.namespace}
+				/>
+				<ActorBreadcrumbSegment />
+			</div>
+		);
+	}
+
 	return (
 		<Popover open={isOpen} onOpenChange={setIsOpen}>
 			<PopoverTrigger asChild>
@@ -266,6 +280,179 @@ function NamespaceSegmentPopover({
 				/>
 			</PopoverContent>
 		</Popover>
+	);
+}
+
+function EngineNamespaceSegmentPopover({
+	currentNamespace,
+}: {
+	currentNamespace: string;
+}) {
+	const [open, setOpen] = useState(false);
+	const { data: nsData } = useQuery(
+		useEngineCompatDataProvider().namespaceQueryOptions(currentNamespace),
+	);
+	const label = nsData?.displayName ?? currentNamespace;
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<Button
+					variant="ghost"
+					className="flex h-auto items-center gap-1.5 px-2 py-1 text-sm font-medium text-foreground hover:bg-foreground/[0.06]"
+					endIcon={
+						<Icon
+							icon={faChevronDown}
+							className="size-2.5 opacity-60"
+						/>
+					}
+				>
+					<span className="truncate">{label}</span>
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent
+				className="p-0 w-56"
+				align="start"
+				closeAnimation={false}
+			>
+				<EngineNamespaceList
+					currentNamespace={currentNamespace}
+					onClose={() => setOpen(false)}
+				/>
+			</PopoverContent>
+		</Popover>
+	);
+}
+
+function EngineNamespaceList({
+	currentNamespace,
+	onClose,
+}: {
+	currentNamespace: string;
+	onClose?: () => void;
+}) {
+	const { data, hasNextPage, isLoading, isFetchingNextPage, fetchNextPage } =
+		useInfiniteQuery(
+			useEngineCompatDataProvider().namespacesQueryOptions(),
+		);
+	const navigate = useNavigate();
+	const leafFullPath = useMatches({
+		select: (matches) => matches[matches.length - 1]?.fullPath,
+	});
+	const namespaceBase = "/ns/$namespace";
+	const namespaceTo = (
+		typeof leafFullPath === "string" &&
+		leafFullPath.startsWith(namespaceBase)
+			? leafFullPath
+			: namespaceBase
+	) as "/ns/$namespace";
+
+	return (
+		<div className="w-full">
+			<Command loop>
+				<CommandInput placeholder="Find namespace..." />
+				<CommandList
+					className="relative p-1 w-full"
+					defaultValue={currentNamespace}
+				>
+					<CommandGroup heading="Namespaces" className="w-full">
+						{!isLoading ? (
+							<CommandEmpty>No namespaces found.</CommandEmpty>
+						) : null}
+
+						{data
+							?.sort((a, b) => {
+								const aTime = getRecentTimestamp(
+									RECENT_NAMESPACES_KEY,
+									a.name,
+								);
+								const bTime = getRecentTimestamp(
+									RECENT_NAMESPACES_KEY,
+									b.name,
+								);
+								return bTime - aTime;
+							})
+							.map((ns) => {
+								const isCurrent = ns.name === currentNamespace;
+								return (
+									<CommandItem
+										key={ns.id}
+										value={ns.name}
+										keywords={[ns.displayName, ns.name]}
+										className="static w-full"
+										onSelect={() => {
+											onClose?.();
+											// Builds and actors are namespace-scoped, so
+											// drop the current selection and land on the
+											// new namespace's grid.
+											return navigate({
+												to: namespaceTo,
+												params: {
+													namespace: ns.name,
+												},
+												search: (old) => ({
+													...(old as Record<
+														string,
+														unknown
+													>),
+													actorId: undefined,
+													actorKey: undefined,
+													n: undefined,
+												}),
+											});
+										}}
+									>
+										<Icon
+											icon={faCheck}
+											className={cn(
+												"mr-2 size-3 shrink-0 text-primary",
+												isCurrent
+													? "opacity-100"
+													: "opacity-0",
+											)}
+										/>
+										<span className="truncate flex-1">
+											{ns.displayName}
+										</span>
+									</CommandItem>
+								);
+							})}
+						{isLoading || isFetchingNextPage ? (
+							<>
+								<ListItemSkeleton />
+								<ListItemSkeleton />
+								<ListItemSkeleton />
+							</>
+						) : null}
+
+						<CommandItem
+							keywords={["create", "new", "namespace"]}
+							className="text-primary"
+							onSelect={() => {
+								onClose?.();
+								return navigate({
+									to: ".",
+									search: (old) => ({
+										...old,
+										modal: "create-ns",
+									}),
+								});
+							}}
+						>
+							<Icon
+								icon={faPlus}
+								className="mr-2 size-3 text-primary"
+							/>
+							New Namespace
+						</CommandItem>
+
+						{hasNextPage && !isFetchingNextPage ? (
+							<VisibilitySensor onChange={fetchNextPage} />
+						) : null}
+					</CommandGroup>
+				</CommandList>
+			</Command>
+		</div>
 	);
 }
 

--- a/frontend/src/components/actors/actors-list.tsx
+++ b/frontend/src/components/actors/actors-list.tsx
@@ -464,9 +464,25 @@ function EmptyState({ count }: { count: number }) {
 						No Actor Name selected.
 						<br />
 						<span className="text-sm text-muted-foreground">
-							Select an Actor Name from the list on the left.
+							Pick an Actor Name to see its instances.
 						</span>
 					</p>
+					<Button
+						variant="outline"
+						onClick={() =>
+							navigate({
+								to: ".",
+								search: (prev) => ({
+									...prev,
+									n: undefined,
+									actorId: undefined,
+									actorKey: undefined,
+								}),
+							})
+						}
+					>
+						Browse Actor Names
+					</Button>
 				</div>
 			) : count === 0 ? (
 				filtersCount === 0 ? (

--- a/frontend/src/routes/_context/ns.$namespace/index.tsx
+++ b/frontend/src/routes/_context/ns.$namespace/index.tsx
@@ -1,9 +1,12 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
 import {
 	CatchBoundary,
 	createFileRoute,
 	redirect,
 } from "@tanstack/react-router";
 import { Actors } from "@/app/actors";
+import { ActorsGrid } from "@/app/actors-grid";
+import { useEngineNamespaceDataProvider } from "@/components/actors";
 
 export const Route = createFileRoute("/_context/ns/$namespace/")({
 	component: RouteComponent,
@@ -40,17 +43,22 @@ export const Route = createFileRoute("/_context/ns/$namespace/")({
 			return;
 		}
 
-		const builds = await context.queryClient.fetchInfiniteQuery(
-			dataProvider.buildsQueryOptions(),
-		);
-		const firstBuildId = Object.keys(builds.pages[0]?.names ?? {})[0];
+		const n: string[] = deps.n || [];
 
-		if (!firstBuildId) {
-			await runnerPrefetch;
+		// Without a selected actor name, render the grid landing instead of
+		// auto-redirecting into the first build's instances.
+		if (!n[0]) {
+			await Promise.all([
+				runnerPrefetch,
+				context.queryClient.prefetchQuery(
+					dataProvider.currentNamespaceQueryOptions(),
+				),
+				context.queryClient.prefetchInfiniteQuery(
+					dataProvider.buildsQueryOptions(),
+				),
+			]);
 			return;
 		}
-
-		const n = [firstBuildId];
 
 		const [actors] = await Promise.all([
 			context.queryClient.fetchInfiniteQuery(
@@ -72,14 +80,46 @@ export const Route = createFileRoute("/_context/ns/$namespace/")({
 			replace: true,
 		});
 	},
+	pendingComponent: PendingComponent,
 });
 
 export function RouteComponent() {
-	const { actorId } = Route.useSearch();
+	const search = Route.useSearch() as Record<string, unknown>;
+	const actorId = search.actorId as string | undefined;
+	const actorKey = search.actorKey as string | undefined;
+	const n = search.n as string[] | undefined;
+	const hasSelection = !!(actorId || actorKey || n?.length);
 
+	if (!hasSelection) {
+		return <NamespaceLanding />;
+	}
+
+	const id = actorKey ?? actorId;
 	return (
-		<CatchBoundary getResetKey={() => actorId ?? "no-actor-id"}>
-			<Actors actorId={actorId} />
+		<CatchBoundary getResetKey={() => id ?? "no-actor-id"}>
+			<Actors actorId={id} />
 		</CatchBoundary>
 	);
+}
+
+function NamespaceLanding() {
+	const dataProvider = useEngineNamespaceDataProvider();
+	const { data: namespace } = useSuspenseQuery(
+		dataProvider.currentNamespaceQueryOptions(),
+	);
+
+	return <ActorsGrid namespaceLabel={namespace?.displayName} />;
+}
+
+function PendingComponent() {
+	const search = Route.useSearch() as Record<string, unknown>;
+	const actorId = search.actorId as string | undefined;
+	const actorKey = search.actorKey as string | undefined;
+	const n = search.n as string[] | undefined;
+	const hasSelection = !!(actorId || actorKey || n?.length);
+
+	if (!hasSelection) {
+		return <ActorsGrid.Skeleton />;
+	}
+	return null;
 }


### PR DESCRIPTION
## Problem

The local inspector (`rivet-engine` at `localhost:6420/ui`) is unusable when the route can't auto-select an actor instance. It dead-ends on "No Actor Name selected. Select an Actor Name from the list on the left." with no list anywhere on the page.

The top bar redesign (#5064) removed the old left sidebar and gave the cloud flavor replacements (the `ActorsGrid` namespace landing + breadcrumb segment popovers), but the engine flavor never got them:

- The engine `/ns/$namespace/` index route still auto-redirected into the first build's first actor and fell through to a dead-end empty state when there was none.
- `ActorsGrid` unconditionally called `useCloudNamespaceDataProvider()`, which throws outside the cloud route tree, so it couldn't be reused.
- The top bar's namespace dropdown opened an empty popover on engine routes (its content requires an organization param), and the actor-name breadcrumb segment never rendered for the engine match.

## Fix

Mirror the cloud flavor in the engine flavor:

- **`routes/_context/ns.$namespace/index.tsx`** — render the `ActorsGrid` landing when no actor name is selected (with a skeleton pending component), and only auto-select the first instance of the *selected* name. This also fixes a latent bug where selecting a name redirected into the **first** build's actor instead of the selected one.
- **`app/actors-grid.tsx`** — make the grid engine-safe: move the managed-pool Logs button and the Deployments section behind `features.compute` wrappers so cloud-only data provider hooks never mount in the engine flavor.
- **`app/context-switcher.tsx`** — add an engine branch to the inline context switcher: a namespace segment popover (find/switch/create, backed by the engine data provider, preserving the leaf route and clearing the namespace-scoped actor selection) plus the existing `ActorBreadcrumbSegment`.
- **`components/actors/actors-list.tsx`** — replace the stale "list on the left" copy with a "Browse Actor Names" button that navigates to the grid landing.

## Verification

Stood up the engine flavor end-to-end (published `rivet-engine` binary on 6420, rivetkit fixture app registering `counter` with 2 instances and `chatRoom` with 0, dev server in engine flavor, driven by Playwright):

- Landing at `/ns/default` shows the grid with both actor names.
- Clicking `chatRoom` (zero instances — the previously broken case) shows the "No actors created" quickstart instead of the dead-end.
- Clicking `counter` auto-opens its first instance.
- Top bar `Default / counter` popovers both work (namespace list was previously an empty box).
- `pnpm check-types` passes, biome findings on touched files are identical to main, and the production `build:engine` embedded build compiles.