### PR TITLE
feat(inspector-tabs): send resolved theme tokens and mounted surface to custom tab iframes

### DIFF
--- a/examples/inspector-tabs/inspector-tabs/counter/index.html
+++ b/examples/inspector-tabs/inspector-tabs/counter/index.html
@@ -20,8 +20,9 @@ File layout:
      3c. HELPERS        — DOM helpers (errors, busy state)
      3d. INSPECTOR HTTP — fetchState / invokeAction wrappers
      3e. RENDERING      — translate actor state into DOM
-     3f. HANDSHAKE      — postMessage receiver + `ready` signal (REQUIRED)
-     3g. WIRING         — connect buttons to actions (UI-specific)
+     3f. THEME          — mirror the dashboard's theme + tokens
+     3g. HANDSHAKE      — postMessage receiver + `ready` signal (REQUIRED)
+     3h. WIRING         — connect buttons to actions (UI-specific)
 
 REQUIRED markers below highlight the contract between every tab and the
 dashboard. Everything else is demo-specific.
@@ -44,9 +45,9 @@ dashboard. Everything else is demo-specific.
 		     The stylesheet exposes the dashboard's design tokens as
 		     `--rivet-*` CSS variables, mirrors the dashboard's light +
 		     dark token blocks, and ships sensible body/button/input
-		     defaults. The tab applies the dashboard's active theme by
-		     toggling the `dark` class on `<html>` from the `v1Init`
-		     handler below.
+		     defaults, including painting `body` with `--rivet-surface`
+		     (the panel the tab is mounted on). The tab applies the
+		     dashboard's active theme in section 3f below.
 
 		     You can omit this link and bring your own CSS — the inspector
 		     tab API doesn't require it. -->
@@ -54,6 +55,13 @@ dashboard. Everything else is demo-specific.
 
 		<style>
 			/* Demo-specific layout on top of the shared sheet. */
+			html,
+			body {
+				/* The dashboard mounts the tab on its `card` panel. Stated
+				   explicitly so the tab matches its host even against an
+				   older stylesheet that defaults to `--rivet-background`. */
+				background: var(--rivet-surface, var(--rivet-card));
+			}
 			body {
 				display: flex;
 				flex-direction: column;
@@ -305,14 +313,48 @@ dashboard. Everything else is demo-specific.
 			}
 
 			// =================================================================
-			// 3f. HANDSHAKE — REQUIRED postMessage contract
+			// 3f. THEME — mirror the dashboard's colors
+			// =================================================================
+			//
+			// Two signals arrive on every `init`, and `init` is re-sent when
+			// the user toggles the dashboard theme, so applying them here is
+			// all a tab needs to follow a live theme change:
+			//
+			//   • `theme` — "light" | "dark". The shared stylesheet keys its
+			//     token blocks off the `dark` class on <html>.
+			//   • `tokens` + `surface` — the dashboard's resolved colors as
+			//     ready-to-use CSS values, with `surface` naming the token of
+			//     the panel this iframe is mounted on. Pinning them as inline
+			//     `--rivet-*` properties makes the tab match the dashboard
+			//     exactly, even if the stylesheet ships different values.
+			//
+			// Both are optional: an older dashboard sends only `theme`, and
+			// the stylesheet alone still resolves the right colors.
+
+			function applyTheme(msg) {
+				const root = document.documentElement;
+				root.classList.toggle("dark", (msg.theme ?? "dark") === "dark");
+				if (!msg.tokens) return;
+				for (const [name, value] of Object.entries(msg.tokens)) {
+					const varName = name.replace(
+						/[A-Z]/g,
+						(c) => `-${c.toLowerCase()}`,
+					);
+					root.style.setProperty(`--rivet-${varName}`, value);
+				}
+				const surface = msg.tokens[msg.surface ?? "card"];
+				if (surface) root.style.setProperty("--rivet-surface", surface);
+			}
+
+			// =================================================================
+			// 3g. HANDSHAKE — REQUIRED postMessage contract
 			// =================================================================
 			//
 			// The dashboard ↔ tab handshake follows a tiny envelope:
 			//
 			//   Dashboard → tab (`v1Init`):
 			//     { type: "init", v: 1, actorId, authToken, rivetToken?,
