### PR TITLE
docs(blog): recategorize world's fastest package manager post as technical

### DIFF
--- a/website/src/content/posts/2026-07-06-introducing-the-agentos-package-registry/page.mdx
+++ b/website/src/content/posts/2026-07-06-introducing-the-agentos-package-registry/page.mdx
@@ -36,7 +36,7 @@ Instead, agentOS packages install in **130µs**. That's **1,900× faster than ap
 
 agentOS mounts the package straight into the VM's filesystem, with zero I/O. Adding packages never touches your cold start, so your agents stay fast no matter how much you install.
 
-For the full breakdown of how this works, read [Building the World's Fastest Package Manager with agentOS](/changelog/2026-07-07-worlds-fastest-package-manager).
+For the full breakdown of how this works, read [Building the World's Fastest Package Manager with agentOS](/blog/2026-07-07-worlds-fastest-package-manager).
 
 ## What the registry provides
 

--- a/website/src/content/posts/2026-07-07-worlds-fastest-package-manager/page.mdx
+++ b/website/src/content/posts/2026-07-07-worlds-fastest-package-manager/page.mdx
@@ -2,7 +2,7 @@
 image: true
 author: nathan-flurry
 published: "2026-07-07"
-category: changelog
+category: technical
 keywords: ["agentos", "package manager", "130µs installs", "mmap", "tar", "filesystem"]
 title: "Building the World's Fastest Package Manager with agentOS"
 description: "agentOS packages install in 130µs, here's how we did it."
@@ -26,7 +26,7 @@ We benchmarked how long that actually takes. Installing `git` offline takes **0.
 
 ![git install time by phase](https://assets.rivet.dev/website/blog/2026-07-07-worlds-fastest-package-manager/install-benchmark.png)
 
-[[Source](https://github.com/rivet-dev/linux-package-manager-bench)]
+[[Benchmarks](https://github.com/rivet-dev/linux-package-manager-bench)]
 
 For your dev machine, these times are fine.
 


### PR DESCRIPTION
- Recategorize the world's fastest package manager post from `changelog` to `technical` (moves its URL from /changelog to /blog)
- Update the registry post's cross-link to the new /blog path
- Rename the benchmark source link label from Source to Benchmarks