### PR TITLE
fix(engine-runner): terminate requests for missing actors

### DIFF
--- a/rivetkit-typescript/packages/engine-runner/src/tunnel.ts
+++ b/rivetkit-typescript/packages/engine-runner/src/tunnel.ts
@@ -677,9 +677,34 @@ export class Tunnel {
 		const actor = await this.#runner.getAndWaitForActor(req.actorId);
 		if (!actor) {
 			this.log?.warn({
-				msg: "actor does not exist in handleRequestStart, request will leak",
+				msg: "ignoring request for unknown actor",
 				actorId: req.actorId,
 				requestId: requestIdStr,
+			});
+
+			const body = new TextEncoder().encode("Actor not found");
+
+			this.#runner.__sendToServer({
+				tag: "ToServerTunnelMessage",
+				val: {
+					messageId: {
+						gatewayId,
+						requestId,
+						messageIndex: 0,
+					},
+					messageKind: {
+						tag: "ToServerResponseStart",
+						val: {
+							status: 503,
+							headers: new Map([
+								["x-rivet-error", "runner.actor_not_found"],
+								["content-length", String(body.byteLength)],
+							]),
+							body: body.buffer,
+							stream: false,
+						},
+					},
+				},
 			});
 			return;
 		}

--- a/rivetkit-typescript/packages/engine-runner/tests/tunnel-missing-actor.test.ts
+++ b/rivetkit-typescript/packages/engine-runner/tests/tunnel-missing-actor.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { Tunnel } from "../src/tunnel";
+
+describe("Tunnel missing actor request handling", () => {
+	it("returns a retryable 503 when a request arrives for an unloaded actor", async () => {
+		const sent: any[] = [];
+
+		const runner = {
+			log: undefined,
+			getAndWaitForActor: vi.fn().mockResolvedValue(undefined),
+			__sendToServer: vi.fn((message) => {
+				sent.push(message);
+			}),
+		} as any;
+
+		const tunnel = new Tunnel(runner);
+
+		const gatewayId = new Uint8Array(16).buffer;
+		const requestId = new Uint8Array(16).buffer;
+
+		await tunnel.handleTunnelMessage({
+			messageId: {
+				gatewayId,
+				requestId,
+				messageIndex: 0,
+			},
+			messageKind: {
+				tag: "ToClientRequestStart",
+				val: {
+					actorId: "missing-actor",
+					method: "GET",
+					path: "/",
+					headers: new Map(),
+					body: null,
+					stream: false,
+				},
+			},
+		} as any);
+
+		expect(sent).toHaveLength(1);
+		expect(sent[0].tag).toBe("ToServerTunnelMessage");
+		expect(sent[0].val.messageKind.tag).toBe("ToServerResponseStart");
+		expect(sent[0].val.messageKind.val.status).toBe(503);
+		expect(sent[0].val.messageKind.val.headers.get("x-rivet-error")).toBe(
+			"runner.actor_not_found",
+		);
+		expect(sent[0].val.messageKind.val.headers.get("content-length")).toBe(
+			"15",
+		);
+		expect(new TextDecoder().decode(sent[0].val.messageKind.val.body)).toBe(
+			"Actor not found",
+		);
+		expect(sent[0].val.messageKind.val.stream).toBe(false);
+	});
+});


### PR DESCRIPTION
Fixes a request leak in the TypeScript engine runner when a request arrives for an actor that is no longer loaded.

Previously, `#handleRequestStart()` logged that the request would leak and returned without sending a terminal response. This left the gateway waiting for a response until its response-start timeout.

The runner now sends a retryable `503 Service Unavailable` response with the `x-rivet-error: runner.actor_not_found` header when the actor cannot be found. This follows the existing missing-actor retry semantics used elsewhere in the runner and allows Guard to retry the request instead of waiting for the timeout.

A regression test was added to verify that requests for unloaded actors receive the expected terminal response.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added a focused regression test covering a `ToClientRequestStart` received for an unloaded actor.

Verified with:

- `pnpm exec vitest run tests/tunnel-missing-actor.test.ts`
- `pnpm --filter @rivetkit/engine-runner check-types`
- `pnpm --filter @rivetkit/engine-runner build`
- `git diff --check`

The regression test verifies that the runner returns:

- HTTP status `503`
- `x-rivet-error: runner.actor_not_found`
- the expected response body and content length
- a terminal non-streaming response

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes