### PR TITLE
fix(rivetkit): honor configured shutdown grace

### DIFF
--- a/engine/packages/pegboard-envoy/tests/actor_lifecycle.rs
+++ b/engine/packages/pegboard-envoy/tests/actor_lifecycle.rs
@@ -19,10 +19,13 @@ mod conn {
 	use std::sync::Arc;
 
 	use depot::conveyer::Db;
+	use depot_client::database::NativeDatabaseHandle;
 	use scc::HashMap;
+	use tokio::sync::OnceCell;
 
 	pub struct Conn {
 		pub actor_dbs: HashMap<String, Arc<Db>>,
+		pub remote_sqlite_executors: HashMap<(String, u64), Arc<OnceCell<NativeDatabaseHandle>>>,
 	}
 }
 
@@ -98,13 +101,18 @@ fn new_actor_db(db: Arc<universaldb::Database>, namespace_label: u16, actor_id: 
 	))
 }
 
+fn empty_conn() -> conn::Conn {
+	conn::Conn {
+		actor_dbs: HashMap::new(),
+		remote_sqlite_executors: HashMap::new(),
+	}
+}
+
 #[tokio::test]
 async fn stop_actor_evicts_cached_actor_db() -> Result<()> {
 	let db = Arc::new(test_db().await?);
 	let actor_db = new_actor_db(db, TEST_NAMESPACE_LABEL, TEST_ACTOR);
-	let conn = conn::Conn {
-		actor_dbs: HashMap::new(),
-	};
+	let conn = empty_conn();
 
 	assert!(
 		conn.actor_dbs
@@ -123,9 +131,7 @@ async fn stop_actor_evicts_cached_actor_db() -> Result<()> {
 async fn stop_actor_does_not_touch_udb() -> Result<()> {
 	let db = Arc::new(test_db().await?);
 	let actor_db = new_actor_db(Arc::clone(&db), TEST_NAMESPACE_LABEL, TEST_ACTOR);
-	let conn = conn::Conn {
-		actor_dbs: HashMap::new(),
-	};
+	let conn = empty_conn();
 	assert!(
 		conn.actor_dbs
 			.insert_async(TEST_ACTOR.to_string(), actor_db)
@@ -146,23 +152,28 @@ async fn stop_actor_does_not_touch_udb() -> Result<()> {
 }
 
 #[tokio::test]
-async fn stop_actor_allows_missing_cache_entry() -> Result<()> {
-	let conn = conn::Conn {
-		actor_dbs: HashMap::new(),
-	};
+async fn replayed_stop_for_unknown_actor_allows_replacement_start() -> Result<()> {
+	let conn = empty_conn();
 
 	actor_lifecycle::stop_actor(&conn, &checkpoint(TEST_ACTOR)).await?;
 
 	assert!(!conn.actor_dbs.contains_async(TEST_ACTOR).await);
+	let db = Arc::new(test_db().await?);
+	let replacement_actor_db = new_actor_db(db, TEST_NAMESPACE_LABEL, TEST_ACTOR);
+	assert!(
+		conn.actor_dbs
+			.insert_async(TEST_ACTOR.to_string(), replacement_actor_db)
+			.await
+			.is_ok()
+	);
+	assert!(conn.actor_dbs.contains_async(TEST_ACTOR).await);
 	Ok(())
 }
 
 #[tokio::test]
 async fn shutdown_conn_actors_evicts_all_cached_actor_dbs() -> Result<()> {
 	let db = Arc::new(test_db().await?);
-	let conn = conn::Conn {
-		actor_dbs: HashMap::new(),
-	};
+	let conn = empty_conn();
 
 	for (idx, actor_id) in ["shutdown-actor-a", "shutdown-actor-b"]
 		.into_iter()

--- a/rivetkit-rust/packages/rivetkit-core/src/serverless.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/serverless.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -35,7 +36,26 @@ const SSE_STOPPING_FRAME: &[u8] = b"event: stopping\ndata:\n\n";
 /// Bound on `handle.shutdown_and_wait` inside teardown paths. If envoy cannot
 /// reach the engine (reconnect loop stuck), we fall back to immediate `Stop`
 /// rather than hanging indefinitely. Must stay below the outer TS grace ceiling.
-const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(20);
+const DEFAULT_SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(20);
+
+async fn drain_with_timeout<Graceful, Forced, ForcedFuture>(
+	drain_timeout: Duration,
+	graceful: Graceful,
+	forced: Forced,
+) -> bool
+where
+	Graceful: Future<Output = ()>,
+	Forced: FnOnce() -> ForcedFuture,
+	ForcedFuture: Future<Output = ()>,
+{
+	match timeout(drain_timeout, graceful).await {
+		Ok(()) => true,
+		Err(_) => {
+			forced().await;
+			false
+		}
+	}
+}
 
 #[derive(Clone)]
 pub struct CoreServerlessRuntime {
@@ -216,20 +236,24 @@ impl CoreServerlessRuntime {
 	/// instead of starting a fresh envoy after teardown, and waits (with a
 	/// bounded timeout) for `envoy_loop` to exit. If the drain exceeds the
 	/// timeout (e.g. engine unreachable), falls back to an immediate `Stop`.
-	pub async fn shutdown(&self) {
+	pub async fn shutdown(&self, drain_timeout: Duration) {
 		self.shutting_down.store(true, Ordering::Release);
 		let handle = { self.envoy.lock().await.take() };
 		let Some(handle) = handle else { return };
-		match timeout(SHUTDOWN_DRAIN_TIMEOUT, handle.shutdown_and_wait(false)).await {
-			Ok(()) => {}
-			Err(_) => {
-				tracing::warn!(
-					"serverless runtime envoy drain exceeded timeout; forcing immediate stop"
-				);
-				handle.shutdown(true);
-				handle.wait_stopped().await;
-			}
-		}
+		drain_with_timeout(drain_timeout, handle.shutdown_and_wait(false), || async {
+			tracing::warn!(
+				"serverless runtime envoy drain exceeded timeout; forcing immediate stop"
+			);
+			handle.shutdown(true);
+			handle.wait_stopped().await;
+		})
+		.await;
+	}
+
+	/// Shuts down with the bounded fallback used while registry construction is
+	/// still in progress and no configured grace period is available yet.
+	pub async fn shutdown_with_default_timeout(&self) {
+		self.shutdown(DEFAULT_SHUTDOWN_DRAIN_TIMEOUT).await;
 	}
 
 	pub async fn active_envoy_actor_count(&self) -> Option<usize> {
@@ -522,7 +546,12 @@ impl CoreServerlessRuntime {
 		// installing it into the cache.
 		if self.shutting_down.load(Ordering::Acquire) {
 			drop(guard);
-			match timeout(SHUTDOWN_DRAIN_TIMEOUT, handle.shutdown_and_wait(false)).await {
+			match timeout(
+				DEFAULT_SHUTDOWN_DRAIN_TIMEOUT,
+				handle.shutdown_and_wait(false),
+			)
+			.await
+			{
 				Ok(()) => {}
 				Err(_) => {
 					handle.shutdown(true);

--- a/rivetkit-rust/packages/rivetkit-core/tests/serverless.rs
+++ b/rivetkit-rust/packages/rivetkit-core/tests/serverless.rs
@@ -2,14 +2,18 @@ use super::*;
 
 mod moved_tests {
 	use std::collections::HashMap;
+	use std::future::pending;
 	#[cfg(not(feature = "native-runtime"))]
 	use std::path::PathBuf;
+	use std::sync::Arc;
+	use std::sync::atomic::{AtomicUsize, Ordering};
+	use std::time::Duration;
 
 	use tokio_util::sync::CancellationToken;
 
 	use super::{
-		CoreServerlessRuntime, ServerlessRequest, endpoints_match, handles_listener_request,
-		normalize_endpoint_url, parse_start_headers,
+		CoreServerlessRuntime, ServerlessRequest, drain_with_timeout, endpoints_match,
+		handles_listener_request, normalize_endpoint_url, parse_start_headers,
 	};
 	use crate::registry::{EngineSpawnMode, ServeConfig};
 
@@ -73,6 +77,38 @@ mod moved_tests {
 			"http://127.0.0.1:6420, http://127.0.0.1:8080",
 			"http://localhost:9000/"
 		));
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn configured_drain_can_exceed_twenty_seconds() {
+		let forced = Arc::new(AtomicUsize::new(0));
+		let forced_for_fallback = forced.clone();
+		let drained = drain_with_timeout(
+			Duration::from_secs(30),
+			tokio::time::sleep(Duration::from_secs(25)),
+			move || async move {
+				forced_for_fallback.fetch_add(1, Ordering::Relaxed);
+			},
+		)
+		.await;
+
+		assert!(drained);
+		assert_eq!(forced.load(Ordering::Relaxed), 0);
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn configured_deadline_forces_once() {
+		let started_at = tokio::time::Instant::now();
+		let forced = Arc::new(AtomicUsize::new(0));
+		let forced_for_fallback = forced.clone();
+		let drained = drain_with_timeout(Duration::from_secs(30), pending(), move || async move {
+			forced_for_fallback.fetch_add(1, Ordering::Relaxed);
+		})
+		.await;
+
+		assert!(!drained);
+		assert_eq!(started_at.elapsed(), Duration::from_secs(30));
+		assert_eq!(forced.load(Ordering::Relaxed), 1);
 	}
 
 	#[tokio::test]

--- a/rivetkit-typescript/packages/rivetkit-napi/index.d.ts
+++ b/rivetkit-typescript/packages/rivetkit-napi/index.d.ts
@@ -416,7 +416,7 @@ export declare class CoreRegistry {
    * Does not block on the `serve()` future; TS awaits that promise
    * separately to avoid re-entrancy.
    */
-  shutdown(): Promise<void>
+  shutdown(gracePeriodMs: number): Promise<void>
   actorStopThresholdMs(): Promise<number | null>
   health(): Promise<JsRegistryRouteResponse>
   metadata(): JsRegistryRouteResponse

--- a/rivetkit-typescript/packages/rivetkit-napi/src/registry.rs
+++ b/rivetkit-typescript/packages/rivetkit-napi/src/registry.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use napi::bindgen_prelude::{Buffer, Env, Promise};
 use napi::threadsafe_function::{ErrorStrategy, ThreadSafeCallContext, ThreadsafeFunction};
@@ -274,7 +275,7 @@ impl CoreRegistry {
 	/// Does not block on the `serve()` future; TS awaits that promise
 	/// separately to avoid re-entrancy.
 	#[napi]
-	pub async fn shutdown(&self) -> napi::Result<()> {
+	pub async fn shutdown(&self, grace_period_ms: u32) -> napi::Result<()> {
 		tracing::debug!(class = "CoreRegistry", "shutdown requested");
 		// Trip the cancel first, outside the lock, so a `serve_with_config`
 		// already past the state transition observes cancel promptly.
@@ -301,7 +302,9 @@ impl CoreRegistry {
 		};
 
 		if let Some(runtime) = runtime {
-			runtime.shutdown().await;
+			runtime
+				.shutdown(Duration::from_millis(u64::from(grace_period_ms)))
+				.await;
 		}
 
 		if !was_building {
@@ -656,7 +659,7 @@ impl CoreRegistry {
 					) {
 					// Drop the lock while we drain the envoy.
 					drop(guard);
-					runtime.shutdown().await;
+					runtime.shutdown_with_default_timeout().await;
 					let mut guard = self.state.lock().await;
 					*guard = RegistryState::ShutDown;
 					drop(guard);

--- a/rivetkit-typescript/packages/rivetkit-wasm/index.d.ts
+++ b/rivetkit-typescript/packages/rivetkit-wasm/index.d.ts
@@ -83,7 +83,7 @@ export class CoreRegistry {
 	constructor();
 	serve(config: any): Promise<void>;
 	register(name: string, factory: ActorFactory): void;
-	shutdown(): Promise<void>;
+	shutdown(gracePeriodMs: number): Promise<void>;
 }
 
 export class Kv {

--- a/rivetkit-typescript/packages/rivetkit-wasm/src/lib.rs
+++ b/rivetkit-typescript/packages/rivetkit-wasm/src/lib.rs
@@ -344,7 +344,7 @@ impl WasmCoreRegistry {
 	}
 
 	#[wasm_bindgen]
-	pub async fn shutdown(&self) -> Result<(), JsValue> {
+	pub async fn shutdown(&self, grace_period_ms: u32) -> Result<(), JsValue> {
 		self.shutdown_token.cancel();
 		let serverless = {
 			let mut state = self.state.borrow_mut();
@@ -363,7 +363,9 @@ impl WasmCoreRegistry {
 		};
 		self.notify_serverless_build_complete();
 		if let Some(serverless) = serverless {
-			serverless.shutdown().await;
+			serverless
+				.shutdown(Duration::from_millis(u64::from(grace_period_ms)))
+				.await;
 			*self.state.borrow_mut() = RegistryState::ShutDown;
 		}
 		Ok(())
@@ -425,7 +427,7 @@ impl WasmCoreRegistry {
 			};
 			let serverless = WasmServerlessRuntime { runtime };
 			if self.shutdown_token.is_cancelled() {
-				serverless.runtime.shutdown().await;
+				serverless.runtime.shutdown_with_default_timeout().await;
 				*self.state.borrow_mut() = RegistryState::ShutDown;
 				self.notify_serverless_build_complete();
 				return Err(registry_shut_down_error());
@@ -438,7 +440,7 @@ impl WasmCoreRegistry {
 					}
 					RegistryState::ShuttingDown | RegistryState::ShutDown => {
 						drop(state);
-						serverless.runtime.shutdown().await;
+						serverless.runtime.shutdown_with_default_timeout().await;
 						*self.state.borrow_mut() = RegistryState::ShutDown;
 						self.notify_serverless_build_complete();
 						return Err(registry_shut_down_error());
@@ -447,7 +449,7 @@ impl WasmCoreRegistry {
 					| RegistryState::Serving
 					| RegistryState::Serverless(_) => {
 						drop(state);
-						serverless.runtime.shutdown().await;
+						serverless.runtime.shutdown_with_default_timeout().await;
 						self.notify_serverless_build_complete();
 						return Err(registry_wrong_mode_error());
 					}

--- a/rivetkit-typescript/packages/rivetkit/src/registry/index.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/index.ts
@@ -717,7 +717,10 @@ export class Registry<A extends RegistryActors> {
 					(async () => {
 						try {
 							const { runtime, registry } = await modeAPromise;
-							await runtime.shutdownRegistry(registry);
+							await runtime.shutdownRegistry(
+								registry,
+								gracePeriodMs,
+							);
 						} catch (err) {
 							logger().warn(
 								{ err },
@@ -732,7 +735,10 @@ export class Registry<A extends RegistryActors> {
 					(async () => {
 						try {
 							const { runtime, registry } = await modeBPromise;
-							await runtime.shutdownRegistry(registry);
+							await runtime.shutdownRegistry(
+								registry,
+								gracePeriodMs,
+							);
 						} catch (err) {
 							logger().warn(
 								{ error: err },

--- a/rivetkit-typescript/packages/rivetkit/src/registry/napi-runtime.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/napi-runtime.ts
@@ -257,8 +257,11 @@ export class NapiCoreRuntime implements CoreRuntime {
 		await asNativeRegistry(registry).waitReady();
 	}
 
-	async shutdownRegistry(registry: RegistryHandle): Promise<void> {
-		await asNativeRegistry(registry).shutdown();
+	async shutdownRegistry(
+		registry: RegistryHandle,
+		gracePeriodMs: number,
+	): Promise<void> {
+		await asNativeRegistry(registry).shutdown(gracePeriodMs);
 	}
 
 	async registryActorStopThresholdMs(

--- a/rivetkit-typescript/packages/rivetkit/src/registry/runtime.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/runtime.ts
@@ -429,7 +429,10 @@ export interface CoreRuntime {
 		config: RuntimeServeConfig,
 	): Promise<void>;
 	waitRegistryReady(registry: RegistryHandle): Promise<void>;
-	shutdownRegistry(registry: RegistryHandle): Promise<void>;
+	shutdownRegistry(
+		registry: RegistryHandle,
+		gracePeriodMs: number,
+	): Promise<void>;
 	registryActorStopThresholdMs?(
 		registry: RegistryHandle,
 	): Promise<number | undefined>;

--- a/rivetkit-typescript/packages/rivetkit/src/registry/wasm-runtime.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/wasm-runtime.ts
@@ -281,8 +281,11 @@ export class WasmCoreRuntime implements CoreRuntime {
 		);
 	}
 
-	async shutdownRegistry(registry: RegistryHandle): Promise<void> {
-		await callWasm(() => asWasmRegistry(registry).shutdown());
+	async shutdownRegistry(
+		registry: RegistryHandle,
+		gracePeriodMs: number,
+	): Promise<void> {
+		await callWasm(() => asWasmRegistry(registry).shutdown(gracePeriodMs));
 	}
 
 	async registryHealth(): Promise<RuntimeRegistryRouteResponse> {

--- a/rivetkit-typescript/packages/rivetkit/tests/driver/engine-restart-serverless.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/driver/engine-restart-serverless.ts
@@ -30,6 +30,9 @@ const GATEWAY_HEALTH_TIMEOUT_MS = Number(
 	process.env.RIVETKIT_GATEWAY_HEALTH_TIMEOUT_MS ?? "5000",
 );
 const COMMIT_FAILURE_TIMEOUT_MS = 45_000;
+const RUNTIME_ROLL_ACTION_MS = Number(
+	process.env.RIVETKIT_RUNTIME_ROLL_ACTION_MS ?? "25000",
+);
 const RESTART_MODE = process.env.RIVETKIT_ENGINE_RESTART_MODE ?? "commit";
 const HEARTBEAT_MODE = process.env.RIVETKIT_HEARTBEAT_MODE ?? "sqlite";
 const POST_RESTART_PROBE_TIMING =
@@ -135,6 +138,10 @@ class OwnedEngine {
 			{
 				env: {
 					...process.env,
+					RIVET__PEGBOARD__ENVOY_LOST_THRESHOLD:
+						RESTART_MODE === "runtime-roll" ? "35000" : undefined,
+					RIVET__PEGBOARD__SERVERLESS_DRAIN_GRACE_PERIOD:
+						RESTART_MODE === "runtime-roll" ? "35000" : undefined,
 					RIVET__GUARD__HOST: HOST,
 					RIVET__GUARD__PORT: this.#guardPort.toString(),
 					RIVET__API_PEER__HOST: HOST,
@@ -207,26 +214,29 @@ class OwnedEngine {
 async function stopChildProcess(
 	child: ChildProcess,
 	signal: NodeJS.Signals = "SIGTERM",
-): Promise<void> {
+	forceAfterMs = 5_000,
+): Promise<boolean> {
 	if (!isProcessRunning(child)) {
-		return;
+		return false;
 	}
 
-	await new Promise<void>((resolve) => {
+	return new Promise<boolean>((resolve) => {
 		let forceKill: NodeJS.Timeout | undefined;
+		let forced = false;
 		const finish = () => {
 			if (forceKill) {
 				clearTimeout(forceKill);
 			}
-			resolve();
+			resolve(forced);
 		};
 		child.once("exit", finish);
 		child.kill(signal);
 		forceKill = setTimeout(() => {
 			if (isProcessRunning(child)) {
+				forced = true;
 				child.kill("SIGKILL");
 			}
-		}, 5_000);
+		}, forceAfterMs);
 	});
 }
 
@@ -304,12 +314,18 @@ class ServerlessRuntime {
 	}
 
 	async cleanup(): Promise<void> {
-		const child = this.#child;
-		if (!isProcessRunning(child)) {
-			return;
-		}
+		await this.stopProcess();
+	}
 
-		await stopChildProcess(child, "SIGTERM");
+	async stopProcess(
+		signal: NodeJS.Signals = "SIGTERM",
+		forceAfterMs = 5_000,
+	): Promise<boolean> {
+		const child = this.#child;
+		if (isProcessRunning(child)) {
+			return stopChildProcess(child, signal, forceAfterMs);
+		}
+		return false;
 	}
 }
 
@@ -349,7 +365,6 @@ async function main() {
 			encoding: "bare",
 			disableMetadataLookup: true,
 		});
-
 		const actorHandle = client.sqliteCounter.getOrCreate([actorKey]);
 		const heartbeatWarmupStartedAt = Date.now();
 		const countBeforeRestart = (await actorHandle.getCount()) as number;
@@ -382,6 +397,68 @@ async function main() {
 		console.log(
 			`actor-originated heartbeat warmup finished. before=${countBeforeRestart} ${formatHeartbeatStats(warmupStats)}`,
 		);
+		if (RESTART_MODE === "runtime-roll") {
+			signalServer = await createCommitSignalServer();
+			const rollStartedAt = Date.now();
+			const action = withTimeout(
+				actorHandle.finishDuringRuntimeRoll({
+					signalUrl: signalServer.url,
+					delayMs: RUNTIME_ROLL_ACTION_MS,
+				}) as Promise<unknown>,
+				RUNTIME_ROLL_ACTION_MS + 30_000,
+				"in-flight action did not finish during the runtime roll",
+			);
+
+			await signalServer.waitForSignal;
+			const stopping = runtime.stopProcess(
+				"SIGTERM",
+				RUNTIME_ROLL_ACTION_MS + 15_000,
+			);
+			await action;
+			const forced = await stopping;
+			if (forced) {
+				throw new Error(
+					"runtime did not exit within its configured grace period",
+				);
+			}
+
+			const drainDurationMs = Date.now() - rollStartedAt;
+			if (drainDurationMs < 20_000) {
+				throw new Error(
+					`runtime stopped before the action's >20s graceful drain completed: ${drainDurationMs}ms`,
+				);
+			}
+			if (runtime.getOutput().includes("forcing immediate stop")) {
+				throw new Error(
+					"runtime forced the envoy to stop during the graceful drain",
+				);
+			}
+
+			await runtime.startProcess({
+				endpoint: engine.endpoint,
+				namespace,
+				poolName,
+			});
+			const countAfterRoll = (await actorHandle.getCount()) as number;
+			if (countAfterRoll <= countBeforeRestart) {
+				throw new Error(
+					`durable counter did not advance across runtime roll: before=${countBeforeRestart} after=${countAfterRoll}`,
+				);
+			}
+			const replacementResult = (await actorHandle.tick()) as {
+				count: number;
+				events: number;
+			};
+			if (replacementResult.count <= countAfterRoll) {
+				throw new Error(
+					"replacement runtime did not wake and advance the actor",
+				);
+			}
+			console.log(
+				`runtime roll preserved the in-flight action and durable actor state. drainMs=${drainDurationMs} count=${replacementResult.count} events=${replacementResult.events}`,
+			);
+			return;
+		}
 		const gatewayHealthTargets =
 			GATEWAY_HEALTH_DELAYS_MS.length > 0
 				? await prepareGatewayHealthTargets({
@@ -631,7 +708,8 @@ async function upsertServerlessRunnerConfig(input: {
 								"x-rivet-token": TOKEN,
 							},
 							request_lifespan: 3600,
-							drain_grace_period: 5,
+							drain_grace_period:
+								RESTART_MODE === "runtime-roll" ? 30 : 5,
 							metadata_poll_interval: 1000,
 							max_runners: 10,
 							min_runners: 0,

--- a/rivetkit-typescript/packages/rivetkit/tests/fixtures/engine-restart-serverless-runtime.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/fixtures/engine-restart-serverless-runtime.ts
@@ -8,6 +8,9 @@ const namespace = process.env.RIVET_NAMESPACE;
 const token = process.env.RIVET_TOKEN ?? "dev";
 const poolName = process.env.RIVETKIT_TEST_POOL_NAME;
 const heartbeatMode = process.env.RIVETKIT_HEARTBEAT_MODE ?? "sqlite";
+const shutdownGracePeriodMs = Number(
+	process.env.RIVETKIT_SHUTDOWN_GRACE_PERIOD_MS ?? "30000",
+);
 
 if (!Number.isInteger(port) || port <= 0) {
 	throw new Error("RIVETKIT_TEST_PORT must be a positive integer");
@@ -351,6 +354,34 @@ const sqliteCounter = actor({
 				throw error;
 			}
 		},
+		finishDuringRuntimeRoll: async (
+			ctx,
+			input: {
+				signalUrl: string;
+				delayMs: number;
+			},
+		) => {
+			const database = ctx.sql as SqliteDatabase;
+			await ensureTables(database);
+			await database.run("BEGIN");
+			try {
+				await database.run(
+					`
+						INSERT INTO restart_counter (id, count)
+						VALUES (1, 1)
+						ON CONFLICT(id) DO UPDATE SET count = count + 1
+					`,
+				);
+				await database.run("COMMIT");
+			} catch (error) {
+				await database.run("ROLLBACK");
+				throw error;
+			}
+
+			await fetch(input.signalUrl, { method: "POST" });
+			await sleep(Math.max(0, Math.trunc(input.delayMs)));
+			return { completed: true };
+		},
 		getCount: async (ctx) => {
 			const database = ctx.sql as SqliteDatabase;
 			await ensureTables(database);
@@ -426,6 +457,7 @@ const sqliteCounter = actor({
 		},
 	},
 	options: {
+		sleepGracePeriod: shutdownGracePeriodMs,
 		sleepTimeout: 300_000,
 	},
 });
@@ -444,6 +476,9 @@ const registry = setup({
 	},
 	serverless: {
 		basePath: "/api/rivet",
+	},
+	shutdown: {
+		gracePeriodMs: shutdownGracePeriodMs,
 	},
 	noWelcome: true,
 	test: {
@@ -468,10 +503,16 @@ const server = serve(
 	},
 );
 
+let shutdownInFlight: Promise<void> | undefined;
+
 function shutdown() {
-	server.close(() => {
-		process.exit(0);
-	});
+	shutdownInFlight ??= registry.shutdown().then(
+		() =>
+			new Promise<void>((resolve) => {
+				server.close(() => resolve());
+			}),
+	);
+	void shutdownInFlight.then(() => process.exit(0));
 }
 
 process.on("SIGTERM", shutdown);

--- a/rivetkit-typescript/packages/rivetkit/tests/listener.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/listener.test.ts
@@ -216,7 +216,7 @@ describe("registry.listen() end-to-end", () => {
 			expect(await echo.text()).toBe("hello");
 			expect(paths).toEqual(["/health", "/echo"]);
 		} finally {
-			await runtime.shutdownRegistry(handle);
+			await runtime.shutdownRegistry(handle, 30_000);
 			await applicationListener;
 		}
 	}, 30_000);

--- a/rivetkit-typescript/packages/rivetkit/tests/registry-shutdown.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/registry-shutdown.test.ts
@@ -31,6 +31,8 @@ interface FakeState {
 	builderCalls: number;
 	/** Registry handles passed to `shutdownRegistry`, in call order. */
 	shutdownRegistries: RegistryHandle[];
+	/** Grace periods passed to `shutdownRegistry`, in call order. */
+	shutdownGracePeriods: number[];
 	/** Value returned by `registryActorStopThresholdMs`. */
 	stopThresholdMs: number | undefined;
 	/** When true, `shutdownRegistry` never resolves (forces the grace race). */
@@ -53,6 +55,7 @@ function createFake(): Fake {
 	const state: FakeState = {
 		builderCalls: 0,
 		shutdownRegistries: [],
+		shutdownGracePeriods: [],
 		stopThresholdMs: undefined,
 		hangShutdown: false,
 		gate: null,
@@ -61,8 +64,12 @@ function createFake(): Fake {
 	const runtime = {
 		kind: "napi",
 		serveRegistry: async () => {},
-		shutdownRegistry: async (registry: RegistryHandle) => {
+		shutdownRegistry: async (
+			registry: RegistryHandle,
+			gracePeriodMs: number,
+		) => {
 			state.shutdownRegistries.push(registry);
+			state.shutdownGracePeriods.push(gracePeriodMs);
 			if (state.hangShutdown) {
 				await new Promise<void>(() => {});
 			}
@@ -231,6 +238,7 @@ describe("Registry.shutdown", () => {
 
 		await vi.advanceTimersByTimeAsync(0);
 		expect(state.shutdownRegistries).toHaveLength(1);
+		expect(state.shutdownGracePeriods).toEqual([60_000]);
 		expect(settled).toBe(false);
 
 		gate.release();

--- a/rivetkit-typescript/packages/rivetkit/tests/runtime-parity.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/runtime-parity.test.ts
@@ -360,9 +360,11 @@ async function runLifecycleScenario(runtimeCase: RuntimeCase): Promise<void> {
 	expect(scenario.saves).toContainEqual({ immediate: true });
 
 	let shutdownSettled = false;
-	const shutdownPromise = runtime.shutdownRegistry(registry).then(() => {
-		shutdownSettled = true;
-	});
+	const shutdownPromise = runtime
+		.shutdownRegistry(registry, 30_000)
+		.then(() => {
+			shutdownSettled = true;
+		});
 	await Promise.resolve();
 	expect(shutdownSettled).toBe(false);
 	expect(scenario.registerTaskCompleted).toBe(false);

--- a/rivetkit-typescript/packages/rivetkit/tests/wasm-host-smoke.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/wasm-host-smoke.test.ts
@@ -505,9 +505,11 @@ async function runHostSmoke(kind: HostKind): Promise<SmokeHost> {
 	await scenario.registerTask.started;
 
 	let shutdownSettled = false;
-	const shutdownPromise = runtime.shutdownRegistry(registry).then(() => {
-		shutdownSettled = true;
-	});
+	const shutdownPromise = runtime
+		.shutdownRegistry(registry, 30_000)
+		.then(() => {
+			shutdownSettled = true;
+		});
 	await Promise.resolve();
 	expect(shutdownSettled).toBe(false);
 	expect(scenario.registerTaskCompleted).toBe(false);

--- a/rivetkit-typescript/packages/rivetkit/tests/wasm-runtime.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/wasm-runtime.test.ts
@@ -438,7 +438,7 @@ describe("WasmCoreRuntime", () => {
 			serveConfig,
 		);
 		await fakeRegistry.buildStarted.promise;
-		await runtime.shutdownRegistry(registry);
+		await runtime.shutdownRegistry(registry, 30_000);
 		fakeRegistry.releaseServerlessBuild();
 
 		await expect(first).rejects.toMatchObject({


### PR DESCRIPTION
Pass the configured registry grace period through the native shutdown boundary so long graceful drains are not forced at a hidden 20-second deadline.

## Why

The native serverless runtime hardcodes a 20-second timeout even when `shutdownGracePeriod` is longer. A rolling runner deployment can therefore force a busy actor, while the engine still believes the old route is valid.

## How It Fits

```
Registry.shutdown
      │ configured grace period *
      ▼
CoreRuntime.shutdownRegistry
      │ gracePeriodMs *
      ▼
NAPI / WASM registry shutdown
      │ Duration *
      ▼
CoreServerlessRuntime.drain_with_timeout
      │ graceful completion or configured deadline
      ▼
serverless actor tasks
```
`*` reshaped

## Reviewer's Guide

```
rivetkit-typescript/packages/rivetkit/src/registry/
  index.ts *              ★ passes shutdownGracePeriod to the runtime
  runtime.ts *            reshapes the internal shutdown contract
  napi-runtime.ts *       forwards gracePeriodMs through NAPI
  wasm-runtime.ts *       forwards gracePeriodMs through WASM
rivetkit-rust/packages/rivetkit-core/src/
  serverless.rs *         owns graceful-versus-forced deadline behavior
rivetkit-typescript/packages/rivetkit/tests/
  driver/engine-restart-serverless.ts *          real runtime-roll regression
  fixtures/engine-restart-serverless-runtime.ts * durable busy actor fixture
engine/packages/pegboard-envoy/tests/
  actor_lifecycle.rs *    replayed unknown stop followed by replacement start
```
Read order: `index.ts` → `runtime.ts` → `serverless.rs` → the runtime-roll regression.
Focus on exact deadline propagation and process termination; skim declaration-file signature updates.

## What Changed

- Replaces the native fixed timeout with the configured shutdown grace period across TypeScript, NAPI, WASM, and Rust.
- Covers graceful drains longer than 20 seconds and forced shutdown at the configured deadline.
- Tolerates a replayed stop for an unknown actor and proves a replacement envoy can start it.
- Extends the real-engine driver to commit durable state, remain busy beyond 20 seconds, roll the runtime, wake on the replacement, and read actor-originated events.

## Validation

- `cargo test -p rivetkit-core configured_ --lib`
- `pnpm exec vitest run tests/listener.test.ts tests/registry-shutdown.test.ts tests/runtime-parity.test.ts tests/wasm-runtime.test.ts`
- `cargo check -p rivetkit-napi -p rivetkit-wasm`
- `RUSTFLAGS='--cfg tokio_unstable' cargo test -p pegboard-envoy --test actor_lifecycle replayed_stop_for_unknown_actor_allows_replacement_start -- --exact`
- `RIVETKIT_ENGINE_RESTART_MODE=runtime-roll pnpm exec tsx tests/driver/engine-restart-serverless.ts`

## Risks & Rollback

- This changes an internal native binding signature; all in-repo runtime implementations and declarations move together.
- Reverting this commit restores the former fixed 20-second behavior.