### PR TITLE
fix(publish): apply publishConfig manifest overrides under npm publish

### DIFF
--- a/rivetkit-typescript/packages/effect/package.json
+++ b/rivetkit-typescript/packages/effect/package.json
@@ -18,7 +18,10 @@
 	"publishConfig": {
 		"access": "public",
 		"exports": {
-			".": "./dist/mod.js"
+			".": {
+				"types": "./dist/mod.d.ts",
+				"default": "./dist/mod.js"
+			}
 		}
 	},
 	"scripts": {

--- a/scripts/publish/src/lib/version.ts
+++ b/scripts/publish/src/lib/version.ts
@@ -36,6 +36,65 @@ interface PackageJson {
 	devDependencies?: Record<string, string>;
 	peerDependencies?: Record<string, string>;
 	optionalDependencies?: Record<string, string>;
+	publishConfig?: Record<string, unknown>;
+	[key: string]: unknown;
+}
+
+/**
+ * Manifest-shape fields that `publishConfig` is allowed to override. These
+ * describe what the package exposes (entry points, types) rather than how the
+ * publish is performed, so they must be folded into the top-level manifest
+ * before packing. Mirrors the set pnpm relocates from `publishConfig`.
+ *
+ * npm-native publish controls (`access`, `registry`, `tag`, `provenance`,
+ * `directory`, ...) are intentionally NOT in this list: npm reads those from
+ * `publishConfig` directly, so they stay put.
+ */
+const PUBLISH_CONFIG_MANIFEST_FIELDS = [
+	"bin",
+	"main",
+	"module",
+	"exports",
+	"types",
+	"typings",
+	"browser",
+	"esnext",
+	"es2015",
+	"unpkg",
+	"umd:main",
+	"typesVersions",
+] as const;
+
+/**
+ * Fold manifest-shape `publishConfig` overrides into the top-level manifest.
+ *
+ * `publishConfig.exports` (and friends) are a pnpm feature: pnpm rewrites the
+ * manifest when it packs the tarball. Plain `npm publish` ignores them, so a
+ * package that ships dev source via `exports` and swaps to `dist` via
+ * `publishConfig.exports` would publish the dev entry instead. Because CI
+ * publishes with `npm publish`, we reproduce pnpm's behavior here at
+ * publish time so the dist swap actually lands in the tarball.
+ *
+ * Returns the list of folded field names (empty if there was nothing to do).
+ */
+function applyPublishConfigOverrides(pkgJson: PackageJson): string[] {
+	const publishConfig = pkgJson.publishConfig;
+	if (!publishConfig) return [];
+
+	const folded: string[] = [];
+	for (const field of PUBLISH_CONFIG_MANIFEST_FIELDS) {
+		if (!Object.hasOwn(publishConfig, field)) continue;
+		pkgJson[field] = publishConfig[field];
+		delete publishConfig[field];
+		folded.push(field);
+	}
+
+	// Drop an emptied publishConfig so the published manifest stays clean.
+	if (Object.keys(publishConfig).length === 0) {
+		delete pkgJson.publishConfig;
+	}
+
+	return folded;
 }
 
 const DEP_FIELDS = [
@@ -117,6 +176,16 @@ export async function bumpPackageJsons(
 		pkgJson.version = version;
 
 		if (!versionOnly) {
+			// Fold manifest-shape publishConfig overrides (e.g. exports -> dist)
+			// into the top-level manifest. npm publish ignores publishConfig
+			// manifest fields, so without this the dev source entry would ship.
+			const folded = applyPublishConfigOverrides(pkgJson);
+			if (folded.length > 0) {
+				log.info(
+					`folded publishConfig into ${pkg.name}: ${folded.join(", ")}`,
+				);
+			}
+
 			// Inject optionalDependencies on meta packages so end users get the
 			// correct platform-specific binary via npm's os/cpu/libc resolution.
 			const platformPkgs = metaPlatformMap.get(pkg.name);


### PR DESCRIPTION
## Problem

Every published version of `@rivetkit/effect` has its top-level `exports["."]` pointing at `./src/mod.ts` (raw TS source) instead of `./dist`. The package's `package.json` intends the dist path via `publishConfig.exports`, but that override never lands in the published tarball.

**Root cause:** `publishConfig` manifest overrides like `exports` are effectively a pnpm feature. pnpm rewrites the manifest when it packs the tarball; plain `npm publish` ignores them. Our CI publishes with `npm publish` (`scripts/publish/src/lib/npm.ts` spawns `npm publish` per package), so the dev `src` entry ships instead of the `dist` swap. All published versions of `@rivetkit/effect` confirm this (`exports["."] = "./src/mod.ts"`).

### Impact

Runtime in Bun/Deno/tsx is fine (they execute `.ts` directly) and bundlers don't deep-type-check deps, so most consumers never see it. It breaks consumers running a strict whole-program `tsc --noEmit`: under `moduleResolution: bundler` the entry resolves to our `src/*.ts`, which then gets compiled under the consumer's tsconfig and errors. `skipLibCheck` doesn't help (it skips `.d.ts`, not `.ts` reached via `exports`), and the shipped `dist/*.d.ts` is never used.

Thanks to the external consumer who reported this (their workaround was a `bun patch` rewriting `exports` to the dist conditional).

## Fix

Make the `publishConfig` → dist swap actually apply at publish time, centrally, so it works under `npm publish` and covers any future `@rivetkit/*` package using the same pattern.

1. **`scripts/publish/src/lib/version.ts`** — `bumpPackageJsons` (the publish-time, non-`versionOnly` rewrite that CI runs on disk immediately before `npm publish`) now folds manifest-shape `publishConfig` fields (`exports`, `main`, `types`, `bin`, ...) into the top-level manifest, mirroring pnpm's behavior. npm-native publish controls (`access`, `registry`, `tag`, `provenance`, ...) are intentionally left in `publishConfig` so npm still reads them.

2. **`rivetkit-typescript/packages/effect/package.json`** — make `publishConfig.exports` an explicit conditional with a `types` condition (`{ "types": "./dist/mod.d.ts", "default": "./dist/mod.js" }`) so strict-tsc consumers resolve the shipped declarations.

This preserves the effect package's deliberate `.ts`-native dev experience (source `exports` in the working tree, `rewriteRelativeImportExtensions`, `@effect/language-service`) while ensuring the published tarball ships the dist entry.

### Why not `pnpm publish` or a per-package `prepack`?

Switching the whole publish path to `pnpm publish` is a broad, riskier infra change (different workspace-dep handling). A `prepack` script would have to be added per package and mutate `package.json` on disk with a matching `postpack` restore. The publish system already rewrites every manifest on disk at publish time (non-committed), so folding `publishConfig` there is the smallest, most robust hook and generalizes to all packages.

### Verification

Replicated the fold against the real effect manifest. Published `exports` becomes `{ ".": { "types": "./dist/mod.d.ts", "default": "./dist/mod.js" } }` and `publishConfig` correctly retains only `{ "access": "public" }`. The full-mode bump runs after the TS build step in `publish.yaml`, so `dist/mod.js` / `dist/mod.d.ts` exist when the manifest is finalized.