-			//       activeTab? }
+			//       activeTab?, theme?, tokens?, surface? }
 			//
 			//   Tab → dashboard (`v1Ready`):
 			//     { type: "ready", v: 1 }
@@ -346,14 +388,7 @@ dashboard. Everything else is demo-specific.
 				if (msg.type === "init" && msg.v === 1) {
 					actorId = msg.actorId;
 					authToken = msg.authToken;
-					// Mirror the dashboard's active theme by toggling
-					// the `dark` class on <html>. The shared stylesheet
-					// drives `--rivet-*` tokens off that class. If the
-					// dashboard omits `theme`, default to dark.
-					document.documentElement.classList.toggle(
-						"dark",
-						(msg.theme ?? "dark") === "dark",
-					);
+					applyTheme(msg);
 					if (pollTimer) clearInterval(pollTimer);
 					fetchState();
 					// Poll every second. For higher-frequency UIs prefer a
@@ -364,7 +399,7 @@ dashboard. Everything else is demo-specific.
 			});
 
 			// =================================================================
-			// 3g. WIRING — connect UI events to actions (demo-specific)
+			// 3h. WIRING — connect UI events to actions (demo-specific)
 			// =================================================================
 
 			document

--- a/examples/inspector-tabs/inspector-tabs/info/index.html
+++ b/examples/inspector-tabs/inspector-tabs/info/index.html
@@ -21,7 +21,8 @@ Structure:
      3b. STATE      — token + actor id (populated by `v1Init`)
      3c. FETCH      — small JSON helper with auth + 401 handling
      3d. RENDER     — pull state + rpcs in parallel, render each panel
-     3e. HANDSHAKE  — `v1Init` receiver + `ready` signal (REQUIRED)
+     3e. THEME      — mirror the dashboard's theme + tokens
+     3f. HANDSHAKE  — `v1Init` receiver + `ready` signal (REQUIRED)
 -->
 <html lang="en">
 	<head>
@@ -35,6 +36,13 @@ Structure:
 		<link rel="stylesheet" href="../../tab.css" />
 
 		<style>
+			html,
+			body {
+				/* The dashboard mounts the tab on its `card` panel. Stated
+				   explicitly so the tab matches its host even against an
+				   older stylesheet that defaults to `--rivet-background`. */
+				background: var(--rivet-surface, var(--rivet-card));
+			}
 			body {
 				display: flex;
 				flex-direction: column;
@@ -223,7 +231,32 @@ Structure:
 			}
 
 			// =================================================================
