### PR TITLE
feat(rivetkit): add actor onError hook

### DIFF
--- a/rivetkit-rust/packages/rivetkit-core/src/actor/context.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/actor/context.rs
@@ -25,6 +25,9 @@ use crate::actor::connection::{
 	hibernatable_id_from_slice,
 };
 use crate::actor::diagnostics::ActorDiagnostics;
+use crate::actor::error_report::{
+	ActorErrorEvent, ErrorReport, HookName, InternalErrorKind, OnErrorHook, RawErrorRef,
+};
 use crate::actor::lifecycle_hooks::Reply;
 use crate::actor::messages::{ActorEvent, Request, StateDelta};
 use crate::actor::metrics::ActorMetrics;
@@ -81,6 +84,8 @@ pub(crate) struct ActorContextInner {
 	// Forced-sync: hooks are registered and cloned from synchronous runtime
 	// wiring slots before use.
 	pub(super) request_save_hooks: RwLock<Vec<Arc<dyn Fn(RequestSaveOpts) + Send + Sync>>>,
+	pub(super) on_error_hook: RwLock<Option<OnErrorHook>>,
+	pub(super) error_report_in_flight: AtomicBool,
 	// Forced-sync: schedule runtime handles and callbacks are synchronous
 	// wiring slots cloned before actor/envoy I/O.
 	pub(super) schedule_generation: Mutex<Option<u32>>,
@@ -264,6 +269,8 @@ impl ActorContext {
 			on_state_change_in_flight: AtomicUsize::new(0),
 			on_state_change_idle: Notify::new(),
 			request_save_hooks: RwLock::new(Vec::new()),
+			on_error_hook: RwLock::new(None),
+			error_report_in_flight: AtomicBool::new(false),
 			schedule_generation: Mutex::new(None),
 			schedule_envoy_handle: Mutex::new(None),
 			client_endpoint: OnceLock::new(),
@@ -677,6 +684,45 @@ impl ActorContext {
 		}
 	}
 
+	pub fn on_error(&self, hook: OnErrorHook) {
+		*self.0.on_error_hook.write() = Some(hook);
+	}
+
+	pub fn report_error(&self, event: ActorErrorEvent, error: &anyhow::Error) {
+		let Some(hook) = self.0.on_error_hook.read().clone() else {
+			return;
+		};
+		if is_suppressed_error(error) {
+			return;
+		}
+		if self
+			.0
+			.error_report_in_flight
+			.compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+			.is_err()
+		{
+			return;
+		}
+
+		let event = event.override_with_hook_marker(error);
+		let extracted = rivet_error::RivetError::extract(error);
+		let raw_error_ref = error
+			.chain()
+			.find_map(|cause| cause.downcast_ref::<RawErrorRef>())
+			.map(|raw| raw.0);
+		hook(ErrorReport {
+			event,
+			group: extracted.group().to_owned(),
+			code: extracted.code().to_owned(),
+			message: extracted.message().to_owned(),
+			metadata: extracted.metadata(),
+			raw_error_ref,
+		});
+		self.0
+			.error_report_in_flight
+			.store(false, Ordering::Release);
+	}
+
 	pub fn region(&self) -> &str {
 		&self.0.region
 	}
@@ -864,6 +910,7 @@ impl ActorContext {
 		event: ActorEvent,
 		operation: &'static str,
 	) -> Result<()> {
+		let event = event.with_error_reporting(self, operation == "scheduled_action");
 		let sender = self.0.actor_events.read().clone().ok_or_else(|| {
 			ActorRuntime::NotConfigured {
 				component: "actor event inbox".to_owned(),
@@ -1532,6 +1579,13 @@ impl ActorContext {
 						);
 					}
 					Err(error) => {
+						let report_error = anyhow::anyhow!("scheduled event reply dropped: {error}");
+						ctx.report_error(
+							ActorErrorEvent::Internal {
+								kind: InternalErrorKind::Alarm,
+							},
+							&report_error,
+						);
 						tracing::error!(
 							?error,
 							event_id,
@@ -1541,6 +1595,12 @@ impl ActorContext {
 					}
 				},
 				Err(error) => {
+					ctx.report_error(
+						ActorErrorEvent::Internal {
+							kind: InternalErrorKind::Alarm,
+						},
+						&error,
+					);
 					tracing::error!(
 						?error,
 						event_id,
@@ -1714,6 +1774,38 @@ impl std::fmt::Debug for ActorContext {
 			.field("region", &self.0.region)
 			.finish()
 	}
+}
+
+impl ActorErrorEvent {
+	fn override_with_hook_marker(self, error: &anyhow::Error) -> Self {
+		let Some(hook_name) = error
+			.chain()
+			.find_map(|cause| cause.downcast_ref::<HookName>())
+			.map(|hook| hook.0)
+		else {
+			return self;
+		};
+
+		match self {
+			Self::Action { .. } | Self::Queue { .. } | Self::Internal { .. } => self,
+			Self::Hook { .. } | Self::Fatal { .. } => Self::Hook {
+				name: hook_name.to_owned(),
+			},
+		}
+	}
+}
+
+fn is_suppressed_error(error: &anyhow::Error) -> bool {
+	let extracted = rivet_error::RivetError::extract(error);
+	matches!(
+		(extracted.group(), extracted.code()),
+		("actor", "aborted")
+			| ("actor", "starting")
+			| ("actor", "not_ready")
+			| ("actor", "stopping")
+			| ("actor", "destroying")
+			| ("actor", "action_not_found")
+	)
 }
 
 // Test shim keeps moved tests in crate-root tests/ with private-module access.

--- a/rivetkit-rust/packages/rivetkit-core/src/actor/error_report.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/actor/error_report.rs
@@ -1,0 +1,62 @@
+use std::fmt;
+use std::sync::Arc;
+
+use serde::Serialize;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ActorErrorEvent {
+	Action { name: String, scheduled: bool },
+	Hook { name: String },
+	Queue { name: String },
+	Internal { kind: InternalErrorKind },
+	Fatal { phase: FatalPhase },
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum InternalErrorKind {
+	Persist,
+	Alarm,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum FatalPhase {
+	Run,
+	Shutdown,
+}
+
+#[derive(Clone, Debug)]
+pub struct ErrorReport {
+	pub event: ActorErrorEvent,
+	pub group: String,
+	pub code: String,
+	pub message: String,
+	pub metadata: Option<serde_json::Value>,
+	pub raw_error_ref: Option<u64>,
+}
+
+pub type OnErrorHook = Arc<dyn Fn(ErrorReport) + Send + Sync>;
+
+#[derive(Debug)]
+pub struct HookName(pub &'static str);
+
+impl fmt::Display for HookName {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.write_str(self.0)
+	}
+}
+
+impl std::error::Error for HookName {}
+
+#[derive(Debug)]
+pub struct RawErrorRef(pub u64);
+
+impl fmt::Display for RawErrorRef {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "raw error ref {}", self.0)
+	}
+}
+
+impl std::error::Error for RawErrorRef {}

--- a/rivetkit-rust/packages/rivetkit-core/src/actor/lifecycle_hooks.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/actor/lifecycle_hooks.rs
@@ -3,17 +3,38 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::actor::connection::ConnHandle;
 use crate::actor::context::ActorContext;
+use crate::actor::error_report::ActorErrorEvent;
 use crate::actor::messages::ActorEvent;
 
 pub struct Reply<T> {
 	tx: Option<oneshot::Sender<Result<T>>>,
+	error_reporter: Option<ReplyErrorReporter>,
+}
+
+struct ReplyErrorReporter {
+	ctx: ActorContext,
+	event: ActorErrorEvent,
 }
 
 impl<T> Reply<T> {
 	pub fn send(mut self, result: Result<T>) {
 		if let Some(tx) = self.tx.take() {
+			if let Err(error) = &result {
+				if let Some(reporter) = &self.error_reporter {
+					reporter.ctx.report_error(reporter.event.clone(), error);
+				}
+			}
 			let _ = tx.send(result);
 		}
+	}
+
+	pub(crate) fn with_error_reporter(
+		mut self,
+		ctx: ActorContext,
+		event: ActorErrorEvent,
+	) -> Self {
+		self.error_reporter = Some(ReplyErrorReporter { ctx, event });
+		self
 	}
 }
 
@@ -35,7 +56,10 @@ impl<T> std::fmt::Debug for Reply<T> {
 
 impl<T> From<oneshot::Sender<Result<T>>> for Reply<T> {
 	fn from(tx: oneshot::Sender<Result<T>>) -> Self {
-		Self { tx: Some(tx) }
+		Self {
+			tx: Some(tx),
+			error_reporter: None,
+		}
 	}
 }
 

--- a/rivetkit-rust/packages/rivetkit-core/src/actor/messages.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/actor/messages.rs
@@ -5,6 +5,8 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::actor::connection::ConnHandle;
+use crate::actor::context::ActorContext;
+use crate::actor::error_report::{ActorErrorEvent, InternalErrorKind};
 use crate::actor::lifecycle_hooks::Reply;
 use crate::actor::task_types::ShutdownKind;
 use crate::error::ProtocolError;
@@ -341,6 +343,167 @@ pub enum ActorEvent {
 }
 
 impl ActorEvent {
+	pub(crate) fn with_error_reporting(
+		self,
+		ctx: &ActorContext,
+		scheduled_action: bool,
+	) -> Self {
+		match self {
+			Self::Action {
+				name,
+				args,
+				conn,
+				reply,
+			} => {
+				let event = ActorErrorEvent::Action {
+					name: name.clone(),
+					scheduled: scheduled_action,
+				};
+				Self::Action {
+					name,
+					args,
+					conn,
+					reply: reply.with_error_reporter(ctx.clone(), event),
+				}
+			}
+			Self::HttpRequest { request, reply } => Self::HttpRequest {
+				request,
+				reply: reply.with_error_reporter(
+					ctx.clone(),
+					ActorErrorEvent::Hook {
+						name: "onRequest".to_owned(),
+					},
+				),
+			},
+			Self::QueueSend {
+				name,
+				body,
+				conn,
+				request,
+				wait,
+				timeout_ms,
+				reply,
+			} => {
+				let event = ActorErrorEvent::Queue { name: name.clone() };
+				Self::QueueSend {
+					name,
+					body,
+					conn,
+					request,
+					wait,
+					timeout_ms,
+					reply: reply.with_error_reporter(ctx.clone(), event),
+				}
+			}
+			Self::WebSocketOpen {
+				conn,
+				ws,
+				request,
+				reply,
+			} => Self::WebSocketOpen {
+				conn,
+				ws,
+				request,
+				reply: reply.with_error_reporter(
+					ctx.clone(),
+					ActorErrorEvent::Hook {
+						name: "onWebSocket".to_owned(),
+					},
+				),
+			},
+			Self::ConnectionPreflight {
+				conn,
+				params,
+				request,
+				reply,
+			} => Self::ConnectionPreflight {
+				conn,
+				params,
+				request,
+				reply: reply.with_error_reporter(
+					ctx.clone(),
+					ActorErrorEvent::Hook {
+						name: "onBeforeConnect".to_owned(),
+					},
+				),
+			},
+			Self::ConnectionOpen {
+				conn,
+				request,
+				reply,
+			} => Self::ConnectionOpen {
+				conn,
+				request,
+				reply: reply.with_error_reporter(
+					ctx.clone(),
+					ActorErrorEvent::Hook {
+						name: "onConnect".to_owned(),
+					},
+				),
+			},
+			Self::SubscribeRequest {
+				conn,
+				event_name,
+				reply,
+			} => Self::SubscribeRequest {
+				conn,
+				event_name,
+				reply: reply.with_error_reporter(
+					ctx.clone(),
+					ActorErrorEvent::Hook {
+						name: "onBeforeSubscribe".to_owned(),
+					},
+				),
+			},
+			Self::SerializeState { reason, reply } => {
+				let reply = if reason == SerializeStateReason::Save {
+					reply.with_error_reporter(
+						ctx.clone(),
+						ActorErrorEvent::Internal {
+							kind: InternalErrorKind::Persist,
+						},
+					)
+				} else {
+					reply
+				};
+				Self::SerializeState { reason, reply }
+			}
+			Self::RunGracefulCleanup { reason, reply } => {
+				let name = match reason {
+					ShutdownKind::Sleep => "onSleep",
+					ShutdownKind::Destroy => "onDestroy",
+				};
+				Self::RunGracefulCleanup {
+					reason,
+					reply: reply.with_error_reporter(
+						ctx.clone(),
+						ActorErrorEvent::Hook {
+							name: name.to_owned(),
+						},
+					),
+				}
+			}
+			Self::DisconnectConn { conn_id, reply } => Self::DisconnectConn {
+				conn_id,
+				reply: reply.with_error_reporter(
+					ctx.clone(),
+					ActorErrorEvent::Hook {
+						name: "onDisconnect".to_owned(),
+					},
+				),
+			},
+			Self::ConnectionClosed { .. }
+			| Self::WorkflowHistoryRequested { .. }
+			| Self::WorkflowReplayRequested { .. } => self,
+			#[cfg(test)]
+			Self::BeginSleep => self,
+			#[cfg(test)]
+			Self::FinalizeSleep { reply } => Self::FinalizeSleep { reply },
+			#[cfg(test)]
+			Self::Destroy { reply } => Self::Destroy { reply },
+		}
+	}
+
 	pub(crate) fn kind(&self) -> &'static str {
 		match self {
 			Self::Action { .. } => "action",

--- a/rivetkit-rust/packages/rivetkit-core/src/actor/mod.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/actor/mod.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod connection;
 pub mod context;
 pub(crate) mod diagnostics;
+pub mod error_report;
 pub mod factory;
 pub(crate) mod keys;
 pub mod kv;
@@ -24,6 +25,10 @@ pub use action::ActionDispatchError;
 pub use config::{ActionDefinition, ActorConfig, ActorConfigOverrides, CanHibernateWebSocket};
 pub use connection::ConnHandle;
 pub use context::{ActorContext, ActorWorkRegion, KeepAwakeRegion, WebSocketCallbackRegion};
+pub use error_report::{
+	ActorErrorEvent, ErrorReport, FatalPhase, HookName, InternalErrorKind, OnErrorHook,
+	RawErrorRef,
+};
 pub use factory::{ActorEntryFn, ActorFactory};
 pub use kv::Kv;
 pub use lifecycle_hooks::{ActorEvents, ActorStart, Reply};

--- a/rivetkit-rust/packages/rivetkit-core/src/actor/state.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/actor/state.rs
@@ -16,6 +16,7 @@ use tokio::time::timeout;
 use tracing::Instrument;
 
 use crate::actor::context::ActorContext;
+use crate::actor::error_report::{ActorErrorEvent, InternalErrorKind};
 use crate::actor::keys::{LAST_PUSHED_ALARM_KEY, PERSIST_DATA_KEY, make_connection_key};
 use crate::actor::kv::APPLY_BATCH_CHUNK_SIZE;
 use crate::actor::messages::StateDelta;
@@ -631,6 +632,12 @@ impl ActorContext {
 			state.take_pending_save();
 
 			if let Err(error) = state.persist_if_dirty().await {
+				state.report_error(
+					ActorErrorEvent::Internal {
+						kind: InternalErrorKind::Persist,
+					},
+					&error,
+				);
 				tracing::error!(?error, "failed to persist actor state");
 			}
 		}
@@ -671,6 +678,12 @@ impl ActorContext {
 			}
 
 			if let Err(error) = state.persist_state(SaveStateOpts { immediate: true }).await {
+				state.report_error(
+					ActorErrorEvent::Internal {
+						kind: InternalErrorKind::Persist,
+					},
+					&error,
+				);
 				tracing::error!(?error, description, "failed to persist actor state");
 			}
 		}

--- a/rivetkit-rust/packages/rivetkit-core/src/actor/task.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/actor/task.rs
@@ -45,6 +45,7 @@ use tracing::{Instrument, instrument::WithSubscriber};
 use crate::actor::action::ActionDispatchError;
 use crate::actor::connection::ConnHandle;
 use crate::actor::context::ActorContext;
+use crate::actor::error_report::{ActorErrorEvent, FatalPhase, HookName, InternalErrorKind};
 use crate::actor::factory::ActorFactory;
 use crate::actor::keys::{LAST_PUSHED_ALARM_KEY, PERSIST_DATA_KEY};
 use crate::actor::lifecycle_hooks::{ActorEvents, ActorStart, Reply};
@@ -459,6 +460,14 @@ impl ActorTask {
 			Ok(result) => result,
 			Err(_) => Err(anyhow!("shutdown panicked during {reason:?}")),
 		};
+		if let Err(error) = &result {
+			self.ctx.report_error(
+				ActorErrorEvent::Fatal {
+					phase: FatalPhase::Shutdown,
+				},
+				error,
+			);
+		}
 		self.deliver_shutdown_reply(reason, &result);
 		self.transition_to(LifecycleState::Terminated);
 		self.record_inbox_depths();
@@ -1036,6 +1045,7 @@ impl ActorTask {
 	}
 
 	fn send_actor_event(&self, operation: &'static str, event: ActorEvent) -> Result<()> {
+		let event = event.with_error_reporting(&self.ctx, operation == "scheduled_action");
 		let sender = self
 			.actor_event_tx
 			.as_ref()
@@ -1383,10 +1393,23 @@ impl ActorTask {
 			.with_subscriber(run_dispatch),
 		));
 		if let Some(startup_ready_rx) = startup_ready_rx {
-			startup_ready_rx
+			if let Err(error) = startup_ready_rx
 				.await
 				.context("receive runtime startup ready reply")?
-				.context("runtime startup preamble")?;
+			{
+				let event = hook_name_from_error(&error)
+					.map(|hook| ActorErrorEvent::Hook {
+						name: hook.to_owned(),
+					})
+					.unwrap_or(ActorErrorEvent::Fatal {
+						phase: FatalPhase::Run,
+					});
+				self.ctx.report_error(event, &error);
+				if let Some(mut run_handle) = self.run_handle.take() {
+					let _ = (&mut run_handle).await;
+				}
+				return Err(error).context("runtime startup preamble");
+			}
 		}
 		Ok(())
 	}
@@ -1458,10 +1481,25 @@ impl ActorTask {
 		let clean_exit = match outcome {
 			Ok(Ok(())) => true,
 			Ok(Err(error)) => {
+				let event = hook_name_from_error(&error)
+					.map(|hook| ActorErrorEvent::Hook {
+						name: hook.to_owned(),
+					})
+					.unwrap_or(ActorErrorEvent::Fatal {
+						phase: FatalPhase::Run,
+					});
+				self.ctx.report_error(event, &error);
 				log_actor_error(&error, "actor run handler failed");
 				false
 			}
 			Err(error) => {
+				let report_error = anyhow!("actor run handler join failed: {error}");
+				self.ctx.report_error(
+					ActorErrorEvent::Fatal {
+						phase: FatalPhase::Run,
+					},
+					&report_error,
+				);
 				tracing::error!(?error, "actor run handler join failed");
 				false
 			}
@@ -1593,10 +1631,23 @@ impl ActorTask {
 		match (&mut run_handle).await {
 			Ok(Ok(())) => {}
 			Ok(Err(error)) => {
+				self.ctx.report_error(
+					ActorErrorEvent::Fatal {
+						phase: FatalPhase::Run,
+					},
+					&error,
+				);
 				log_actor_error(&error, "actor run handler failed during shutdown");
 			}
 			Err(error) => {
 				if !error.is_cancelled() {
+					let report_error = anyhow!("actor run handler join failed during shutdown: {error}");
+					self.ctx.report_error(
+						ActorErrorEvent::Fatal {
+							phase: FatalPhase::Run,
+						},
+						&report_error,
+					);
 					tracing::error!(?error, "actor run handler join failed during shutdown");
 				}
 			}
@@ -1974,6 +2025,12 @@ impl ActorTask {
 					.save_state_with_revision(deltas, save_request_revision)
 					.await
 				{
+					self.ctx.report_error(
+						ActorErrorEvent::Internal {
+							kind: InternalErrorKind::Persist,
+						},
+						&error,
+					);
 					tracing::error!(?error, "failed to persist actor save tick");
 					self.schedule_state_save(true);
 					self.sync_inspector_serialize_deadline();
@@ -2187,6 +2244,35 @@ impl ActorTask {
 			LifecycleState::Started | LifecycleState::SleepGrace
 		));
 	}
+}
+
+fn hook_name_from_error(error: &anyhow::Error) -> Option<&'static str> {
+	error.chain().find_map(|cause| {
+		if let Some(hook) = cause.downcast_ref::<HookName>() {
+			return Some(hook.0);
+		}
+
+		match cause.to_string().as_str() {
+			"createState" => Some("createState"),
+			"onCreate" => Some("onCreate"),
+			"createVars" => Some("createVars"),
+			"onMigrate" => Some("onMigrate"),
+			"onWake" => Some("onWake"),
+			"onBeforeActorStart" => Some("onBeforeActorStart"),
+			"onSleep" => Some("onSleep"),
+			"onDestroy" => Some("onDestroy"),
+			"onBeforeConnect" => Some("onBeforeConnect"),
+			"onConnect" => Some("onConnect"),
+			"onDisconnect" => Some("onDisconnect"),
+			"onBeforeSubscribe" => Some("onBeforeSubscribe"),
+			"onBeforeActionResponse" => Some("onBeforeActionResponse"),
+			"onRequest" => Some("onRequest"),
+			"onQueueSend" => Some("onQueueSend"),
+			"onWebSocket" => Some("onWebSocket"),
+			"run" => Some("run"),
+			_ => None,
+		}
+	})
 }
 
 fn shutdown_reason_label(reason: ShutdownKind) -> &'static str {

--- a/rivetkit-rust/packages/rivetkit-core/src/lib.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/lib.rs
@@ -120,6 +120,10 @@ pub use actor::config::{
 };
 pub use actor::connection::ConnHandle;
 pub use actor::context::{ActorContext, ActorWorkRegion, KeepAwakeRegion, WebSocketCallbackRegion};
+pub use actor::error_report::{
+	ActorErrorEvent, ErrorReport, FatalPhase, HookName, InternalErrorKind, OnErrorHook,
+	RawErrorRef,
+};
 pub use actor::factory::{ActorEntryFn, ActorFactory};
 pub use actor::kv::Kv;
 pub use actor::lifecycle_hooks::{ActorEvents, ActorStart, Reply};

--- a/rivetkit-typescript/packages/rivetkit-napi/index.d.ts
+++ b/rivetkit-typescript/packages/rivetkit-napi/index.d.ts
@@ -267,6 +267,7 @@ export declare class ActorContext {
   keepAwake(promise: Promise<any>): void
   beginWebsocketCallback(): number
   endWebsocketCallback(regionId: number): void
+  reportError(hookName: string, rawErrorRef?: number | undefined | null): void
   abortSignal(): AbortSignal
   conns(): Array<ConnHandle>
   connectConn(params: Buffer, request?: JsHttpRequest | undefined | null): Promise<ConnHandle>

--- a/rivetkit-typescript/packages/rivetkit-napi/src/actor_context.rs
+++ b/rivetkit-typescript/packages/rivetkit-napi/src/actor_context.rs
@@ -18,8 +18,9 @@ use napi_derive::napi;
 use parking_lot::Mutex;
 use rivetkit_core::types::ActorKeySegment;
 use rivetkit_core::{
-	ActorContext as CoreActorContext, ActorWorkKind, ConnHandle as CoreConnHandle, KeepAwakeRegion,
-	Request as CoreRequest, RequestSaveOpts, StateDelta, WebSocketCallbackRegion,
+	ActorContext as CoreActorContext, ActorErrorEvent, ActorWorkKind,
+	ConnHandle as CoreConnHandle, KeepAwakeRegion, RawErrorRef, Request as CoreRequest,
+	RequestSaveOpts, StateDelta, WebSocketCallbackRegion,
 };
 use scc::HashMap as SccHashMap;
 use tokio::sync::mpsc::UnboundedSender;
@@ -497,6 +498,16 @@ impl ActorContext {
 	#[napi]
 	pub fn end_websocket_callback(&self, region_id: u32) {
 		self.shared.end_websocket_callback(region_id);
+	}
+
+	#[napi]
+	pub fn report_error(&self, hook_name: String, raw_error_ref: Option<i64>) {
+		let mut error = anyhow::anyhow!("actor hook `{hook_name}` failed");
+		if let Some(raw_error_ref) = raw_error_ref.and_then(|value| u64::try_from(value).ok()) {
+			error = error.context(RawErrorRef(raw_error_ref));
+		}
+		self.inner
+			.report_error(ActorErrorEvent::Hook { name: hook_name }, &error);
 	}
 
 	#[napi(ts_return_type = "AbortSignal")]

--- a/rivetkit-typescript/packages/rivetkit-napi/src/actor_factory.rs
+++ b/rivetkit-typescript/packages/rivetkit-napi/src/actor_factory.rs
@@ -4,15 +4,17 @@ use std::time::Duration;
 
 use anyhow::Result;
 use napi::bindgen_prelude::{Buffer, Promise};
-use napi::threadsafe_function::{ErrorStrategy, ThreadSafeCallContext, ThreadsafeFunction};
+use napi::threadsafe_function::{
+	ErrorStrategy, ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode,
+};
 use napi::{Env, JsFunction, JsObject};
 use napi_derive::napi;
 use rivet_error::{ActorSpecifier, RivetError, RivetErrorKind};
 use rivetkit_core::inspector::InspectorTabEntry;
 use rivetkit_core::{
 	ActionDefinition, ActorConfig, ActorConfigInput, ActorContext as CoreActorContext,
-	ActorFactory as CoreActorFactory, ConnHandle as CoreConnHandle, Request, Response,
-	WebSocket as CoreWebSocket,
+	ActorErrorEvent, ActorFactory as CoreActorFactory, ConnHandle as CoreConnHandle, ErrorReport,
+	FatalPhase, InternalErrorKind, RawErrorRef, Request, Response, WebSocket as CoreWebSocket,
 };
 
 use crate::actor_context::{ActorContext, StateDeltaPayload};
@@ -260,6 +262,7 @@ pub(crate) struct CallbackBindings {
 	pub(crate) get_workflow_history: Option<CallbackTsfn<WorkflowHistoryPayload>>,
 	pub(crate) replay_workflow: Option<CallbackTsfn<WorkflowReplayPayload>>,
 	pub(crate) serialize_state: Option<CallbackTsfn<SerializeStatePayload>>,
+	pub(crate) on_error: Option<CallbackTsfn<OnErrorPayload>>,
 }
 
 #[derive(serde::Deserialize)]
@@ -273,6 +276,20 @@ struct BridgeRivetErrorPayload {
 	#[serde(rename = "statusCode")]
 	status_code: Option<u16>,
 	actor: Option<ActorSpecifier>,
+	#[serde(rename = "rawErrorId")]
+	raw_error_id: Option<u64>,
+}
+
+pub(crate) struct OnErrorPayload {
+	identity: OnErrorIdentity,
+	report: ErrorReport,
+}
+
+#[derive(Clone)]
+pub(crate) struct OnErrorIdentity {
+	actor_id: String,
+	name: String,
+	key: String,
 }
 
 #[derive(Debug)]
@@ -311,9 +328,13 @@ impl NapiActorFactory {
 #[napi]
 impl NapiActorFactory {
 	#[napi(constructor)]
-	pub fn constructor(callbacks: JsObject, config: Option<JsActorConfig>) -> napi::Result<Self> {
+	pub fn constructor(
+		env: Env,
+		callbacks: JsObject,
+		config: Option<JsActorConfig>,
+	) -> napi::Result<Self> {
 		crate::init_tracing(None);
-		let bindings = Arc::new(CallbackBindings::from_js(callbacks)?);
+		let bindings = Arc::new(CallbackBindings::from_js(&env, callbacks)?);
 		let js_config = config.unwrap_or_default();
 		tracing::debug!(
 			class = "NapiActorFactory",
@@ -375,7 +396,7 @@ impl AdapterConfig {
 }
 
 impl CallbackBindings {
-	fn from_js(callbacks: JsObject) -> napi::Result<Self> {
+	fn from_js(env: &Env, callbacks: JsObject) -> napi::Result<Self> {
 		let actions = if let Some(actions) = callbacks.get::<_, JsObject>("actions")? {
 			let mut mapped = HashMap::new();
 			for name in JsObject::keys(&actions)? {
@@ -459,6 +480,7 @@ impl CallbackBindings {
 				"serializeState",
 				build_serialize_state_payload,
 			)?,
+			on_error: optional_unref_tsfn(env, &callbacks, "onError", build_on_error_payload)?,
 		})
 	}
 }
@@ -478,6 +500,24 @@ where
 	create_tsfn(callback, build_args).map(Some)
 }
 
+fn optional_unref_tsfn<T, F>(
+	env: &Env,
+	callbacks: &JsObject,
+	name: &str,
+	build_args: F,
+) -> napi::Result<Option<CallbackTsfn<T>>>
+where
+	T: Send + 'static,
+	F: Fn(&Env, T) -> napi::Result<Vec<napi::JsUnknown>> + Send + Sync + 'static,
+{
+	let Some(callback) = callbacks.get::<_, JsFunction>(name)? else {
+		return Ok(None);
+	};
+	let mut callback = create_tsfn(callback, build_args)?;
+	callback.unref(env)?;
+	Ok(Some(callback))
+}
+
 fn create_tsfn<T, F>(callback: JsFunction, build_args: F) -> napi::Result<CallbackTsfn<T>>
 where
 	T: Send + 'static,
@@ -487,6 +527,28 @@ where
 	callback.create_threadsafe_function(0, move |ctx: ThreadSafeCallContext<T>| {
 		build_args(&ctx.env, ctx.value)
 	})
+}
+
+pub(crate) fn configure_on_error_hook(bindings: &Arc<CallbackBindings>, ctx: &CoreActorContext) {
+	let Some(on_error) = bindings.on_error.clone() else {
+		return;
+	};
+	let identity = OnErrorIdentity {
+		actor_id: ctx.actor_id().to_owned(),
+		name: ctx.name().to_owned(),
+		key: rivetkit_core::types::format_actor_key(ctx.key()),
+	};
+	ctx.on_error(Arc::new(move |report| {
+		let payload = OnErrorPayload {
+			identity: identity.clone(),
+			report,
+		};
+		let status = on_error.call(Ok(payload), ThreadsafeFunctionCallMode::NonBlocking);
+		tracing::debug!(?status, "napi onError TSF callback returned");
+		if status != napi::Status::Ok && status != napi::Status::Closing {
+			tracing::warn!(?status, "failed to deliver actor onError report");
+		}
+	}));
 }
 
 #[allow(dead_code)]
@@ -966,6 +1028,70 @@ fn build_request_object(env: &Env, request: Request) -> napi::Result<JsObject> {
 	Ok(request_object)
 }
 
+fn build_on_error_payload(env: &Env, payload: OnErrorPayload) -> napi::Result<Vec<napi::JsUnknown>> {
+	let mut root = env.create_object()?;
+	let mut identity = env.create_object()?;
+	identity.set("actorId", payload.identity.actor_id)?;
+	identity.set("name", payload.identity.name)?;
+	identity.set("key", payload.identity.key)?;
+	root.set("identity", identity)?;
+
+	let mut report = env.create_object()?;
+	report.set("event", build_error_event(env, payload.report.event)?)?;
+	report.set("group", payload.report.group)?;
+	report.set("code", payload.report.code)?;
+	report.set("message", payload.report.message)?;
+	report.set("metadata", payload.report.metadata)?;
+	report.set("rawErrorRef", payload.report.raw_error_ref)?;
+	root.set("report", report)?;
+	Ok(vec![root.into_unknown()])
+}
+
+fn build_error_event(env: &Env, event: ActorErrorEvent) -> napi::Result<JsObject> {
+	let mut root = env.create_object()?;
+	match event {
+		ActorErrorEvent::Action { name, scheduled } => {
+			let mut action = env.create_object()?;
+			action.set("name", name)?;
+			action.set("scheduled", scheduled)?;
+			root.set("action", action)?;
+		}
+		ActorErrorEvent::Hook { name } => {
+			let mut hook = env.create_object()?;
+			hook.set("name", name)?;
+			root.set("hook", hook)?;
+		}
+		ActorErrorEvent::Queue { name } => {
+			let mut queue = env.create_object()?;
+			queue.set("name", name)?;
+			root.set("queue", queue)?;
+		}
+		ActorErrorEvent::Internal { kind } => {
+			let mut internal = env.create_object()?;
+			internal.set(
+				"kind",
+				match kind {
+					InternalErrorKind::Persist => "persist",
+					InternalErrorKind::Alarm => "alarm",
+				},
+			)?;
+			root.set("internal", internal)?;
+		}
+		ActorErrorEvent::Fatal { phase } => {
+			let mut fatal = env.create_object()?;
+			fatal.set(
+				"phase",
+				match phase {
+					FatalPhase::Run => "run",
+					FatalPhase::Shutdown => "shutdown",
+				},
+			)?;
+			root.set("fatal", fatal)?;
+		}
+	}
+	Ok(root)
+}
+
 fn parse_bridge_rivet_error(reason: &str) -> Option<anyhow::Error> {
 	let prefix_index = reason.find(BRIDGE_RIVET_ERROR_PREFIX)?;
 	let payload = &reason[prefix_index + BRIDGE_RIVET_ERROR_PREFIX.len()..];
@@ -991,11 +1117,15 @@ fn parse_bridge_rivet_error(reason: &str) -> Option<anyhow::Error> {
 		message: Some(message.clone()),
 		actor: payload.actor,
 	});
-	Some(error.context(BridgeRivetErrorContext {
+	let error = error.context(BridgeRivetErrorContext {
 		message: Some(message),
 		public_: payload.public_,
 		status_code: payload.status_code,
-	}))
+	});
+	Some(match payload.raw_error_id {
+		Some(raw_error_id) => error.context(RawErrorRef(raw_error_id)),
+		None => error,
+	})
 }
 
 pub(crate) fn callback_error(callback_name: &str, error: napi::Error) -> anyhow::Error {

--- a/rivetkit-typescript/packages/rivetkit-napi/src/napi_actor_events.rs
+++ b/rivetkit-typescript/packages/rivetkit-napi/src/napi_actor_events.rs
@@ -8,8 +8,9 @@ use rivet_error::{
 	MacroMarker, RivetError as RivetTransportError, RivetErrorKind, RivetErrorSchema,
 };
 use rivetkit_core::{
-	ActorContext as CoreActorContext, ActorEvent, ActorEvents, ActorLifecycle, ActorStart,
-	QueueSendResult, QueueSendStatus, Reply, SerializeStateReason, StateDelta,
+	ActorContext as CoreActorContext, ActorErrorEvent, ActorEvent, ActorEvents, ActorLifecycle,
+	ActorStart, FatalPhase, HookName, QueueSendResult, QueueSendStatus, Reply,
+	SerializeStateReason, StateDelta,
 };
 use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
 use tokio::task::JoinHandle;
@@ -26,7 +27,7 @@ use crate::actor_factory::{
 	CreateStatePayload, HttpRequestPayload, LifecyclePayload, MigratePayload, QueueSendPayload,
 	SerializeStatePayload, WebSocketPayload, WorkflowHistoryPayload, WorkflowReplayPayload,
 	call_buffer, call_optional_buffer, call_queue_send, call_request, call_state_delta_payload,
-	call_void,
+	call_void, configure_on_error_hook,
 };
 
 // Restart hooks are synchronous callback slots; the guard is only held while
@@ -113,6 +114,7 @@ pub(crate) async fn run_adapter_loop(
 
 	let ctx = ActorContext::new(core_ctx.clone());
 	ctx.reset_runtime_shared_state();
+	configure_on_error_hook(&bindings, &core_ctx);
 	let abort = CancellationToken::new();
 	ctx.attach_napi_abort_token(abort.clone());
 	let (registered_task_tx, mut registered_task_rx) = unbounded_channel();
@@ -147,6 +149,12 @@ pub(crate) async fn run_adapter_loop(
 		Err(error) => {
 			if let Some(reply) = startup_ready {
 				let startup_error = anyhow::Error::new(RivetTransportError::extract(&error));
+				let hook_name = hook_name_from_error(&error);
+				let startup_error = if let Some(hook_name) = hook_name {
+					startup_error.context(HookName(hook_name))
+				} else {
+					startup_error
+				};
 				let _ = reply.send(Err(startup_error));
 			}
 			return Err(error);
@@ -627,54 +635,56 @@ pub(crate) async fn dispatch_event(
 		ActorEvent::SerializeState { reason, reply } => {
 			reply.send(maybe_serialize(bindings.as_ref(), ctx, dirty.as_ref(), reason).await);
 		}
-		ActorEvent::RunGracefulCleanup { reason, reply } => {
-			let callback = match reason {
-				rivetkit_core::actor::ShutdownKind::Sleep => bindings.on_sleep.clone(),
-				rivetkit_core::actor::ShutdownKind::Destroy => bindings.on_destroy.clone(),
-			};
-			let ctx = ctx.clone();
-			let shutdown_deadline = ctx.inner().shutdown_deadline_token();
-			tasks.spawn(async move {
-				let work = async {
-					let result: Result<()> = async {
-						if let Some(callback) = callback {
-							match reason {
-								rivetkit_core::actor::ShutdownKind::Sleep => {
-									call_on_sleep(&callback, &ctx).await
-								}
-								rivetkit_core::actor::ShutdownKind::Destroy => {
-									call_on_destroy(&callback, &ctx).await
-								}
-							}?;
-						}
-						Ok(())
-					}
-					.await;
-					if let Err(error) = result {
-						tracing::error!(
-							actor_id = %ctx.inner().actor_id(),
-							?error,
-							"graceful cleanup callback failed",
-						);
-					}
+			ActorEvent::RunGracefulCleanup { reason, reply } => {
+				let callback = match reason {
+					rivetkit_core::actor::ShutdownKind::Sleep => bindings.on_sleep.clone(),
+					rivetkit_core::actor::ShutdownKind::Destroy => bindings.on_destroy.clone(),
 				};
-				tokio::select! {
-					_ = work => {}
-					_ = shutdown_deadline.cancelled() => {
-						tracing::warn!(
-							actor_id = %ctx.inner().actor_id(),
-							reason = ?reason,
-							"graceful cleanup aborted by shutdown grace deadline",
-						);
-					}
-				}
-				reply.send(Ok(()));
-			});
-		}
-		ActorEvent::DisconnectConn { conn_id, reply } => {
-			let callback = bindings.on_disconnect_final.clone();
-			let ctx = ctx.clone();
-			tasks.spawn(async move {
+				let ctx = ctx.clone();
+				let shutdown_deadline = ctx.inner().shutdown_deadline_token();
+				tasks.spawn(async move {
+					let work = async {
+						let result: Result<()> = async {
+							if let Some(callback) = callback {
+								match reason {
+									rivetkit_core::actor::ShutdownKind::Sleep => {
+										call_on_sleep(&callback, &ctx).await
+									}
+									rivetkit_core::actor::ShutdownKind::Destroy => {
+										call_on_destroy(&callback, &ctx).await
+									}
+								}?;
+							}
+							Ok(())
+						}
+						.await;
+						if let Err(error) = &result {
+							tracing::error!(
+								actor_id = %ctx.inner().actor_id(),
+								?error,
+								"graceful cleanup callback failed",
+							);
+						}
+						result
+					};
+					let result = tokio::select! {
+						result = work => result,
+						_ = shutdown_deadline.cancelled() => {
+							tracing::warn!(
+								actor_id = %ctx.inner().actor_id(),
+								reason = ?reason,
+								"graceful cleanup aborted by shutdown grace deadline",
+							);
+							Err(actor_shutting_down())
+						}
+					};
+					reply.send(result);
+				});
+			}
+			ActorEvent::DisconnectConn { conn_id, reply } => {
+				let callback = bindings.on_disconnect_final.clone();
+				let ctx = ctx.clone();
+				tasks.spawn(async move {
 				let result: Result<()> = async {
 					let conn = { ctx.inner().conns().find(|conn| conn.id() == conn_id) };
 					if let Some(conn) = conn {
@@ -684,18 +694,20 @@ pub(crate) async fn dispatch_event(
 						ctx.inner().disconnect_conn(conn_id).await?;
 					}
 					Ok(())
-				}
-				.await;
-				if let Err(error) = result {
-					tracing::error!(
-						actor_id = %ctx.inner().actor_id(),
-						?error,
-						"disconnect cleanup callback failed",
-					);
-				}
-				reply.send(Ok(()));
-			});
-		}
+					}
+					.await;
+					if let Err(error) = result {
+						tracing::error!(
+							actor_id = %ctx.inner().actor_id(),
+							?error,
+							"disconnect cleanup callback failed",
+						);
+						reply.send(Err(error));
+					} else {
+						reply.send(Ok(()));
+					}
+				});
+			}
 		ActorEvent::WorkflowHistoryRequested { reply } => {
 			let Some(callback) = bindings.get_workflow_history.clone() else {
 				reply.send(Ok(None));
@@ -861,7 +873,7 @@ async fn stop_run_handler(run_handler: &RunHandlerSlot) {
 	}
 }
 
-async fn with_timeout<T, F>(callback_name: &str, duration: Duration, future: F) -> Result<T>
+async fn with_timeout<T, F>(callback_name: &'static str, duration: Duration, future: F) -> Result<T>
 where
 	F: std::future::Future<Output = Result<T>>,
 {
@@ -876,7 +888,37 @@ where
 		duration,
 		future,
 	)
-	.await
+		.await
+		.map_err(|error| error.context(HookName(callback_name)))
+}
+
+fn hook_name_from_error(error: &anyhow::Error) -> Option<&'static str> {
+	error.chain().find_map(|cause| {
+		if let Some(hook) = cause.downcast_ref::<HookName>() {
+			return Some(hook.0);
+		}
+
+		match cause.to_string().as_str() {
+			"createState" => Some("createState"),
+			"onCreate" => Some("onCreate"),
+			"createVars" => Some("createVars"),
+			"onMigrate" => Some("onMigrate"),
+			"onWake" => Some("onWake"),
+			"onBeforeActorStart" => Some("onBeforeActorStart"),
+			"onSleep" => Some("onSleep"),
+			"onDestroy" => Some("onDestroy"),
+			"onBeforeConnect" => Some("onBeforeConnect"),
+			"onConnect" => Some("onConnect"),
+			"onDisconnect" => Some("onDisconnect"),
+			"onBeforeSubscribe" => Some("onBeforeSubscribe"),
+			"onBeforeActionResponse" => Some("onBeforeActionResponse"),
+			"onRequest" => Some("onRequest"),
+			"onQueueSend" => Some("onQueueSend"),
+			"onWebSocket" => Some("onWebSocket"),
+			"run" => Some("run"),
+			_ => None,
+		}
+	})
 }
 
 async fn with_structured_timeout<T, F>(
@@ -963,6 +1005,12 @@ fn spawn_run_handler(
 						"napi run handler aborted for sleep"
 					);
 				} else {
+					ctx.inner().report_error(
+						ActorErrorEvent::Fatal {
+							phase: FatalPhase::Run,
+						},
+						&error,
+					);
 					tracing::error!(
 						actor_id = %ctx.inner().actor_id(),
 						?error,

--- a/rivetkit-typescript/packages/rivetkit-wasm/src/lib.rs
+++ b/rivetkit-typescript/packages/rivetkit-wasm/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
+use std::future::Future;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -13,12 +14,14 @@ use rivet_error::{ActorSpecifier, RivetError as RivetTransportError, RivetErrorK
 use rivetkit_core::error::public_error_status_code;
 use rivetkit_core::inspector::InspectorAuth;
 use rivetkit_core::{
-	ActorConfig, ActorConfigInput, ActorEvent, ActorFactory as CoreActorFactory, ActorStart,
-	ActorWorkKind, BindParam, ColumnValue, CoreRegistry as NativeCoreRegistry,
-	CoreServerlessRuntime, EngineSpawnMode, EnqueueAndWaitOpts, KeepAwakeRegion, ListOpts,
-	QueueMessage, QueueNextBatchOpts, QueueSendResult, QueueSendStatus, QueueTryNextBatchOpts,
-	QueueWaitOpts, Request, RequestSaveOpts, Response, RuntimeSpawner, SerializeStateReason,
-	ServeConfig, ServerlessRequest, StateDelta, WebSocket, WebSocketCallbackRegion, WsMessage,
+	ActorConfig, ActorConfigInput, ActorErrorEvent, ActorEvent, ActorFactory as CoreActorFactory,
+	ActorStart, ActorWorkKind, BindParam, ColumnValue, CoreRegistry as NativeCoreRegistry,
+	CoreServerlessRuntime, EngineSpawnMode, EnqueueAndWaitOpts, FatalPhase, HookName,
+	KeepAwakeRegion,
+	ListOpts, QueueMessage, QueueNextBatchOpts, QueueSendResult, QueueSendStatus,
+	QueueTryNextBatchOpts, QueueWaitOpts, RawErrorRef, Request, RequestSaveOpts, Response,
+	RuntimeSpawner, SerializeStateReason, ServeConfig, ServerlessRequest, StateDelta, WebSocket,
+	WebSocketCallbackRegion, WsMessage,
 };
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken as CoreCancellationToken;
@@ -63,6 +66,8 @@ struct BridgeRivetErrorPayload {
 	#[serde(rename = "statusCode")]
 	status_code: Option<u16>,
 	actor: Option<ActorSpecifier>,
+	#[serde(rename = "rawErrorId")]
+	raw_error_id: Option<u64>,
 }
 
 #[derive(Debug)]
@@ -96,6 +101,12 @@ impl WasmFunction {
 	fn call1(&self, payload: &JsValue) -> Result<JsValue> {
 		self.0
 			.call1(&JsValue::UNDEFINED, payload)
+			.map_err(js_value_to_anyhow)
+	}
+
+	fn call2(&self, first: &JsValue, second: &JsValue) -> Result<JsValue> {
+		self.0
+			.call2(&JsValue::UNDEFINED, first, second)
 			.map_err(js_value_to_anyhow)
 	}
 }
@@ -480,7 +491,8 @@ impl WasmActorFactory {
 		config
 			.validate()
 			.map_err(|e| JsValue::from_str(&format!("{e:?}")))?;
-		let callbacks = WasmCallbacks::new(callbacks);
+		let action_timeout = config.action_timeout;
+		let callbacks = WasmCallbacks::new(callbacks, action_timeout);
 		let factory = CoreActorFactory::new_with_manual_startup_ready(config, move |start| {
 			let callbacks = callbacks.clone();
 			Box::pin(async move { run_actor_adapter(callbacks, start).await })
@@ -514,11 +526,13 @@ struct WasmCallbacks {
 	run: Option<Function>,
 	get_workflow_history: Option<Function>,
 	replay_workflow: Option<Function>,
+	on_error: Option<Function>,
 	actions: JsValue,
+	action_timeout: Duration,
 }
 
 impl WasmCallbacks {
-	fn new(callbacks: JsValue) -> Self {
+	fn new(callbacks: JsValue, action_timeout: Duration) -> Self {
 		Self {
 			create_state: function_property(&callbacks, "createState"),
 			on_create: function_property(&callbacks, "onCreate"),
@@ -542,8 +556,10 @@ impl WasmCallbacks {
 			run: function_property(&callbacks, "run"),
 			get_workflow_history: function_property(&callbacks, "getWorkflowHistory"),
 			replay_workflow: function_property(&callbacks, "replayWorkflow"),
+			on_error: function_property(&callbacks, "onError"),
 			actions: Reflect::get(&callbacks, &JsValue::from_str("actions"))
 				.unwrap_or(JsValue::UNDEFINED),
+			action_timeout,
 		}
 	}
 }
@@ -560,13 +576,21 @@ async fn run_actor_adapter(callbacks: WasmCallbacks, start: ActorStart) -> Resul
 	} = start;
 
 	let ctx = WasmActorContext::from_core(core_ctx.clone(), callbacks.clone());
+	configure_on_error_hook(&callbacks, &core_ctx);
 	let preamble = run_preamble(&callbacks, &ctx, input, is_new, snapshot).await;
 	if let Some(reply) = startup_ready {
 		let _ = reply.send(
 			preamble
 				.as_ref()
 				.map(|_| ())
-				.map_err(|error| anyhow!(RivetTransportError::extract(error))),
+				.map_err(|error| {
+					let startup_error = anyhow!(RivetTransportError::extract(error));
+					if let Some(hook_name) = hook_name_from_error(error) {
+						startup_error.context(HookName(hook_name))
+					} else {
+						startup_error
+					}
+				}),
 		);
 	}
 	preamble?;
@@ -579,26 +603,212 @@ async fn run_actor_adapter(callbacks: WasmCallbacks, start: ActorStart) -> Resul
 	Ok(())
 }
 
+fn hook_name_from_error(error: &anyhow::Error) -> Option<&'static str> {
+	error.chain().find_map(|cause| {
+		if let Some(hook) = cause.downcast_ref::<HookName>() {
+			return Some(hook.0);
+		}
+
+		match cause.to_string().as_str() {
+			"createState" => Some("createState"),
+			"onCreate" => Some("onCreate"),
+			"createVars" => Some("createVars"),
+			"onMigrate" => Some("onMigrate"),
+			"onWake" => Some("onWake"),
+			"onBeforeActorStart" => Some("onBeforeActorStart"),
+			"onSleep" => Some("onSleep"),
+			"onDestroy" => Some("onDestroy"),
+			"onBeforeConnect" => Some("onBeforeConnect"),
+			"onConnect" => Some("onConnect"),
+			"onDisconnect" => Some("onDisconnect"),
+			"onBeforeSubscribe" => Some("onBeforeSubscribe"),
+			"onBeforeActionResponse" => Some("onBeforeActionResponse"),
+			"onRequest" => Some("onRequest"),
+			"onQueueSend" => Some("onQueueSend"),
+			"onWebSocket" => Some("onWebSocket"),
+			"run" => Some("run"),
+			_ => None,
+		}
+	})
+}
+
+async fn with_action_timeout<T, F>(duration: Duration, future: F) -> Result<T>
+where
+	F: Future<Output = Result<T>>,
+{
+	if duration >= Duration::from_secs(60) {
+		return future.await;
+	}
+
+	tokio::pin!(future);
+	let timeout = js_delay(duration);
+	tokio::pin!(timeout);
+
+	tokio::select! {
+		result = &mut future => result,
+		() = &mut timeout => Err(action_timeout_error()),
+	}
+}
+
+fn action_timeout_error() -> anyhow::Error {
+	anyhow::Error::new(RivetTransportError {
+		kind: RivetErrorKind::Dynamic {
+			group: "actor".to_owned(),
+			code: "action_timed_out".to_owned(),
+			default_message: "Action timed out".to_owned(),
+		},
+		meta: None,
+		message: Some("Action timed out".to_owned()),
+		actor: None,
+	})
+}
+
+async fn js_delay(duration: Duration) {
+	let millis = duration.as_millis().min(u32::MAX as u128) as i32;
+	let promise = Promise::new(&mut |resolve, _reject| {
+		if let Ok(set_timeout) = Reflect::get(&js_sys::global(), &JsValue::from_str("setTimeout"))
+			.and_then(|value| value.dyn_into::<Function>())
+		{
+			let _ = set_timeout.call2(
+				&JsValue::UNDEFINED,
+				resolve.as_ref(),
+				&JsValue::from_f64(millis as f64),
+			);
+		} else {
+			let _ = resolve.call0(&JsValue::UNDEFINED);
+		}
+	});
+	let _ = JsFuture::from(promise).await;
+}
+
+fn configure_on_error_hook(callbacks: &WasmCallbacks, ctx: &rivetkit_core::ActorContext) {
+	let Some(callback) = callbacks.on_error.clone() else {
+		return;
+	};
+	let callback = Arc::new(WasmFunction(callback));
+	let actor_id = ctx.actor_id().to_owned();
+	let name = ctx.name().to_owned();
+	let key = rivetkit_core::types::format_actor_key(ctx.key());
+	ctx.on_error(Arc::new(move |report| {
+		let Ok(payload) = build_on_error_payload(&actor_id, &name, &key, report) else {
+			console_error("failed to build wasm onError payload");
+			return;
+		};
+		if let Err(error) = callback.call2(&JsValue::NULL, &payload.into()) {
+			console_error(&format!("failed to deliver wasm onError report: {error:?}"));
+		}
+	}));
+}
+
+fn build_on_error_payload(
+	actor_id: &str,
+	name: &str,
+	key: &str,
+	report: rivetkit_core::ErrorReport,
+) -> Result<Object> {
+	let root = object();
+	let identity = object();
+	set_anyhow(&identity, "actorId", JsValue::from_str(actor_id))?;
+	set_anyhow(&identity, "name", JsValue::from_str(name))?;
+	set_anyhow(&identity, "key", JsValue::from_str(key))?;
+	set_anyhow(&root, "identity", identity.into())?;
+
+	let report_object = object();
+	set_anyhow(&report_object, "event", build_error_event(report.event)?.into())?;
+	set_anyhow(&report_object, "group", JsValue::from_str(&report.group))?;
+	set_anyhow(&report_object, "code", JsValue::from_str(&report.code))?;
+	set_anyhow(&report_object, "message", JsValue::from_str(&report.message))?;
+	let metadata = match report.metadata {
+		Some(metadata) => serde_wasm_bindgen::to_value(&metadata)
+			.map_err(|error| anyhow!("failed to serialize onError metadata: {error:?}"))?,
+		None => JsValue::NULL,
+	};
+	set_anyhow(&report_object, "metadata", metadata)?;
+	set_anyhow(
+		&report_object,
+		"rawErrorRef",
+		report
+			.raw_error_ref
+			.map(|value| JsValue::from_f64(value as f64))
+			.unwrap_or(JsValue::UNDEFINED),
+	)?;
+	set_anyhow(&root, "report", report_object.into())?;
+	Ok(root)
+}
+
+fn build_error_event(event: ActorErrorEvent) -> Result<Object> {
+	let root = object();
+	match event {
+		ActorErrorEvent::Action { name, scheduled } => {
+			let action = object();
+			set_anyhow(&action, "name", JsValue::from_str(&name))?;
+			set_anyhow(&action, "scheduled", JsValue::from_bool(scheduled))?;
+			set_anyhow(&root, "action", action.into())?;
+		}
+		ActorErrorEvent::Hook { name } => {
+			let hook = object();
+			set_anyhow(&hook, "name", JsValue::from_str(&name))?;
+			set_anyhow(&root, "hook", hook.into())?;
+		}
+		ActorErrorEvent::Queue { name } => {
+			let queue = object();
+			set_anyhow(&queue, "name", JsValue::from_str(&name))?;
+			set_anyhow(&root, "queue", queue.into())?;
+		}
+		ActorErrorEvent::Internal { kind } => {
+			let internal = object();
+			set_anyhow(
+				&internal,
+				"kind",
+				JsValue::from_str(match kind {
+					rivetkit_core::InternalErrorKind::Persist => "persist",
+					rivetkit_core::InternalErrorKind::Alarm => "alarm",
+				}),
+			)?;
+			set_anyhow(&root, "internal", internal.into())?;
+		}
+		ActorErrorEvent::Fatal { phase } => {
+			let fatal = object();
+			set_anyhow(
+				&fatal,
+				"phase",
+				JsValue::from_str(match phase {
+					FatalPhase::Run => "run",
+					FatalPhase::Shutdown => "shutdown",
+				}),
+			)?;
+			set_anyhow(&root, "fatal", fatal.into())?;
+		}
+	}
+	Ok(root)
+}
+
 fn start_run_handler(callbacks: &WasmCallbacks, ctx: &WasmActorContext) {
 	let Some(callback) = callbacks.run.clone() else {
 		return;
 	};
 	let ctx = ctx.clone();
 	ctx.inner.begin_run_handler();
-	spawn_local(async move {
-		let result = async {
-			let payload = object();
-			set_anyhow(&payload, "ctx", JsValue::from(ctx.clone()))?;
-			call_callback(&callback, &payload.into()).await?;
-			Ok::<_, anyhow::Error>(())
-		}
-		.await;
-		if let Err(error) = &result {
-			console_error(&format!("wasm run callback failed: {error:#}"));
-		}
-		ctx.inner.end_run_handler();
-	});
-}
+		spawn_local(async move {
+			let result = async {
+				let payload = object();
+				set_anyhow(&payload, "ctx", JsValue::from(ctx.clone()))?;
+				call_callback(&callback, &payload.into()).await?;
+				Ok::<_, anyhow::Error>(())
+			}
+			.await;
+			if let Err(error) = &result {
+				ctx.inner.report_error(
+					ActorErrorEvent::Fatal {
+						phase: FatalPhase::Run,
+					},
+					error,
+				);
+				console_error(&format!("wasm run callback failed: {error:#}"));
+			}
+			ctx.inner.end_run_handler();
+		});
+	}
 
 async fn run_preamble(
 	callbacks: &WasmCallbacks,
@@ -611,7 +821,9 @@ async fn run_preamble(
 		let payload = object();
 		set_anyhow(&payload, "ctx", JsValue::from(ctx.clone()))?;
 		set_anyhow(&payload, "isNew", JsValue::from_bool(is_new))?;
-		call_callback(callback, &payload.into()).await?;
+		call_callback(callback, &payload.into())
+			.await
+			.map_err(|error| error.context(HookName("onMigrate")))?;
 	}
 
 	if is_new {
@@ -621,7 +833,9 @@ async fn run_preamble(
 			if let Some(input) = input.as_ref() {
 				set_anyhow(&payload, "input", bytes_to_js(input))?;
 			}
-			let state = call_callback_bytes(callback, &payload.into()).await?;
+			let state = call_callback_bytes(callback, &payload.into())
+				.await
+				.map_err(|error| error.context(HookName("createState")))?;
 			ctx.inner.set_state_initial(state);
 		}
 		if let Some(callback) = &callbacks.on_create {
@@ -630,7 +844,9 @@ async fn run_preamble(
 			if let Some(input) = input.as_ref() {
 				set_anyhow(&payload, "input", bytes_to_js(input))?;
 			}
-			call_callback(callback, &payload.into()).await?;
+			call_callback(callback, &payload.into())
+				.await
+				.map_err(|error| error.context(HookName("onCreate")))?;
 		}
 	} else if let Some(snapshot) = snapshot {
 		ctx.inner.set_state_initial(snapshot);
@@ -640,7 +856,9 @@ async fn run_preamble(
 		if let Some(input) = input.as_ref() {
 			set_anyhow(&payload, "input", bytes_to_js(input))?;
 		}
-		let state = call_callback_bytes(callback, &payload.into()).await?;
+		let state = call_callback_bytes(callback, &payload.into())
+			.await
+			.map_err(|error| error.context(HookName("createState")))?;
 		ctx.inner.set_state_initial(state.clone());
 		ctx.inner
 			.save_state(vec![StateDelta::ActorState(state)])
@@ -650,19 +868,25 @@ async fn run_preamble(
 	if let Some(callback) = &callbacks.create_vars {
 		let payload = object();
 		set_anyhow(&payload, "ctx", JsValue::from(ctx.clone()))?;
-		call_callback(callback, &payload.into()).await?;
+		call_callback(callback, &payload.into())
+			.await
+			.map_err(|error| error.context(HookName("createVars")))?;
 	}
 
 	if let Some(callback) = &callbacks.on_wake {
 		let payload = object();
 		set_anyhow(&payload, "ctx", JsValue::from(ctx.clone()))?;
-		call_callback(callback, &payload.into()).await?;
+		call_callback(callback, &payload.into())
+			.await
+			.map_err(|error| error.context(HookName("onWake")))?;
 	}
 
 	if let Some(callback) = &callbacks.on_before_actor_start {
 		let payload = object();
 		set_anyhow(&payload, "ctx", JsValue::from(ctx.clone()))?;
-		call_callback(callback, &payload.into()).await?;
+		call_callback(callback, &payload.into())
+			.await
+			.map_err(|error| error.context(HookName("onBeforeActorStart")))?;
 	}
 
 	Ok(())
@@ -684,8 +908,9 @@ async fn dispatch_event(callbacks: &WasmCallbacks, ctx: &WasmActorContext, event
 
 			let ctx = ctx.clone();
 			let on_before_action_response = callbacks.on_before_action_response.clone();
+			let timeout = callbacks.action_timeout;
 			RuntimeSpawner::spawn(async move {
-				let result = async {
+				let result = with_action_timeout(timeout, async {
 					let payload = object();
 					set_anyhow(&payload, "ctx", JsValue::from(ctx.clone()))?;
 					set_anyhow(
@@ -710,7 +935,7 @@ async fn dispatch_event(callbacks: &WasmCallbacks, ctx: &WasmActorContext, event
 					}
 
 					Ok(output)
-				}
+				})
 				.await;
 				if let Err(error) = &result {
 					console_error(&format!("wasm action callback `{name}` failed: {error:#}"));
@@ -949,12 +1174,12 @@ async fn dispatch_event(callbacks: &WasmCallbacks, ctx: &WasmActorContext, event
 				}
 				ctx.inner.disconnect_conn(conn_id).await
 			}
-			.await;
-			if let Err(error) = result {
-				console_error(&format!("wasm disconnect callback failed: {error:#}"));
+				.await;
+				if let Err(error) = &result {
+					console_error(&format!("wasm disconnect callback failed: {error:#}"));
+				}
+				reply.send(result);
 			}
-			reply.send(Ok(()));
-		}
 		ActorEvent::ConnectionClosed { conn } => {
 			if let Some(callback) = &callbacks.on_disconnect_final {
 				let result = async {
@@ -1462,6 +1687,16 @@ impl WasmActorContext {
 	#[wasm_bindgen(js_name = restartRunHandler)]
 	pub fn restart_run_handler(&self) {
 		start_run_handler(&self.callbacks, self);
+	}
+
+	#[wasm_bindgen(js_name = reportError)]
+	pub fn report_error(&self, hook_name: String, raw_error_ref: Option<f64>) {
+		let mut error = anyhow!("actor hook `{hook_name}` failed");
+		if let Some(raw_error_ref) = raw_error_ref.and_then(f64_to_u64) {
+			error = error.context(RawErrorRef(raw_error_ref));
+		}
+		self.inner
+			.report_error(ActorErrorEvent::Hook { name: hook_name }, &error);
 	}
 
 	#[wasm_bindgen(js_name = beginKeepAwake)]
@@ -2271,6 +2506,14 @@ fn set_anyhow(object: &Object, key: &str, value: JsValue) -> Result<()> {
 	set(object, key, value).map_err(js_value_to_anyhow)
 }
 
+fn f64_to_u64(value: f64) -> Option<u64> {
+	if value.is_finite() && value >= 0.0 && value <= u64::MAX as f64 {
+		Some(value as u64)
+	} else {
+		None
+	}
+}
+
 fn bytes_to_js(bytes: &[u8]) -> JsValue {
 	Uint8Array::from(bytes).into()
 }
@@ -2751,11 +2994,15 @@ fn parse_bridge_rivet_error(reason: &str) -> Option<anyhow::Error> {
 		message: Some(message.clone()),
 		actor: payload.actor,
 	});
-	Some(error.context(BridgeRivetErrorContext {
+	let error = error.context(BridgeRivetErrorContext {
 		message: Some(message),
 		public_: payload.public_,
 		status_code: payload.status_code,
-	}))
+	});
+	Some(match payload.raw_error_id {
+		Some(raw_error_id) => error.context(RawErrorRef(raw_error_id)),
+		None => error,
+	})
 }
 
 fn console_error(message: &str) {

--- a/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/actor-onerror.ts
+++ b/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/actor-onerror.ts
@@ -1,0 +1,261 @@
+// @ts-nocheck
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { actor, queue } from "rivetkit";
+import type { ActorErrorContext, ActorErrorEvent } from "../../src/actor/config";
+
+export interface ActorOnErrorRecord {
+	source: "actor" | "registry" | "throwing-actor" | "rejecting-actor";
+	actorId: string;
+	name: string;
+	key?: string;
+	arm: "action" | "hook" | "queue" | "internal" | "fatal";
+	detail?: string;
+	scheduled?: boolean;
+	errorMessage: string;
+	errorName?: string;
+	errorGroup?: string;
+	errorCode?: string;
+	rawError: boolean;
+}
+
+const reports = new Map<string, ActorOnErrorRecord[]>();
+const reportDir = join("/tmp", "rivetkit-actor-onerror-reports");
+
+function reportFile(key: string): string {
+	return join(reportDir, `${encodeURIComponent(key)}.json`);
+}
+
+function reportKey(c: ActorErrorContext): string {
+	return c.key ?? c.actorId;
+}
+
+function readEvent(event: ActorErrorEvent): {
+	arm: ActorOnErrorRecord["arm"];
+	data: Record<string, unknown> & { error: unknown };
+} {
+	const [arm, data] = Object.entries(event)[0] as [
+		ActorOnErrorRecord["arm"],
+		Record<string, unknown> & { error: unknown },
+	];
+	return { arm, data };
+}
+
+export function recordActorOnError(
+	source: ActorOnErrorRecord["source"],
+	c: ActorErrorContext,
+	event: ActorErrorEvent,
+): void {
+	const { arm, data } = readEvent(event);
+	const error = data.error as {
+		message?: string;
+		name?: string;
+		group?: string;
+		code?: string;
+	};
+	const record: ActorOnErrorRecord = {
+		source,
+		actorId: c.actorId,
+		name: c.name,
+		key: c.key,
+		arm,
+		detail:
+			typeof data.name === "string"
+				? data.name
+				: typeof data.kind === "string"
+					? data.kind
+					: typeof data.phase === "string"
+						? data.phase
+						: undefined,
+		scheduled:
+			typeof data.scheduled === "boolean" ? data.scheduled : undefined,
+		errorMessage:
+			typeof error?.message === "string"
+				? error.message
+				: String(data.error),
+		errorName: typeof error?.name === "string" ? error.name : undefined,
+		errorGroup:
+			typeof error?.group === "string" ? error.group : undefined,
+		errorCode: typeof error?.code === "string" ? error.code : undefined,
+		rawError: data.error instanceof Error,
+	};
+	const key = reportKey(c);
+	reports.set(key, [...(reports.get(key) ?? []), record]);
+	const next = [...readReportFile(key), record];
+	mkdirSync(reportDir, { recursive: true });
+	writeFileSync(reportFile(key), JSON.stringify(next), "utf8");
+}
+
+export function resetActorOnErrorReports(key?: string): void {
+	if (key === undefined) {
+		reports.clear();
+		rmSync(reportDir, { force: true, recursive: true });
+	} else {
+		reports.delete(key);
+		rmSync(reportFile(key), { force: true });
+	}
+}
+
+export function getActorOnErrorReports(key: string): ActorOnErrorRecord[] {
+	const fileReports = readReportFile(key);
+	return fileReports.length > 0 ? fileReports : [...(reports.get(key) ?? [])];
+}
+
+function readReportFile(key: string): ActorOnErrorRecord[] {
+	try {
+		return JSON.parse(readFileSync(reportFile(key), "utf8"));
+	} catch {
+		return [];
+	}
+}
+
+export const actorOnErrorActionActor = actor({
+	state: {
+		changed: 0,
+	},
+	onError: (c, event) => {
+		recordActorOnError("actor", c, event);
+	},
+	actions: {
+		failAction: () => {
+			throw new Error("onError action boom");
+		},
+		succeed: () => "ok",
+		scheduleFailure: (c, delayMs: number) => {
+			c.schedule.after(delayMs, "scheduledFailure");
+			return true;
+		},
+		scheduledFailure: () => {
+			throw new Error("onError scheduled boom");
+		},
+		breakPersist: (c) => {
+			c.state.changed++;
+			c.state.unserializable = () => "nope";
+			return true;
+		},
+	},
+	options: {
+		actionTimeout: 200,
+	},
+});
+
+export const actorOnErrorTimeoutActor = actor({
+	onError: (c, event) => {
+		recordActorOnError("actor", c, event);
+	},
+	actions: {
+		timeoutAction: async () => {
+			await new Promise((resolve) => setTimeout(resolve, 5_000));
+		},
+	},
+	options: {
+		actionTimeout: 100,
+	},
+});
+
+export const actorOnErrorHookActor = actor({
+	onError: (c, event) => {
+		recordActorOnError("actor", c, event);
+	},
+	onRequest: (_c, _request) => {
+		throw new Error("onError request boom");
+	},
+	actions: {},
+});
+
+export const actorOnErrorStartupActor = actor({
+	onError: (c, event) => {
+		recordActorOnError("actor", c, event);
+	},
+	onCreate: () => {
+		throw new Error("onError startup boom");
+	},
+	actions: {
+		ping: () => "pong",
+	},
+});
+
+export const actorOnErrorQueueActor = actor({
+	queues: {
+		fail: queue<{ value: number }>({
+			canPublish: () => {
+				throw new Error("onError queue boom");
+			},
+		}),
+	},
+	onError: (c, event) => {
+		recordActorOnError("actor", c, event);
+	},
+	actions: {},
+});
+
+export const actorOnErrorRunActor = actor({
+	state: {
+		runStarted: false,
+	},
+	onError: (c, event) => {
+		recordActorOnError("actor", c, event);
+	},
+	run: async (c) => {
+		c.state.runStarted = true;
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		throw new Error("onError run boom");
+	},
+	actions: {
+		ping: (c) => c.state.runStarted,
+	},
+});
+
+export const actorOnErrorThrowingHookActor = actor({
+	onError: (c, event) => {
+		recordActorOnError("throwing-actor", c, event);
+		throw new Error("onError hook threw");
+	},
+	actions: {
+		failAction: () => {
+			throw new Error("onError original after throw");
+		},
+		ping: () => "pong",
+	},
+});
+
+export const actorOnErrorRejectingHookActor = actor({
+	onError: async (c, event) => {
+		recordActorOnError("rejecting-actor", c, event);
+		await Promise.resolve();
+		throw new Error("onError hook rejected");
+	},
+	actions: {
+		failAction: () => {
+			throw new Error("onError original after reject");
+		},
+		ping: () => "pong",
+	},
+});
+
+export const actorOnErrorAbortRunActor = actor({
+	onError: (c, event) => {
+		recordActorOnError("actor", c, event);
+	},
+	run: async (c) => {
+		await new Promise((_resolve, reject) => {
+			c.abortSignal.addEventListener(
+				"abort",
+				() => reject(Object.assign(new Error("aborted"), {
+					group: "actor",
+					code: "aborted",
+				})),
+				{ once: true },
+			);
+		});
+	},
+	actions: {
+		destroySelf: (c) => {
+			c.destroy();
+		},
+		ping: () => "pong",
+	},
+	options: {
+		sleepTimeout: 50,
+	},
+});

--- a/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/registry-static.ts
+++ b/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/registry-static.ts
@@ -20,6 +20,18 @@ import {
 	syncActionActor,
 } from "./action-types";
 import { dbActorRaw, dbRemoteLifecycleProbe } from "./actor-db-raw";
+import {
+	actorOnErrorAbortRunActor,
+	actorOnErrorActionActor,
+	actorOnErrorHookActor,
+	actorOnErrorQueueActor,
+	actorOnErrorRejectingHookActor,
+	actorOnErrorRunActor,
+	actorOnErrorStartupActor,
+	actorOnErrorThrowingHookActor,
+	actorOnErrorTimeoutActor,
+	recordActorOnError,
+} from "./actor-onerror";
 import { onStateChangeActor } from "./actor-onstatechange";
 import { connErrorSerializationActor } from "./conn-error-serialization";
 import { counterWithParams } from "./conn-params";
@@ -240,6 +252,16 @@ export const registry = setup({
 		// From error-handling.ts
 		errorHandlingActor,
 		customTimeoutActor,
+		// From actor-onerror.ts
+		actorOnErrorActionActor,
+		actorOnErrorTimeoutActor,
+		actorOnErrorHookActor,
+		actorOnErrorStartupActor,
+		actorOnErrorQueueActor,
+		actorOnErrorRunActor,
+		actorOnErrorThrowingHookActor,
+		actorOnErrorRejectingHookActor,
+		actorOnErrorAbortRunActor,
 		// From kv.ts
 		kvActor,
 		// From queue.ts
@@ -376,5 +398,8 @@ export const registry = setup({
 					agentOsTestActor,
 				}
 			: {}),
+	},
+	onError: (c, event) => {
+		recordActorOnError("registry", c, event);
 	},
 });

--- a/rivetkit-typescript/packages/rivetkit/src/actor/config.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/config.ts
@@ -37,6 +37,64 @@ export interface ActorLogger {
 	[key: string]: any;
 }
 
+export interface ActorErrorContext {
+	actorId: string;
+	name: string;
+	key?: string;
+	log: ActorLogger;
+}
+
+export type LifecycleHookName =
+	| "createState"
+	| "createVars"
+	| "createConnState"
+	| "onCreate"
+	| "onMigrate"
+	| "onWake"
+	| "onSleep"
+	| "onDestroy"
+	| "onStateChange"
+	| "onBeforeConnect"
+	| "onConnect"
+	| "onDisconnect"
+	| "onBeforeSubscribe"
+	| "onBeforeActionResponse"
+	| "onRequest"
+	| "onWebSocket";
+
+export interface ActorActionErrorEvent {
+	name: string;
+	scheduled: boolean;
+	error: unknown;
+}
+
+export interface ActorHookErrorEvent {
+	name: LifecycleHookName;
+	error: unknown;
+}
+
+export interface ActorQueueErrorEvent {
+	name: string;
+	error: unknown;
+}
+
+export interface ActorInternalErrorEvent {
+	kind: "persist" | "alarm";
+	error: unknown;
+}
+
+export interface ActorFatalErrorEvent {
+	phase: "run" | "shutdown";
+	error: unknown;
+}
+
+export type ActorErrorEvent =
+	| { action: ActorActionErrorEvent }
+	| { hook: ActorHookErrorEvent }
+	| { queue: ActorQueueErrorEvent }
+	| { internal: ActorInternalErrorEvent }
+	| { fatal: ActorFatalErrorEvent };
+
 type ActorKvValueType = "text" | "arrayBuffer" | "binary";
 type ActorKvKeyType = "text" | "binary";
 type ActorKvValueTypeMap = {
@@ -1036,6 +1094,7 @@ export const ActorConfigSchema = z
 		onSleep: zFunction().optional(),
 		run: zRunHandler,
 		onStateChange: zFunction().optional(),
+		onError: zFunction().optional(),
 		onBeforeConnect: zFunction().optional(),
 		onConnect: zFunction().optional(),
 		onDisconnect: zFunction().optional(),
@@ -1402,6 +1461,13 @@ interface BaseActorConfig<
 	) => void;
 
 	/**
+	 * Called when actor user code, lifecycle hooks, runtime internals, or fatal
+	 * actor execution fails. Observational only; throwing here does not suppress
+	 * the original error.
+	 */
+	onError?: (c: ActorErrorContext, event: ActorErrorEvent) => void;
+
+	/**
 	 * Called before a client connects to the actor.
 	 *
 	 * Use this hook to determine if a connection should be accepted
@@ -1641,6 +1707,7 @@ export type ActorConfig<
 	| "onSleep"
 	| "run"
 	| "onStateChange"
+	| "onError"
 	| "onBeforeConnect"
 	| "onConnect"
 	| "onDisconnect"
@@ -1739,6 +1806,7 @@ export type ActorConfigInput<
 	| "onSleep"
 	| "run"
 	| "onStateChange"
+	| "onError"
 	| "onBeforeConnect"
 	| "onConnect"
 	| "onDisconnect"
@@ -2057,6 +2125,12 @@ export const DocActorConfigSchema = z
 			.optional()
 			.describe(
 				"Called when the actor's state changes. State changes within this hook won't trigger recursion.",
+			),
+		onError: z
+			.unknown()
+			.optional()
+			.describe(
+				"Called when actor user code, lifecycle hooks, runtime internals, or fatal actor execution fails. Observational only.",
 			),
 		onBeforeConnect: z
 			.unknown()

--- a/rivetkit-typescript/packages/rivetkit/src/actor/errors.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/errors.ts
@@ -36,7 +36,9 @@ export interface RivetErrorLike {
 	actor?: ActorSpecifier;
 }
 
-export interface BridgeRivetErrorPayload extends RivetErrorLike {}
+export interface BridgeRivetErrorPayload extends RivetErrorLike {
+	rawErrorId?: number;
+}
 
 export interface UserErrorOptions extends ErrorOptions {
 	/**
@@ -224,7 +226,10 @@ export function toRivetError(
 	);
 }
 
-export function encodeBridgeRivetError(error: RivetErrorLike): string {
+export function encodeBridgeRivetError(
+	error: RivetErrorLike,
+	rawErrorId?: number,
+): string {
 	return `${BRIDGE_RIVET_ERROR_PREFIX}${JSON.stringify({
 		group: error.group,
 		code: error.code,
@@ -233,6 +238,7 @@ export function encodeBridgeRivetError(error: RivetErrorLike): string {
 		public: error.public,
 		statusCode: error.statusCode,
 		actor: error.actor,
+		rawErrorId,
 	})}`;
 }
 

--- a/rivetkit-typescript/packages/rivetkit/src/registry/config/index.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/config/index.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
-import { getRunMetadata } from "@/actor/config";
+import {
+	type ActorErrorContext,
+	type ActorErrorEvent,
+	getRunMetadata,
+} from "@/actor/config";
 import type {
 	AnyActorDefinition,
 	BaseActorDefinition,
@@ -153,6 +157,11 @@ export const RegistryConfigSchema = z
 			})
 			.optional()
 			.default(() => ({})),
+		onError: z
+			.custom<
+				(c: ActorErrorContext, event: ActorErrorEvent) => void
+			>()
+			.optional(),
 
 		// MARK: Routing
 		// // This is a function to allow for lazy configuration of upgradeWebSocket on the
@@ -611,6 +620,12 @@ export const DocRegistryConfigSchema = z
 			})
 			.optional()
 			.describe("Logging configuration."),
+		onError: z
+			.unknown()
+			.optional()
+			.describe(
+				"Called when any actor user code, lifecycle hook, runtime internal, or fatal actor execution fails.",
+			),
 		endpoint: z
 			.string()
 			.optional()

--- a/rivetkit-typescript/packages/rivetkit/src/registry/napi-runtime.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/napi-runtime.ts
@@ -505,6 +505,14 @@ export class NapiCoreRuntime implements CoreRuntime {
 		asNativeActorContext(ctx).restartRunHandler();
 	}
 
+	actorReportError(
+		ctx: ActorContextHandle,
+		hookName: string,
+		rawErrorRef?: number,
+	): void {
+		asNativeActorContext(ctx).reportError(hookName, rawErrorRef);
+	}
+
 	actorBeginWebsocketCallback(ctx: ActorContextHandle): number {
 		return asNativeActorContext(ctx).beginWebsocketCallback();
 	}

--- a/rivetkit-typescript/packages/rivetkit/src/registry/native.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/native.ts
@@ -2,6 +2,8 @@ import { VirtualWebSocket } from "@rivetkit/virtual-websocket";
 import {
 	ACTOR_CONTEXT_INTERNAL_SYMBOL,
 	CONN_STATE_MANAGER_SYMBOL,
+	type ActorErrorContext,
+	type ActorErrorEvent,
 	disposeRunInspector,
 	getRunFunction,
 	getRunInspectorConfig,
@@ -89,6 +91,9 @@ import { createWriteThroughProxy } from "./write-through-proxy";
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
+const MAX_RAW_ERROR_STASH_SIZE = 1024;
+const rawErrorStash = new Map<number, unknown>();
+let nextRawErrorId = 1;
 
 type ResolvedRuntimeKind = Exclude<RuntimeKind, "auto">;
 type RuntimeHostKind = "node-like" | "edge-like";
@@ -105,6 +110,33 @@ type NativeOnStateChangeHandler = (
 	ctx: ActorContextHandleAdapter,
 	state: unknown,
 ) => void | Promise<void>;
+type NativeOnErrorPayload = {
+	identity: {
+		actorId: string;
+		name: string;
+		key?: string;
+	};
+	report: {
+		event: OmitError<ActorErrorEvent>;
+		group: string;
+		code: string;
+		message: string;
+		metadata?: unknown;
+		rawErrorRef?: number;
+	};
+};
+type OmitError<T> =
+	T extends { action: infer E }
+		? { action: Omit<E, "error"> }
+		: T extends { hook: infer E }
+			? { hook: Omit<E, "error"> }
+			: T extends { queue: infer E }
+				? { queue: Omit<E, "error"> }
+				: T extends { internal: infer E }
+					? { internal: Omit<E, "error"> }
+					: T extends { fatal: infer E }
+						? { fatal: Omit<E, "error"> }
+						: never;
 type NativePersistConnState = {
 	state: unknown;
 };
@@ -701,12 +733,62 @@ function isStructuredBridgeError(
 	);
 }
 
-function encodeNativeCallbackError(error: unknown): Error {
+function stashRawError(error: unknown): number {
+	const id = nextRawErrorId++;
+	rawErrorStash.set(id, error);
+	while (rawErrorStash.size > MAX_RAW_ERROR_STASH_SIZE) {
+		const oldest = rawErrorStash.keys().next().value;
+		if (oldest === undefined) break;
+		rawErrorStash.delete(oldest);
+	}
+	return id;
+}
+
+function takeRawError(id?: number): unknown | undefined {
+	if (id === undefined || id === null) return undefined;
+	const error = rawErrorStash.get(id);
+	rawErrorStash.delete(id);
+	return error;
+}
+
+function reportToRivetError(report: NativeOnErrorPayload["report"]): RivetError {
+	return new RivetError(report.group, report.code, report.message, {
+		metadata: report.metadata,
+	});
+}
+
+function makeErrorEvent(
+	report: NativeOnErrorPayload["report"],
+): ActorErrorEvent {
+	const raw = takeRawError(report.rawErrorRef) ?? reportToRivetError(report);
+	const entries = Object.entries(report.event) as Array<
+		[string, Record<string, unknown>]
+	>;
+	const [tag, data] = entries[0] ?? ["fatal", { phase: "run" }];
+	return { [tag]: { ...data, error: raw } } as ActorErrorEvent;
+}
+
+function makeErrorContext(
+	identity: NativeOnErrorPayload["identity"],
+): ActorErrorContext {
+	return {
+		actorId: identity.actorId,
+		name: identity.name,
+		key: identity.key,
+		log: logger(),
+	};
+}
+
+function logOnErrorHookFailure(scope: string, error: unknown): void {
+	logger().error({ msg: `error in ${scope} \`onError\` hook`, error });
+}
+
+function encodeNativeCallbackError(error: unknown, rawErrorId?: number): Error {
 	const structuredError = isStructuredBridgeError(error)
 		? error
 		: deconstructError(error, true);
 
-	const bridgeError = new Error(encodeBridgeRivetError(structuredError), {
+	const bridgeError = new Error(encodeBridgeRivetError(structuredError, rawErrorId), {
 		cause: error instanceof Error ? error : undefined,
 	});
 	return Object.assign(bridgeError, {
@@ -1123,7 +1205,7 @@ function wrapNativeCallback<Args extends Array<unknown>, Result>(
 		try {
 			return await callback(...args);
 		} catch (error) {
-			throw encodeNativeCallbackError(error);
+			throw encodeNativeCallbackError(error, stashRawError(error));
 		}
 	};
 }
@@ -3055,24 +3137,45 @@ export class ActorContextHandleAdapter {
 				this,
 				actorState.state,
 			) as unknown;
-			if (isPromiseLike(result)) {
-				shouldFinish = false;
-				void Promise.resolve(result)
-					.catch((error) => {
-						logger().error({
-							msg: "error in `onStateChange`",
-							error,
-						});
+				if (isPromiseLike(result)) {
+					shouldFinish = false;
+					void Promise.resolve(result)
+						.catch((error) => {
+							const rawErrorRef = stashRawError(error);
+							callNativeSync(() =>
+								this.#runtime.actorReportError(
+									this.#ctx,
+									"onStateChange",
+									rawErrorRef,
+								),
+							);
+							logger().error({
+								msg: "error in `onStateChange`",
+								error,
+							});
 					})
 					.finally(() => {
 						actorState.isInOnStateChange = false;
 						callNativeSync(() =>
 							this.#runtime.actorEndOnStateChange(this.#ctx),
 						);
-					});
-			}
-		} finally {
-			if (shouldFinish) {
+						});
+				}
+			} catch (error) {
+				const rawErrorRef = stashRawError(error);
+				callNativeSync(() =>
+					this.#runtime.actorReportError(
+						this.#ctx,
+						"onStateChange",
+						rawErrorRef,
+					),
+				);
+				logger().error({
+					msg: "error in `onStateChange`",
+					error,
+				});
+			} finally {
+				if (shouldFinish) {
 				actorState.isInOnStateChange = false;
 				callNativeSync(() =>
 					this.#runtime.actorEndOnStateChange(this.#ctx),
@@ -4835,6 +4938,31 @@ export function buildNativeFactory(
 				}
 			},
 		),
+		onError:
+			typeof config.onError === "function" ||
+			typeof registryConfig.onError === "function"
+				? (
+						error: unknown,
+						payload: NativeOnErrorPayload,
+					): void => {
+						const { identity, report } = unwrapTsfnPayload(
+							error,
+							payload,
+						);
+						const c = makeErrorContext(identity);
+						const event = makeErrorEvent(report);
+						Promise.resolve()
+							.then(() => config.onError?.(c, event))
+							.catch((error) => {
+								logOnErrorHookFailure("actor", error);
+							});
+						Promise.resolve()
+							.then(() => registryConfig.onError?.(c, event))
+							.catch((error) => {
+								logOnErrorHookFailure("registry", error);
+							});
+					}
+				: undefined,
 	};
 
 	return runtime.createActorFactory(
@@ -4866,26 +4994,23 @@ export async function buildServeConfig(
 		serverlessMaxStartPayloadBytes: config.serverless.maxStartPayloadBytes,
 	};
 
-	// Always best-effort resolve the npm-installed engine binary and hand its
-	// path to the core. The core alone decides whether to actually spawn a local
-	// engine (its `should_manage_engine`, based on the endpoint + spawn mode), so
-	// JS must not duplicate that decision here. Only JS knows the npm
-	// `node_modules` layout, so it resolves the path; if no binary is available
-	// (remote-only install, unsupported platform, optional deps skipped), leave
-	// it unset and let the core report `engine.binary_unavailable` if it actually
-	// needs one.
-	try {
-		const { getEnginePath } = await loadEngineCli();
-		serveConfig.engineBinaryPath = getEnginePath();
-	} catch (error) {
-		// The npm-installed engine binary could not be resolved. The core still
-		// decides whether it needs to spawn a local engine; if it does, it will
-		// fail with engine.binary_unavailable (auto-download is off in the napi
-		// runtime). Warn so the cause is actionable.
-		logger().warn({
-			msg: "could not resolve a local engine binary; if a local engine must be spawned it will fail with engine.binary_unavailable — set RIVET_ENGINE_BINARY_PATH or install the @rivetkit/engine-cli platform package",
-			error: stringifyError(error),
-		});
+	if (config.runtime !== "wasm") {
+		// Always best-effort resolve the npm-installed engine binary and hand its
+		// path to native core. Wasm runtimes cannot spawn native engine binaries,
+		// so the field must stay unset there.
+		try {
+			const { getEnginePath } = await loadEngineCli();
+			serveConfig.engineBinaryPath = getEnginePath();
+		} catch (error) {
+			// The npm-installed engine binary could not be resolved. The core still
+			// decides whether it needs to spawn a local engine; if it does, it will
+			// fail with engine.binary_unavailable (auto-download is off in the napi
+			// runtime). Warn so the cause is actionable.
+			logger().warn({
+				msg: "could not resolve a local engine binary; if a local engine must be spawned it will fail with engine.binary_unavailable — set RIVET_ENGINE_BINARY_PATH or install the @rivetkit/engine-cli platform package",
+				error: stringifyError(error),
+			});
+		}
 	}
 	serveConfig.engineHost = config.engineHost;
 	serveConfig.enginePort = config.enginePort;

--- a/rivetkit-typescript/packages/rivetkit/src/registry/runtime.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/runtime.ts
@@ -440,6 +440,11 @@ export interface CoreRuntime {
 	actorRuntimeState(ctx: ActorContextHandle): object;
 	actorClearRuntimeState(ctx: ActorContextHandle): void;
 	actorRestartRunHandler(ctx: ActorContextHandle): void;
+	actorReportError(
+		ctx: ActorContextHandle,
+		hookName: string,
+		rawErrorRef?: number,
+	): void;
 	actorBeginWebsocketCallback(ctx: ActorContextHandle): number;
 	actorEndWebsocketCallback(ctx: ActorContextHandle, regionId: number): void;
 
@@ -613,22 +618,21 @@ export async function buildServeConfig(
 		serverlessMaxStartPayloadBytes: config.serverless.maxStartPayloadBytes,
 	};
 
-	// Always best-effort resolve the engine binary path and hand it to the core.
-	// The core alone decides whether to actually spawn a local engine, so JS must
-	// not duplicate that decision here. `loadEnginePath` throws when no binary is
-	// available (remote-only install, unsupported platform, optional deps
-	// skipped); in that case leave it unset and let the core report
-	// `engine.binary_unavailable` only if it actually needs one.
-	try {
-		serveConfig.engineBinaryPath = await loadEnginePath();
-	} catch (error) {
-		// The engine binary could not be resolved. The core still decides whether
-		// it needs to spawn a local engine; if it does, it will fail with
-		// engine.binary_unavailable (auto-download is off in the napi runtime).
-		logger().warn({
-			msg: "could not resolve a local engine binary; if a local engine must be spawned it will fail with engine.binary_unavailable — set RIVET_ENGINE_BINARY_PATH or install the @rivetkit/engine-cli platform package",
-			error: stringifyError(error),
-		});
+	if (config.runtime !== "wasm") {
+		// Always best-effort resolve the engine binary path and hand it to native
+		// core. Wasm runtimes cannot spawn native engine binaries, so the field
+		// must stay unset there.
+		try {
+			serveConfig.engineBinaryPath = await loadEnginePath();
+		} catch (error) {
+			// The engine binary could not be resolved. The core still decides whether
+			// it needs to spawn a local engine; if it does, it will fail with
+			// engine.binary_unavailable (auto-download is off in the napi runtime).
+			logger().warn({
+				msg: "could not resolve a local engine binary; if a local engine must be spawned it will fail with engine.binary_unavailable — set RIVET_ENGINE_BINARY_PATH or install the @rivetkit/engine-cli platform package",
+				error: stringifyError(error),
+			});
+		}
 	}
 	serveConfig.engineHost = config.engineHost;
 	serveConfig.enginePort = config.enginePort;

--- a/rivetkit-typescript/packages/rivetkit/src/registry/wasm-runtime.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/wasm-runtime.ts
@@ -580,6 +580,14 @@ export class WasmCoreRuntime implements CoreRuntime {
 		callHandle(asWasmActorContext(ctx), "restartRunHandler");
 	}
 
+	actorReportError(
+		ctx: ActorContextHandle,
+		hookName: string,
+		rawErrorRef?: number,
+	): void {
+		callHandle(asWasmActorContext(ctx), "reportError", hookName, rawErrorRef);
+	}
+
 	actorBeginWebsocketCallback(ctx: ActorContextHandle): number {
 		return callHandle(asWasmActorContext(ctx), "beginWebsocketCallback");
 	}

--- a/rivetkit-typescript/packages/rivetkit/tests/driver/actor-onerror.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/driver/actor-onerror.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test } from "vitest";
+import {
+	getActorOnErrorReports,
+	resetActorOnErrorReports,
+} from "../../fixtures/driver-test-suite/actor-onerror";
+import { describeDriverMatrix } from "./shared-matrix";
+import { setupDriverTest, waitFor } from "./shared-utils";
+
+async function waitForReports(
+	driverTestConfig: Parameters<typeof waitFor>[0],
+	key: string,
+	count: number,
+) {
+	for (let i = 0; i < 60; i++) {
+		const reports = getActorOnErrorReports(key);
+		if (reports.length >= count) return reports;
+		await waitFor(driverTestConfig, 50);
+	}
+	return getActorOnErrorReports(key);
+}
+
+describeDriverMatrix("Actor onError", (driverTestConfig) => {
+	describe("universal actor onError", () => {
+		test("reports action errors to actor hook before registry hook without suppressing", async (c) => {
+			const key = "onerror-action";
+			resetActorOnErrorReports(key);
+			const { client } = await setupDriverTest(c, driverTestConfig);
+			const handle = client.actorOnErrorActionActor.getOrCreate([key]);
+
+			await expect(handle.failAction()).rejects.toThrow();
+
+			const reports = await waitForReports(driverTestConfig, key, 2);
+			expect(reports.map((report) => report.source)).toEqual([
+				"actor",
+				"registry",
+			]);
+			expect(reports[0]).toMatchObject({
+				arm: "action",
+				detail: "failAction",
+				scheduled: false,
+				errorMessage: "onError action boom",
+				rawError: true,
+			});
+			await expect(handle.succeed()).resolves.toBe("ok");
+		});
+
+		test("reports scheduled action errors as scheduled action events", async (c) => {
+			const key = "onerror-scheduled";
+			resetActorOnErrorReports(key);
+			const { client } = await setupDriverTest(c, driverTestConfig);
+			const handle = client.actorOnErrorActionActor.getOrCreate([key]);
+
+			await handle.scheduleFailure(10);
+
+			const reports = await waitForReports(driverTestConfig, key, 2);
+			expect(reports[0]).toMatchObject({
+				source: "actor",
+				arm: "action",
+				detail: "scheduledFailure",
+				scheduled: true,
+				errorMessage: "onError scheduled boom",
+			});
+		});
+
+		test("reports request hook errors", async (c) => {
+			const key = "onerror-request";
+			resetActorOnErrorReports(key);
+			const { client } = await setupDriverTest(c, driverTestConfig);
+			const handle = client.actorOnErrorHookActor.getOrCreate([key]);
+
+			const response = await handle.fetch("/boom");
+			expect(response.status).toBe(500);
+
+			const reports = await waitForReports(driverTestConfig, key, 2);
+			expect(reports[0]).toMatchObject({
+				arm: "hook",
+				detail: "onRequest",
+				errorMessage: "onError request boom",
+			});
+		});
+
+		test("reports startup hook errors with the hook name", async (c) => {
+			const key = "onerror-startup";
+			resetActorOnErrorReports(key);
+			const { client } = await setupDriverTest(c, driverTestConfig);
+			const handle = client.actorOnErrorStartupActor.getOrCreate([key]);
+
+			await expect(handle.ping()).rejects.toThrow();
+
+			const reports = await waitForReports(driverTestConfig, key, 2);
+			expect(reports[0]).toMatchObject({
+				arm: "hook",
+				detail: "onCreate",
+				errorMessage: "onError startup boom",
+			});
+		});
+
+		test("reports queue publish errors as queue events", async (c) => {
+			const key = "onerror-queue";
+			resetActorOnErrorReports(key);
+			const { client } = await setupDriverTest(c, driverTestConfig);
+			const handle = client.actorOnErrorQueueActor.getOrCreate([key]);
+
+			await expect(handle.send("fail", { value: 1 })).rejects.toThrow();
+
+			const reports = await waitForReports(driverTestConfig, key, 2);
+			expect(reports[0]).toMatchObject({
+				arm: "queue",
+				detail: "fail",
+				errorMessage: "onError queue boom",
+			});
+		});
+
+		test.skipIf(!driverTestConfig.useRealTimers)(
+			"reports action timeout errors",
+			async (c) => {
+				const key = "onerror-timeout";
+				resetActorOnErrorReports(key);
+				const { client } = await setupDriverTest(c, driverTestConfig);
+				const handle =
+					client.actorOnErrorTimeoutActor.getOrCreate([key]);
+
+				await expect(handle.timeoutAction()).rejects.toThrow(
+					/timed out/i,
+				);
+
+				const reports = await waitForReports(driverTestConfig, key, 2);
+				expect(reports[0]).toMatchObject({
+					arm: "action",
+					detail: "timeoutAction",
+					scheduled: false,
+				});
+				expect(reports[0].errorMessage).toMatch(/timed out/i);
+			},
+		);
+
+		test("reports run handler failures as fatal run events", async (c) => {
+			const key = "onerror-run";
+			resetActorOnErrorReports(key);
+			const { client } = await setupDriverTest(c, driverTestConfig);
+			const handle = client.actorOnErrorRunActor.getOrCreate([key]);
+
+			await handle.ping().catch(() => undefined);
+
+			const reports = await waitForReports(driverTestConfig, key, 2);
+			expect(reports[0]).toMatchObject({
+				arm: "fatal",
+				detail: "run",
+				errorMessage: "onError run boom",
+			});
+		});
+
+		test("reports state serialization failures at the action boundary", async (c) => {
+			const key = "onerror-internal";
+			resetActorOnErrorReports(key);
+			const { client } = await setupDriverTest(c, driverTestConfig);
+			const handle = client.actorOnErrorActionActor.getOrCreate([key]);
+
+			await expect(handle.breakPersist()).rejects.toThrow();
+
+			const reports = await waitForReports(driverTestConfig, key, 2);
+			expect(reports[0]).toMatchObject({
+				arm: "action",
+				detail: "breakPersist",
+			});
+		});
+
+		test("swallows throwing and rejecting onError hooks", async (c) => {
+			resetActorOnErrorReports("onerror-throwing");
+			resetActorOnErrorReports("onerror-rejecting");
+			const { client } = await setupDriverTest(c, driverTestConfig);
+
+			const throwing =
+				client.actorOnErrorThrowingHookActor.getOrCreate([
+					"onerror-throwing",
+				]);
+			await expect(throwing.failAction()).rejects.toThrow();
+			await expect(throwing.ping()).resolves.toBe("pong");
+
+			const rejecting =
+				client.actorOnErrorRejectingHookActor.getOrCreate([
+					"onerror-rejecting",
+				]);
+			await expect(rejecting.failAction()).rejects.toThrow();
+			await expect(rejecting.ping()).resolves.toBe("pong");
+
+			const throwingReports = await waitForReports(
+				driverTestConfig,
+				"onerror-throwing",
+				2,
+			);
+			const rejectingReports = await waitForReports(
+				driverTestConfig,
+				"onerror-rejecting",
+				2,
+			);
+			expect(throwingReports[0]?.source).toBe("throwing-actor");
+			expect(rejectingReports[0]?.source).toBe("rejecting-actor");
+		});
+
+		test("does not report actor.aborted run unwind", async (c) => {
+			const key = "onerror-aborted";
+			resetActorOnErrorReports(key);
+			const { client } = await setupDriverTest(c, driverTestConfig);
+			const handle = client.actorOnErrorAbortRunActor.getOrCreate([key]);
+
+			await handle.ping();
+			await handle.destroySelf();
+			await waitFor(driverTestConfig, 250);
+
+			expect(getActorOnErrorReports(key)).toEqual([]);
+		});
+	});
+});

--- a/website/src/content/docs/actors/errors.mdx
+++ b/website/src/content/docs/actors/errors.mdx
@@ -112,6 +112,37 @@ The client receives only a generic "Internal error" message for security, but yo
 
 **Always check your server logs to see the actual error details when debugging internal errors.**
 
+### Reporting Errors to Sentry
+
+Use registry-level `onError` to forward actor errors to Sentry or another error tracker. It fires for action errors, lifecycle hook errors, request and WebSocket handler errors, queue errors, and internal runtime failures.
+
+```ts
+import * as Sentry from "@sentry/node";
+import { setup, UserError } from "rivetkit";
+import { counter } from "./counter";
+
+Sentry.init({ dsn: process.env.SENTRY_DSN });
+
+export const registry = setup({
+	use: { counter },
+	onError: (c, event) => {
+		const [[source, data]] = Object.entries(event);
+		if (data.error instanceof UserError) return;
+
+		Sentry.captureException(data.error, {
+			tags: {
+				actor: c.name,
+				actorId: c.actorId,
+				source,
+			},
+			extra: data,
+		});
+	},
+});
+```
+
+`onError` is observational: the original error still propagates to the caller, and throwing or rejecting inside `onError` is logged and ignored. Define actor-level `onError` when one actor needs custom reporting; actor-level hooks run before the registry-level hook.
+
 ### Exposing Errors to Clients (Development Only)
 
 **Warning:** Only enable error exposure in development environments. In production, this will leak sensitive internal details to clients.
@@ -126,4 +157,3 @@ With error exposure enabled, clients will see the full error message instead of 
 
 - [`UserError`](/typedoc/classes/rivetkit.actor_errors.UserError.html) - User-facing error class
 - [`ActorError`](/typedoc/classes/rivetkit.client_mod.ActorError.html) - Errors received by the client
-

--- a/website/src/content/docs/actors/lifecycle.mdx
+++ b/website/src/content/docs/actors/lifecycle.mdx
@@ -71,6 +71,11 @@ Loading ──Start──▶ Ready ──spawn driver──▶ Started
 1. `queues.<name>.canPublish` (if defined)
 2. Queue message is enqueued
 
+**On Error** (diagnostic only)
+
+1. Actor-level `onError` (if defined)
+2. Registry-level `onError` (if defined)
+
 **On Event Subscription Request** (per subscribe request)
 
 1. `events.<name>.canSubscribe` (if defined)
@@ -159,6 +164,14 @@ This hook may not always be called in situations like crashes or forced terminat
 Not supported on Cloudflare Workers.
 
 <CodeSnippet file="examples/docs/actors-lifecycle/on-sleep.ts" />
+
+### `onError`
+
+[API Reference](/typedoc/interfaces/rivetkit.mod.ActorDefinition.html)
+
+The `onError` hook is called when actor user code or runtime machinery reports an error. It receives an error context with actor identity and a tagged event such as `action`, `hook`, `queue`, `internal`, or `fatal`.
+
+This hook is observational only. It cannot suppress the original error, and errors thrown from `onError` are logged and ignored. Use it for diagnostics such as sending actor failures to an error tracker.
 
 ### `run`
 


### PR DESCRIPTION
- Add the universal actor `onError` hook across rivetkit-core, NAPI, wasm, and TypeScript runtime plumbing.
- Report action, hook, queue, internal, fatal, timeout, and state-change errors without allowing `onError` to suppress the original failure.
- Document the lifecycle hook and Sentry integration path.
- Add driver coverage for actor-level and registry-level delivery, ordering, swallowed hook failures, timeout reporting, and `actor.aborted` suppression.
- Verified with `cargo check -p rivetkit-core`, `pnpm build:force` in `packages/rivetkit-napi`, `pnpm build` in `packages/rivetkit-wasm`, and targeted native/wasm actor-onerror driver tests.
