### PR TITLE
fix(guard): only echo rivet websocket subprotocol when client offers it

### DIFF
--- a/engine/packages/guard-core/src/proxy_service.rs
+++ b/engine/packages/guard-core/src/proxy_service.rs
@@ -43,6 +43,24 @@ pub const X_RIVET_ERROR: HeaderName = HeaderName::from_static("x-rivet-error");
 const PROXY_STATE_CACHE_TTL: Duration = Duration::from_secs(60 * 60); // 1 hour
 const WEBSOCKET_CLOSE_LINGER: Duration = Duration::from_millis(5); // Keep TCP connection open briefly after WebSocket close
 
+// The WebSocket subprotocol that Rivet clients offer and the gateway speaks.
+const RIVET_WS_SUBPROTOCOL: &str = "rivet";
+
+// Returns whether the client offered the `rivet` WebSocket subprotocol in its
+// `Sec-WebSocket-Protocol` request header. Per RFC 6455 a server may only select
+// a subprotocol the client offered, and browsers reject a handshake response that
+// echoes an unsolicited subprotocol. Non-Rivet raw clients (for example tldraw's
+// `useSync`) connect without offering `rivet`, so the gateway must only echo it
+// when the client actually offered it.
+fn client_offered_rivet_subprotocol(headers: &hyper::HeaderMap) -> bool {
+	headers
+		.get_all(hyper::header::SEC_WEBSOCKET_PROTOCOL)
+		.iter()
+		.filter_map(|value| value.to_str().ok())
+		.flat_map(|value| value.split(','))
+		.any(|proto| proto.trim() == RIVET_WS_SUBPROTOCOL)
+}
+
 // State shared across all request handlers
 pub struct ProxyState {
 	config: rivet_config::Config,
@@ -543,12 +561,17 @@ impl ProxyService {
 							// Extract the parts from the response but preserve all headers and status
 							let (mut parts, _) = client_response.into_parts();
 
-							// Add Sec-WebSocket-Protocol header to the response
-							// Many WebSocket clients (e.g. node-ws & Cloudflare) require a protocol in the response
-							parts.headers.insert(
-								"sec-websocket-protocol",
-								hyper::header::HeaderValue::from_static("rivet"),
-							);
+							// Echo the Sec-WebSocket-Protocol header only when the client
+							// offered the `rivet` subprotocol. Many WebSocket clients (e.g.
+							// node-ws & Cloudflare) require a protocol in the response, but
+							// browsers reject a response that echoes a subprotocol the client
+							// did not offer.
+							if client_offered_rivet_subprotocol(&req_ctx.headers) {
+								parts.headers.insert(
+									"sec-websocket-protocol",
+									hyper::header::HeaderValue::from_static(RIVET_WS_SUBPROTOCOL),
+								);
+							}
 
 							// Create a new response with an empty body - WebSocket upgrades don't need a body
 							Response::from_parts(
@@ -1860,12 +1883,16 @@ impl ProxyService {
 		// Extract the parts from the response but preserve all headers and status
 		let (mut parts, _) = client_response.into_parts();
 
-		// Add Sec-WebSocket-Protocol header to the response
-		// Many WebSocket clients (e.g. node-ws & Cloudflare) require a protocol in the response
-		parts.headers.insert(
-			"sec-websocket-protocol",
-			hyper::header::HeaderValue::from_static("rivet"),
-		);
+		// Echo the Sec-WebSocket-Protocol header only when the client offered the
+		// `rivet` subprotocol. Many WebSocket clients (e.g. node-ws & Cloudflare)
+		// require a protocol in the response, but browsers reject a response that
+		// echoes a subprotocol the client did not offer.
+		if client_offered_rivet_subprotocol(&req_ctx.headers) {
+			parts.headers.insert(
+				"sec-websocket-protocol",
+				hyper::header::HeaderValue::from_static(RIVET_WS_SUBPROTOCOL),
+			);
+		}
 
 		// Create a new response with an empty body - WebSocket upgrades don't need a body
 		Ok(Response::from_parts(

--- a/engine/packages/guard/src/routing/pegboard_gateway/mod.rs
+++ b/engine/packages/guard/src/routing/pegboard_gateway/mod.rs
@@ -810,25 +810,21 @@ fn read_gateway_token_for_path_based<'a>(
 	}
 
 	if req_ctx.is_websocket() {
-		let protocols_header = req_ctx
+		// The gateway token may be supplied via the `rivet_token.*` entry in the
+		// sec-websocket-protocol header. It is optional: a plain browser WebSocket
+		// client (for example tldraw's `useSync`) connects without offering any
+		// subprotocol, so the absence of the header simply means no token. Auth, if
+		// required, is enforced downstream; do not reject the upgrade here.
+		Ok(req_ctx
 			.headers()
 			.get(SEC_WEBSOCKET_PROTOCOL)
 			.and_then(|protocols| protocols.to_str().ok())
-			.ok_or_else(|| {
-				crate::errors::MissingHeader {
-					header: "sec-websocket-protocol".to_string(),
-				}
-				.build()
-			})?;
-
-		let protocols = protocols_header
-			.split(',')
-			.map(|p| p.trim())
-			.collect::<Vec<&str>>();
-
-		Ok(protocols
-			.iter()
-			.find_map(|p| p.strip_prefix(WS_PROTOCOL_TOKEN)))
+			.and_then(|protocols_header| {
+				protocols_header
+					.split(',')
+					.map(|p| p.trim())
+					.find_map(|p| p.strip_prefix(WS_PROTOCOL_TOKEN))
+			}))
 	} else {
 		req_ctx
 			.headers()


### PR DESCRIPTION
## Problem

Browser WebSocket clients that connect to the actor gateway with a **plain** `WebSocket` (no `rivet` subprotocol) cannot connect. Two issues in the guard:

1. **Unsolicited subprotocol echo.** The gateway unconditionally added `Sec-WebSocket-Protocol: rivet` to the handshake response (`guard-core/proxy_service.rs`, both the normal and error-proxy upgrade paths). Per RFC 6455 a server may only select a subprotocol the client offered, and browsers reject a handshake response that echoes an unsolicited one. RivetKit's own browser clients offer `rivet`, so they were unaffected, but any non-RivetKit raw client (e.g. tldraw's `useSync`) was rejected by the browser with:

   > Error during WebSocket handshake: Response must not include 'Sec-WebSocket-Protocol' header if not present in request: rivet

2. **Mandatory subprotocol header on the query-gateway path.** `read_gateway_token_for_path_based` (used by the `?rvt-method=...` query routing path) required a `Sec-WebSocket-Protocol` header purely to look for an optional `rivet_token.*` entry, throwing `missing_header` when absent. The gateway token is optional (auth, when required, is enforced downstream), so a plain browser client with no token was rejected before the upgrade completed.

## Fix

- Echo `Sec-WebSocket-Protocol: rivet` only when the client actually offered it (new `client_offered_rivet_subprotocol` helper, applied at both upgrade sites).
- Make `read_gateway_token_for_path_based` treat the subprotocol header as optional for WebSockets: return `None` (no token) when it is absent instead of erroring.

The query-gateway path already routes by URL (`/gateway/{name}?rvt-namespace=...&rvt-method=getOrCreate&rvt-key=...`), so no subprotocol is needed for routing. RivetKit clients that offer `rivet` are unchanged (they still get the echo).

## Validation

Verified end-to-end against a local build of this branch: a tldraw multiplayer whiteboard (plain `useSync` browser WebSocket → query gateway → actor `onWebSocket` hosting `TLSocketRoom`) connects, and edits sync bidirectionally between two browser sessions with live presence. Before this change the handshake was rejected by the browser; after it, the WebSocket connects and routes to the actor.