-			// 3e. HANDSHAKE — REQUIRED postMessage contract
+			// 3e. THEME — mirror the dashboard's theme + tokens
+			// =================================================================
+			//
+			// `init` carries `theme` (the class the shared stylesheet keys
+			// its token blocks off) plus `tokens` and `surface` (the
+			// dashboard's resolved colors, and which of them paints the
+			// panel this iframe sits on). Both are re-sent on every theme
+			// toggle. See `../counter/index.html` for the longer walkthrough.
+
+			function applyTheme(msg) {
+				const root = document.documentElement;
+				root.classList.toggle("dark", (msg.theme ?? "dark") === "dark");
+				if (!msg.tokens) return;
+				for (const [name, value] of Object.entries(msg.tokens)) {
+					const varName = name.replace(
+						/[A-Z]/g,
+						(c) => `-${c.toLowerCase()}`,
+					);
+					root.style.setProperty(`--rivet-${varName}`, value);
+				}
+				const surface = msg.tokens[msg.surface ?? "card"];
+				if (surface) root.style.setProperty("--rivet-surface", surface);
+			}
+
+			// =================================================================
+			// 3f. HANDSHAKE — REQUIRED postMessage contract
 			// =================================================================
 
 			window.addEventListener("message", (event) => {
@@ -233,12 +266,7 @@ Structure:
 				if (msg.type === "init" && msg.v === 1) {
 					actorId = msg.actorId;
 					authToken = msg.authToken;
-					// Match the dashboard's active theme — the shared
-					// stylesheet drives tokens off the `dark` class.
-					document.documentElement.classList.toggle(
-						"dark",
-						(msg.theme ?? "dark") === "dark",
-					);
+					applyTheme(msg);
 					document.getElementById("actor-id").textContent = actorId;
 					document.getElementById("engine-origin").textContent =
 						window.location.origin;

--- a/frontend/scripts/generate-inspector-tab-css.mjs
+++ b/frontend/scripts/generate-inspector-tab-css.mjs
@@ -49,11 +49,20 @@ const HEADER = `/*!
  *
  *   <link rel="stylesheet" href="../../tab.css">
  *
- * Theme switching: tokens follow the dashboard's mechanism — \`:root\`
+ * Theme switching: tokens follow the dashboard's mechanism. \`:root\`
  * carries the light defaults and \`:root[class~="dark"]\` overrides with
  * dark values. The dashboard passes the active theme via the \`v1Init\`
  * postMessage (\`theme: "light" | "dark"\`); apply it by toggling the
- * \`dark\` class on \`<html>\` inside the tab.
+ * \`dark\` class on \`<html>\` inside the tab. \`v1Init\` also carries
+ * \`tokens\` (resolved CSS colors) and \`surface\` (which token names the
+ * panel the tab is mounted on); pinning those as inline
+ * \`--rivet-*\` properties makes the tab track the dashboard exactly even
+ * if this stylesheet is older than the shell.
+ *
+ * Surface: the tab is mounted on the dashboard's \`--card\` panel, so
+ * \`--rivet-surface\` (defaulting to \`--rivet-card\`) is what \`html\` and
+ * \`body\` paint. Do not use \`--rivet-background\` for the tab's own
+ * backdrop; it is the color of the dashboard shell around the panel.
  */`;
 
 function main() {

--- a/frontend/scripts/inspector-tab-aliases.css
+++ b/frontend/scripts/inspector-tab-aliases.css
@@ -60,6 +60,15 @@
 	--rivet-input: hsl(var(--input));
 	--rivet-ring: hsl(var(--ring));
 
+	/* The surface the tab iframe is mounted on. The dashboard hosts custom
+	 * tabs on a `--card` panel, so a tab painting itself with this token
+	 * composites flush against its host instead of showing a seam. The
+	 * dashboard also sends the resolved value as `init.tokens[init.surface]`;
+	 * applying that overrides this default if the host ever moves the tab
+	 * onto a different surface. */
+	--rivet-surface: var(--rivet-card);
+	--rivet-surface-foreground: var(--rivet-card-foreground);
+
 	--rivet-radius: var(--radius);
 	--rivet-radius-sm: calc(var(--rivet-radius) - 4px);
 	--rivet-radius-md: calc(var(--rivet-radius) - 2px);
@@ -95,8 +104,8 @@
 html, body {
 	margin: 0;
 	padding: 0;
-	background: var(--rivet-background);
-	color: var(--rivet-foreground);
+	background: var(--rivet-surface);
+	color: var(--rivet-surface-foreground);
 	font-family: var(--rivet-font-sans);
 	font-size: 14px;
 	line-height: 1.5;

--- a/frontend/src/components/actors/actor-details-iframe.tsx
+++ b/frontend/src/components/actors/actor-details-iframe.tsx
@@ -39,6 +39,10 @@ import {
 import { useFiltersValue } from "./actor-filters-context";
 import { useDataProvider } from "./data-provider";
 import { resolveInspectorTabIcon } from "./inspector-tab-icons";
+import {
+	INSPECTOR_TAB_SURFACE,
+	readInspectorTabTokens,
+} from "./inspector-tab-tokens";
 import type { InspectorTabDescriptor } from "./inspector-tab-registry";
 import type { ActorId, ActorStatus } from "./queries";
 import { ActorStatusLabel, QueriedActorError } from "./actor-status-label";
@@ -463,6 +467,10 @@ function ActorDetailsIframePath({
 	const themeRef = useRef(theme);
 	themeRef.current = theme;
 
+	// `useTheme` derives the theme from the class on `<html>`, so by the time
+	// this re-renders the new theme's tokens are already the computed values.
+	const tokens = useMemo(() => readInspectorTabTokens(), [theme]);
+
 	const actorSegment = useMemo(
 		() =>
 			rivetToken
@@ -527,6 +535,8 @@ function ActorDetailsIframePath({
 				rivetToken: rivetToken || undefined,
 				activeTab: activeInspectorTabId,
 				theme,
+				tokens: tokens ?? undefined,
+				surface: INSPECTOR_TAB_SURFACE,
 			},
 			expectedOrigin,
 		);
@@ -538,6 +548,7 @@ function ActorDetailsIframePath({
 		expectedOrigin,
 		activeInspectorTabId,
 		theme,
+		tokens,
 	]);
 
 	const postSetActiveTab = useCallback(

--- a/frontend/src/components/actors/inspector-tab-tokens.ts
+++ b/frontend/src/components/actors/inspector-tab-tokens.ts
@@ -1,0 +1,49 @@
+import {
+	INSPECTOR_TAB_TOKEN_NAMES,
+	type InspectorTabTokens,
+} from "rivetkit/inspector-tab";
+
+/**
+ * Token name of the surface custom tabs are mounted on. The iframe's
+ * container is painted `bg-card`, so a tab that paints its body with this
+ * token sits flush in the panel instead of one step darker/lighter.
+ */
+export const INSPECTOR_TAB_SURFACE = "card";
+
+// Dashboard tokens are stored as bare HSL components (`240 7% 5%`) so they
+// can be composed with alpha. Tabs get finished CSS colors instead, since
+// they can't know which of the dashboard's tokens are raw.
+function toCssColor(value: string): string {
+	return /^(#|rgb|hsl|hwb|lab|lch|oklab|oklch|color|var\()/i.test(value)
+		? value
+		: `hsl(${value})`;
+}
+
+/**
+ * Reads the dashboard's resolved theme colors for the theme currently
+ * applied to `<html>`.
+ *
+ * Returns `null` if any token is missing, rather than a partial payload:
+ * a tab receiving half the tokens would paint an inconsistent mix, while
+ * a tab receiving none falls back to its stylesheet, which is correct.
+ */
+export function readInspectorTabTokens(): InspectorTabTokens | null {
+	if (typeof document === "undefined") return null;
+	const computed = getComputedStyle(document.documentElement);
+	const tokens: Record<string, string> = {};
+	for (const name of INSPECTOR_TAB_TOKEN_NAMES) {
+		const raw = computed
+			.getPropertyValue(
+				`--${name.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)}`,
+			)
+			.trim();
+		if (!raw) {
+			console.error(
+				`inspector tab tokens: missing dashboard token --${name}, sending none`,
+			);
+			return null;
+		}
+		tokens[name] = toCssColor(raw);
+	}
+	return tokens as InspectorTabTokens;
+}

--- a/rivetkit-typescript/packages/rivetkit/src/inspector-tab/mod.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/inspector-tab/mod.ts
@@ -97,6 +97,79 @@ export const InspectorTabDescriptorSchema = z.object({
 });
 
 /**
+ * Names of the theme tokens the dashboard resolves and sends on `init`.
+ *
+ * Each name maps to a `--rivet-<kebab-case>` CSS variable in the shared
+ * stylesheet (`/inspector/tab.css`), so a tab can push the whole payload
+ * into inline custom properties without a name table of its own.
+ */
+export const INSPECTOR_TAB_TOKEN_NAMES = [
+	"background",
+	"foreground",
+	"card",
+	"cardForeground",
+	"popover",
+	"popoverForeground",
+	"primary",
+	"primaryForeground",
+	"secondary",
+	"secondaryForeground",
+	"muted",
+	"mutedForeground",
+	"accent",
+	"accentForeground",
+	"destructive",
+	"destructiveForeground",
+	"border",
+	"input",
+	"ring",
+] as const;
+
+export type InspectorTabTokenName = (typeof INSPECTOR_TAB_TOKEN_NAMES)[number];
+
+/**
+ * Resolved theme colors, as CSS color strings usable directly in a
+ * declaration (`background: tokens.card`). The dashboard reads them from
+ * its own live computed styles, so they track the dashboard's tokens
+ * without the tab hardcoding values.
+ *
+ * Unknown extra keys are preserved rather than rejected, so a dashboard
+ * that adds a token doesn't break tabs pinned to an older rivetkit.
+ */
+export const InspectorTabTokensSchema = z
+	.object({
+		background: z.string(),
+		foreground: z.string(),
+		card: z.string(),
+		cardForeground: z.string(),
+		popover: z.string(),
+		popoverForeground: z.string(),
+		primary: z.string(),
+		primaryForeground: z.string(),
+		secondary: z.string(),
+		secondaryForeground: z.string(),
+		muted: z.string(),
+		mutedForeground: z.string(),
+		accent: z.string(),
+		accentForeground: z.string(),
+		destructive: z.string(),
+		destructiveForeground: z.string(),
+		border: z.string(),
+		input: z.string(),
+		ring: z.string(),
+	})
+	.catchall(z.string());
+
+export type InspectorTabTokens = z.infer<typeof InspectorTabTokensSchema>;
+
+/**
+ * Token name of the surface the tab iframe is mounted on, when the
+ * dashboard doesn't say. Also the fallback used by
+ * `resolveInspectorTabSurface`.
+ */
+export const DEFAULT_INSPECTOR_TAB_SURFACE = "card";
+
+/**
  * Initial handshake from the dashboard. Sent on first mount and again on
  * every token refresh. Tabs MUST accept late `init` messages and replace
  * the cached token.
@@ -129,6 +202,23 @@ export const V1InitSchema = z.object({
 	 * mode before this field was added).
 	 */
 	theme: z.enum(["light", "dark"]).optional(),
+	/**
+	 * Theme colors resolved from the dashboard's live styles for the
+	 * active theme. Re-sent on every theme change, so a tab that applies
+	 * them repaints without a reload. Optional for backwards
+	 * compatibility — tabs that only read `theme` and use the shared
+	 * stylesheet still resolve the same values from CSS.
+	 */
+	tokens: InspectorTabTokensSchema.optional(),
+	/**
+	 * Key in `tokens` naming the surface the iframe is mounted on. A tab
+	 * that paints its body with this color sits flush in the panel that
+	 * hosts it. Left as a plain string (not an enum) so a dashboard that
+	 * moves the tab to a different surface doesn't fail the parse on
+	 * tabs pinned to an older rivetkit; resolve it through
+	 * `resolveInspectorTabSurface`, which falls back to `card`.
+	 */
+	surface: z.string().optional(),
 });
 
 /**
@@ -202,6 +292,65 @@ export const POSTMESSAGE_PROTOCOL_VERSION = 1;
 /** URL query parameters the dashboard sets on the tab iframe `src`. */
 export const SHELL_ORIGIN_PARAM = "shellOrigin";
 export const ACTOR_ID_PARAM = "actorId";
+
+// ============================================================================
+// Theme application helpers.
+//
+// Tabs bundled with a build step can import these; a plain `index.html`
+// tab can inline the same three lines by hand (see the docs page).
+// ============================================================================
+
+/** CSS custom property a token name maps to in the shared stylesheet. */
+export function inspectorTabTokenVar(name: string): string {
+	return `--rivet-${name.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)}`;
+}
+
+/**
+ * Color of the surface the tab is mounted on, or `undefined` when the
+ * dashboard sent no tokens (older shell). Paint the tab's body with this
+ * to sit flush in the hosting panel.
+ */
+export function resolveInspectorTabSurface(
+	init: Pick<V1Init, "tokens" | "surface">,
+): string | undefined {
+	const tokens = init.tokens;
+	if (!tokens) return undefined;
+	return (
+		tokens[init.surface ?? DEFAULT_INSPECTOR_TAB_SURFACE] ??
+		tokens[DEFAULT_INSPECTOR_TAB_SURFACE]
+	);
+}
+
+/**
+ * Structural subset of `HTMLElement` the theme helper touches. Declared
+ * structurally because this package builds without the DOM lib.
+ */
+export interface InspectorTabThemeTarget {
+	classList: { toggle(token: string, force?: boolean): boolean };
+	style: { setProperty(property: string, value: string): void };
+}
+
+/**
+ * Mirrors the dashboard's theme onto a tab document: toggles the `dark`
+ * class the shared stylesheet keys off, then pins every token the
+ * dashboard resolved as an inline custom property so the tab renders the
+ * dashboard's exact colors even if its vendored stylesheet is older.
+ *
+ * Pass `document.documentElement`. Safe to call on every `init`, which is
+ * how live theme changes arrive.
+ */
+export function applyInspectorTabTheme(
+	init: Pick<V1Init, "theme" | "tokens" | "surface">,
+	target: InspectorTabThemeTarget,
+): void {
+	target.classList.toggle("dark", (init.theme ?? "dark") === "dark");
+	if (!init.tokens) return;
+	for (const [name, value] of Object.entries(init.tokens)) {
+		target.style.setProperty(inspectorTabTokenVar(name), value);
+	}
+	const surface = resolveInspectorTabSurface(init);
+	if (surface) target.style.setProperty("--rivet-surface", surface);
+}
 
 // ============================================================================
 // Inspector HTTP endpoint response schemas (source of truth).

--- a/website/src/content/docs/actors/inspector-tabs.mdx
+++ b/website/src/content/docs/actors/inspector-tabs.mdx
@@ -33,6 +33,13 @@ Drop an `index.html` in the `source` directory:
 <html lang="en">
   <head>
     <link rel="stylesheet" href="../../tab.css" />
+    <style>
+      /* The tab is mounted on the dashboard's `card` panel. */
+      html,
+      body {
+        background: var(--rivet-surface, var(--rivet-card));
+      }
+    </style>
   </head>
   <body>
     <h1>Counter: <span id="value">…</span></h1>
@@ -58,11 +65,22 @@ Drop an `index.html` in the `source` directory:
         });
         const { state } = await r.json();
         document.getElementById("value").textContent = state.value;
-        document.documentElement.classList.toggle(
-          "dark",
-          (e.data.theme ?? "dark") === "dark",
-        );
+        applyTheme(e.data);
       });
+
+      // Mirror the dashboard's theme. Re-run on every `init` — the
+      // dashboard re-sends it when the user toggles the theme.
+      function applyTheme(msg) {
+        const root = document.documentElement;
+        root.classList.toggle("dark", (msg.theme ?? "dark") === "dark");
+        if (!msg.tokens) return;
+        for (const [name, value] of Object.entries(msg.tokens)) {
+          const varName = name.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`);
+          root.style.setProperty(`--rivet-${varName}`, value);
+        }
+        const surface = msg.tokens[msg.surface ?? "card"];
+        if (surface) root.style.setProperty("--rivet-surface", surface);
+      }
 
       window.parent.postMessage({ type: "ready", v: 1 }, SHELL_ORIGIN);
     </script>
@@ -135,6 +153,8 @@ arrives.
   actorId: string,
   authToken: string,         // Per-actor inspector bearer token
   theme?: "light" | "dark",
+  tokens?: Record<string, string>,  // Resolved CSS colors — see Styling
+  surface?: string,          // Key in `tokens` for the host panel's color
   activeTab?: string,        // For multi-view tabs
 }
 ```
@@ -143,6 +163,11 @@ Multi-view tabs can read the optional `activeTab` field on `init` to
 seed their initial sub-view. The dashboard does not send a separate
 message when the user switches custom tabs — it navigates the iframe
 `src` instead, so the tab reloads and receives a fresh `init`.
+
+`init` is also the theme channel. The dashboard re-sends it whenever the
+user toggles the theme, so a tab that applies `theme` / `tokens` on every
+`init` follows theme changes without reloading. See
+[Styling](#styling).
 
 ### From the tab
 
@@ -219,17 +244,93 @@ custom CSS:
 }
 ```
 
-Toggle dark mode by adding the `dark` class to `<html>` — the dashboard
-sends the active theme in the `init` message.
+### Which surface the tab is on
 
-Color tokens come in both pre-wrapped (`--rivet-card`) and raw HSL
-(`--rivet-card-raw`) forms, so you can compose with alpha:
+The tab iframe is mounted on the dashboard's **`card`** panel, not on the
+page background. Use `--rivet-surface` (an alias of `--rivet-card`) for
+the tab's own backdrop so it composites seamlessly with the panel around
+it. The stylesheet already paints `html` and `body` with it, so a tab that
+doesn't override the body background needs no extra work.
+
+Do **not** paint the tab with `--rivet-background`. That is the color of
+the dashboard shell *around* the panel, and using it leaves a visible
+seam.
+
+If your tab sets its own body background, state the surface explicitly.
+The fallback keeps it correct against an older stylesheet that predates
+`--rivet-surface`:
+
+```css
+html, body { background: var(--rivet-surface, var(--rivet-card)); }
+```
+
+### Token names
+
+Every dashboard token is exposed under a `--rivet-` prefix, and the same
+names arrive as `init.tokens` keys in camelCase (`--rivet-muted-foreground`
+↔ `tokens.mutedForeground`). These names are stable:
+
+`background`, `foreground`, `card`, `cardForeground`, `popover`,
+`popoverForeground`, `primary`, `primaryForeground`, `secondary`,
+`secondaryForeground`, `muted`, `mutedForeground`, `accent`,
+`accentForeground`, `destructive`, `destructiveForeground`, `border`,
+`input`, `ring`.
+
+Plus `surface` / `--rivet-surface` for the mounted surface described
+above. New tokens may be added; existing names won't change meaning.
+`init.tokens` may carry keys your version of the stylesheet doesn't know,
+so iterate it rather than reading a fixed list.
+
+Color tokens also come in raw HSL form (`--rivet-card-raw`) so you can
+compose with alpha:
 
 ```css
 .overlay { background: hsl(var(--rivet-background-raw) / 0.6); }
 ```
 
-You're free to skip the stylesheet entirely and bring your own.
+### Reacting to theme changes
+
+The dashboard signals the theme two ways on `init`, and re-sends `init`
+every time the user toggles the theme — so a tab that applies both on
+every `init` updates live, with no reload:
+
+- **`theme`** (`"light" | "dark"`) — toggle the `dark` class on `<html>`.
+  The stylesheet's token blocks key off it. Default to `"dark"` if absent.
+- **`tokens`** and **`surface`** — the dashboard's resolved colors, as CSS
+  color values ready to use in a declaration. Pinning them as inline
+  `--rivet-*` custom properties makes the tab render the dashboard's exact
+  colors even if the stylesheet it vendored is older than the dashboard.
+
+```js
+function applyTheme(msg) {
+  const root = document.documentElement;
+  root.classList.toggle("dark", (msg.theme ?? "dark") === "dark");
+  if (!msg.tokens) return;
+  for (const [name, value] of Object.entries(msg.tokens)) {
+    const varName = name.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`);
+    root.style.setProperty(`--rivet-${varName}`, value);
+  }
+  const surface = msg.tokens[msg.surface ?? "card"];
+  if (surface) root.style.setProperty("--rivet-surface", surface);
+}
+```
+
+Tabs built with a bundler can import that logic instead of copying it:
+
+```ts @nocheck
+import { applyInspectorTabTheme } from "rivetkit/inspector-tab";
+
+applyInspectorTabTheme(init, document.documentElement);
+```
+
+`tokens` and `surface` are both optional. An older dashboard sends only
+`theme`, and the stylesheet resolves the right colors on its own — never
+hardcode hex values as a fallback, or the tab drifts the next time the
+dashboard's tokens change.
+
+You're free to skip the stylesheet entirely and bring your own. If you do,
+`init.tokens` is the whole palette, and `init.tokens[init.surface]` is the
+color your body must be for the tab to sit flush in its panel.
 
 ## Security
 


### PR DESCRIPTION
- Custom inspector tab iframes now receive the dashboard's resolved theme colors on the existing `init` postMessage, as `tokens` (ready-to-use CSS color values) plus `surface`, which names the token of the panel the tab is mounted on. `theme` is unchanged, so tabs that only read it keep working.
- The dashboard resolves the tokens from its own live computed styles per theme and re-sends them through the same path it already used for theme changes, so a tab that applies them updates without a reload.
- The shared tab stylesheet gains `--rivet-surface` (the mounted surface, aliasing `--rivet-card`) and paints `html` / `body` with it instead of `--rivet-background`. This alone makes existing tabs sit flush in their host panel with no tab-side change.
- Added `applyInspectorTabTheme`, `resolveInspectorTabSurface`, and `inspectorTabTokenVar` helpers to `rivetkit/inspector-tab` for tabs built with a bundler.
- Documented the contract on the custom-tabs docs page: which surface a tab is mounted on, the stable token names, and how to follow a live theme change.
- Updated both example tabs and the docs quickstart to apply the payload and declare the surface explicitly.

Verified against the generated stylesheet and real theme tokens in a harness reproducing the dashboard's `card` panel: the tab body computes to the same color as its host panel in dark (`rgb(12,12,14)`) and light (`rgb(255,255,255)`), updates on theme toggle without reloading, and a theme-only tab with no token handling measures identically.
