### PR TITLE
chore: remove hub.rivet.gg references

### DIFF
--- a/frontend/src/routes/join.tsx
+++ b/frontend/src/routes/join.tsx
@@ -25,17 +25,6 @@ function RouteComponent() {
 			<div className="flex flex-col items-center gap-6 w-full">
 				<Logo className="h-10 mb-4" />
 				<SignUp />
-				<p className="max-w-md text-center text-xs text-muted-foreground">
-					Looking for Rivet Enterprise Cloud? Visit{" "}
-					<a
-						href="https://hub.rivet.gg"
-						className="underline"
-						target="_blank"
-						rel="noreferrer"
-					>
-						hub.rivet.gg
-					</a>
-				</p>
 			</div>
 		</div>
 	);

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -42,17 +42,6 @@ function RouteComponent() {
 			<div className="flex flex-col items-center gap-6 w-full">
 				<Logo className="h-10 mb-4" />
 				<Login />
-				<p className="max-w-md text-center text-xs text-muted-foreground">
-					Looking for Rivet Enterprise Cloud? Visit{" "}
-					<a
-						href="https://hub.rivet.gg"
-						className="underline"
-						target="_blank"
-						rel="noreferrer"
-					>
-						hub.rivet.gg
-					</a>
-				</p>
 			</div>
 		</div>
 	);

--- a/website/src/content/posts/2026-02-26-sqlite-for-rivet-actors/page.mdx
+++ b/website/src/content/posts/2026-02-26-sqlite-for-rivet-actors/page.mdx
@@ -91,7 +91,7 @@ Combine SQLite with actor events and `useActor` to build realtime apps. Writes p
 
 ## Built-in Database Explorer
 
-Browse and query your actor databases directly from the Rivet Hub. Select any actor instance to view its tables, run queries, and inspect data in realtime.
+Browse and query your actor databases directly from the Rivet dashboard. Select any actor instance to view its tables, run queries, and inspect data in realtime.
 
 ![SQLite Inspector](https://assets.rivet.dev/website/blog/2026-02-26-sqlite-for-rivet-actors/sqliteinspector.png)
 


### PR DESCRIPTION
- Remove the "Looking for Rivet Enterprise Cloud? Visit hub.rivet.gg" banner from the login and join pages
- Update the SQLite blog post to reference the Rivet dashboard instead of the Rivet Hub