### PR TITLE
fix(inspector): send workflow history as raw BARE bytes

### DIFF
--- a/frontend/src/components/actors/actor-inspector-context.tsx
+++ b/frontend/src/components/actors/actor-inspector-context.tsx
@@ -154,9 +154,9 @@ interface ActorInspectorApi {
 	getWorkflowHistory: () => Promise<{
 		history: WorkflowHistory | null;
 		isEnabled: boolean;
+		error: string | null;
 	}>;
 	replayWorkflowFromStep: (entryId?: string) => Promise<{
-		history: WorkflowHistory | null;
 		isEnabled: boolean;
 	}>;
 	getDatabaseSchema: () => Promise<DatabaseSchema>;
@@ -188,7 +188,11 @@ type FeatureSupport = {
 };
 
 type WorkflowHistoryHttpResponse = {
-	history: number[] | null;
+	// `history` is the decoded workflow JSON documented for the inspector HTTP
+	// routes. It is deliberately not read here: the tab refreshes history over
+	// the websocket after a replay, and the BARE transform expects transport
+	// bytes rather than this shape.
+	history: unknown;
 	isWorkflowEnabled: boolean;
 };
 
@@ -661,19 +665,6 @@ export const createDefaultActorInspectorContext = ({
 const computeActorUrl = ({ url, actorId }: { url: string; actorId: ActorId }) =>
 	new URL(`/gateway/${actorId}`, url).href;
 
-function transformWorkflowHistoryFromJson(raw: number[] | null): {
-	history: WorkflowHistory | null;
-	isEnabled: boolean;
-} {
-	if (!raw) {
-		return { history: null, isEnabled: true };
-	}
-
-	return transformWorkflowHistoryFromInspector(
-		new Uint8Array(raw).buffer as ArrayBuffer,
-	);
-}
-
 const replayWorkflowFromStepHttp = async ({
 	actorId,
 	credentials,
@@ -710,16 +701,10 @@ const replayWorkflowFromStepHttp = async ({
 	}
 
 	const data = z
-		.object({
-			history: z.array(z.number().int().min(0).max(255)).nullable(),
-			isWorkflowEnabled: z.boolean(),
-		})
+		.object({ isWorkflowEnabled: z.boolean() })
 		.parse((await response.json()) satisfies WorkflowHistoryHttpResponse);
 
-	return {
-		history: transformWorkflowHistoryFromJson(data.history).history,
-		isEnabled: data.isWorkflowEnabled,
-	};
+	return { isEnabled: data.isWorkflowEnabled };
 };
 
 export const actorWakeUpMutationOptions = () =>
@@ -1115,6 +1100,7 @@ export const ActorInspectorProvider = ({
 				const { id, promise } = actionsManager.current.createResolver<{
 					history: WorkflowHistory | null;
 					isEnabled: boolean;
+					error: string | null;
 				}>({
 					name: "getWorkflowHistory",
 					timeoutMs: 10_000,
@@ -1533,6 +1519,7 @@ const createMessageHandler =
 				actionsManager.current.resolve(Number(rid), {
 					history: transformed?.history ?? null,
 					isEnabled: body.val.isWorkflowEnabled,
+					error: transformed?.error ?? null,
 				});
 			})
 			.with({ tag: "WorkflowReplayResponse" }, (body) => {
@@ -1551,6 +1538,7 @@ const createMessageHandler =
 				actionsManager.current.resolve(Number(rid), {
 					history: transformed?.history ?? null,
 					isEnabled: body.val.isWorkflowEnabled,
+					error: transformed?.error ?? null,
 				});
 			})
 			.with({ tag: "DatabaseSchemaResponse" }, (body) => {
@@ -1618,16 +1606,27 @@ function transformState(state: ArrayBuffer) {
 function transformWorkflowHistoryFromInspector(raw: ArrayBuffer): {
 	history: WorkflowHistory | null;
 	isEnabled: boolean;
+	error: string | null;
 } {
 	try {
 		const decoded = decodeWorkflowHistoryTransport(raw);
 		return {
 			history: transformWorkflowHistory(decoded),
 			isEnabled: true,
+			error: null,
 		};
 	} catch (error) {
-		console.warn("Failed to decode workflow history", error);
-		return { history: null, isEnabled: true };
+		// A decode failure is a protocol mismatch, not an empty workflow. It is
+		// reported so the tab cannot render it as "nothing recorded yet".
+		console.error("Failed to decode workflow history", error);
+		return {
+			history: null,
+			isEnabled: true,
+			error:
+				error instanceof Error
+					? error.message
+					: "Workflow history could not be decoded.",
+		};
 	}
 }
 

--- a/frontend/src/components/actors/workflow/actor-workflow-tab.tsx
+++ b/frontend/src/components/actors/workflow/actor-workflow-tab.tsx
@@ -33,6 +33,7 @@ export function ActorWorkflowTab({ actorId }: ActorWorkflowTabProps) {
 
 	const isLoading = isEnabledLoading || isHistoryLoading;
 	const workflow = workflowData?.history ?? null;
+	const historyError = workflowData?.error ?? null;
 	const currentStep = useMemo(() => getCurrentStep(workflow), [workflow]);
 	const hasHiddenRunningStep =
 		actorStatus === "running" &&
@@ -53,13 +54,8 @@ export function ActorWorkflowTab({ actorId }: ActorWorkflowTabProps) {
 	const handleReplay = async (entryId?: string) => {
 		try {
 			const result = await replayMutation.mutateAsync(entryId);
-			queryClient.setQueryData(
-				actorInspectorQueriesKeys.actorWorkflowHistory(actorId),
-				{
-					history: result.history,
-					isEnabled: result.isEnabled,
-				},
-			);
+			// History itself is refreshed over the websocket below; the replay
+			// response does not carry it in a form this tab can render.
 			queryClient.setQueryData(
 				actorInspectorQueriesKeys.actorIsWorkflowEnabled(actorId),
 				result.isEnabled,
@@ -100,6 +96,17 @@ export function ActorWorkflowTab({ actorId }: ActorWorkflowTabProps) {
 				<p>
 					Workflow Visualizer is not enabled for this Actor. <br />{" "}
 					This feature requires a workflow-based Actor.
+				</p>
+			</Info>
+		);
+	}
+
+	if (historyError) {
+		return (
+			<Info>
+				<p>
+					Workflow history could not be read from this Actor. <br />
+					{historyError}
 				</p>
 			</Info>
 		);

--- a/rivetkit-rust/packages/rivetkit-core/src/registry/inspector.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/registry/inspector.rs
@@ -393,12 +393,7 @@ impl RegistryDispatcher {
 	) -> Result<(bool, Option<JsonValue>)> {
 		self.inspector_workflow_history_bytes(instance).await.map(
 			|(workflow_supported, history)| {
-				(
-					workflow_supported,
-					history
-						.map(|payload| decode_cbor_json_or_null(&payload))
-						.filter(|value| !value.is_null()),
-				)
+				(workflow_supported, warn_and_omit_workflow_history(history))
 			},
 		)
 	}
@@ -411,12 +406,7 @@ impl RegistryDispatcher {
 		self.inspector_workflow_replay_bytes(instance, entry_id)
 			.await
 			.map(|(workflow_supported, history)| {
-				(
-					workflow_supported,
-					history
-						.map(|payload| decode_cbor_json_or_null(&payload))
-						.filter(|value| !value.is_null()),
-				)
+				(workflow_supported, warn_and_omit_workflow_history(history))
 			})
 	}
 
@@ -831,6 +821,21 @@ pub(super) fn inspector_error_status(group: &str, code: &str) -> StatusCode {
 		}
 		_ => StatusCode::INTERNAL_SERVER_ERROR,
 	}
+}
+
+// These JSON routes document `history` as decoded workflow JSON, but the bytes are BARE and the
+// only codec lives in the TypeScript workflow engine, which serves these routes itself. Runtimes
+// that fall through to core have no workflow engine, so history is expected to be absent. Decoding
+// the bytes as CBOR here yields a garbage value rather than an error, so refuse instead.
+fn warn_and_omit_workflow_history(history: Option<Vec<u8>>) -> Option<JsonValue> {
+	if let Some(history) = history {
+		tracing::warn!(
+			byte_len = history.len(),
+			"omitting workflow history from json inspector response, BARE decoding is not available in core",
+		);
+	}
+
+	None
 }
 
 pub(super) fn parse_json_body<T>(request: &Request) -> std::result::Result<T, HttpResponse>

--- a/rivetkit-typescript/packages/rivetkit/src/common/inspector-transport.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/common/inspector-transport.ts
@@ -5,10 +5,20 @@ import {
 } from "@/common/bare/transport/v1";
 import { bufferToArrayBuffer, toUint8Array } from "@/utils";
 
+declare const workflowHistoryBare: unique symbol;
+
+// Branded so these bytes cannot be handed to the CBOR compat encoder, which
+// would rewrite the buffer as `["$ArrayBuffer", "<base64>"]`.
+export type WorkflowHistoryBytes = ArrayBuffer & {
+	readonly [workflowHistoryBare]: true;
+};
+
 export function encodeWorkflowHistoryTransport(
 	history: WorkflowHistory,
-): ArrayBuffer {
-	return bufferToArrayBuffer(encodeWorkflowHistory(history));
+): WorkflowHistoryBytes {
+	return bufferToArrayBuffer(
+		encodeWorkflowHistory(history),
+	) as WorkflowHistoryBytes;
 }
 
 export function decodeWorkflowHistoryTransport(

--- a/rivetkit-typescript/packages/rivetkit/src/registry/native.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/native.ts
@@ -682,6 +682,10 @@ function decodeValue<T>(value?: RuntimeBytes | null): T {
 
 // Rejects `WorkflowHistoryBytes`: the compat layer rewrites an ArrayBuffer as
 // `["$ArrayBuffer", "<base64>"]`, and the inspector wire field carries raw BARE.
+// The conditional distributes, so it catches the branded type on its own but
+// only strips it from a union that also has other members. A non-distributive
+// `[T] extends [...]` resolves to `never` for the `any` arguments this takes
+// elsewhere, so the union case stays uncovered.
 function encodeValue<T>(
 	value: T extends WorkflowHistoryBytes ? never : T,
 ): RuntimeBytes {

--- a/rivetkit-typescript/packages/rivetkit/src/registry/native.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/native.ts
@@ -48,7 +48,10 @@ import type { AnyDatabaseProvider } from "@/common/database/config";
 import { wrapJsNativeDatabase } from "@/common/database/native-database";
 import { assertJsonCompatValue, type JsonCompatValue } from "@/common/encoding";
 import { isResponseLike, type ResponseLike } from "@/common/fetch-like";
-import { decodeWorkflowHistoryTransport } from "@/common/inspector-transport";
+import {
+	decodeWorkflowHistoryTransport,
+	type WorkflowHistoryBytes,
+} from "@/common/inspector-transport";
 import { deconstructError, stringifyError } from "@/common/utils";
 import type {
 	RivetCloseEvent,
@@ -64,7 +67,7 @@ import type {
 	SqliteBackend,
 } from "@/registry/config";
 import { decodeCborCompat, encodeCborCompat } from "@/serde";
-import { getEnvUniversal, VERSION } from "@/utils";
+import { getEnvUniversal, toUint8Array, VERSION } from "@/utils";
 import {
 	getNodeFsSync,
 	getNodePath,
@@ -677,7 +680,11 @@ function decodeValue<T>(value?: RuntimeBytes | null): T {
 	return decodeCborCompat(value);
 }
 
-function encodeValue(value: unknown): RuntimeBytes {
+// Rejects `WorkflowHistoryBytes`: the compat layer rewrites an ArrayBuffer as
+// `["$ArrayBuffer", "<base64>"]`, and the inspector wire field carries raw BARE.
+function encodeValue<T>(
+	value: T extends WorkflowHistoryBytes ? never : T,
+): RuntimeBytes {
 	return encodeCborCompat(value as JsonCompatValue);
 }
 
@@ -769,9 +776,10 @@ function callNativeSync<T>(invoke: () => T): T {
 	}
 }
 
-type NativeWorkflowInspectorConfig = WorkflowInspectorConfig<ArrayBuffer> & {
-	getState?: () => Promise<unknown> | unknown;
-};
+type NativeWorkflowInspectorConfig =
+	WorkflowInspectorConfig<WorkflowHistoryBytes> & {
+		getState?: () => Promise<unknown> | unknown;
+	};
 
 function isClosedTaskRegistrationError(error: unknown): boolean {
 	const metadata = error instanceof RivetError ? error.metadata : undefined;
@@ -4816,7 +4824,7 @@ export function buildNativeFactory(
 								getNativeWorkflowInspector(ctx)?.getHistory();
 							return history == null
 								? undefined
-								: encodeValue(history);
+								: toUint8Array(history);
 						},
 					)
 				: undefined,
@@ -4846,7 +4854,7 @@ export function buildNativeFactory(
 								)) ?? null;
 							return history == null
 								? undefined
-								: encodeValue(history);
+								: toUint8Array(history);
 						},
 					)
 				: undefined,

--- a/rivetkit-typescript/packages/rivetkit/src/workflow/inspector.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/workflow/inspector.ts
@@ -10,14 +10,14 @@ import type {
 	WorkflowHistorySnapshot,
 	WorkflowState,
 } from "@rivetkit/workflow-engine";
-import type * as inspectorSchema from "@/common/bare/generated/inspector/v4";
 import * as transport from "@/common/bare/transport/v1";
 import type { JsonCompatValue } from "@/common/encoding";
+import type { WorkflowHistoryBytes } from "@/common/inspector-transport";
 import { encodeWorkflowHistoryTransport } from "@/common/inspector-transport";
 import { encodeCborCompat } from "@/serde";
 import { assertUnreachable, bufferToArrayBuffer } from "@/utils";
 
-type HistoryListener = (history: inspectorSchema.WorkflowHistory) => void;
+type HistoryListener = (history: WorkflowHistoryBytes) => void;
 
 function createHistoryEmitter() {
 	const listeners = new Set<HistoryListener>();
@@ -27,7 +27,7 @@ function createHistoryEmitter() {
 			listeners.add(listener);
 			return () => listeners.delete(listener);
 		},
-		emit: (history: inspectorSchema.WorkflowHistory) => {
+		emit: (history: WorkflowHistoryBytes) => {
 			for (const listener of listeners) {
 				listener(history);
 			}
@@ -36,14 +36,12 @@ function createHistoryEmitter() {
 }
 
 export interface WorkflowInspectorAdapter {
-	getHistory: () => inspectorSchema.WorkflowHistory | null;
+	getHistory: () => WorkflowHistoryBytes | null;
 	getState: () => Promise<WorkflowState | null>;
 	onHistoryUpdated: (
-		listener: (history: inspectorSchema.WorkflowHistory) => void,
+		listener: (history: WorkflowHistoryBytes) => void,
 	) => () => void;
-	replayFromStep: (
-		entryId?: string,
-	) => Promise<inspectorSchema.WorkflowHistory | null>;
+	replayFromStep: (entryId?: string) => Promise<WorkflowHistoryBytes | null>;
 }
 
 export function createWorkflowInspectorAdapter(): {
@@ -51,17 +49,15 @@ export function createWorkflowInspectorAdapter(): {
 	update: (snapshot: WorkflowHistorySnapshot) => void;
 	setGetState: (fn: () => Promise<WorkflowState | null>) => void;
 	setReplayFromStep: (
-		fn: (
-			entryId?: string,
-		) => Promise<inspectorSchema.WorkflowHistory | null>,
+		fn: (entryId?: string) => Promise<WorkflowHistoryBytes | null>,
 	) => void;
 } {
 	const emitter = createHistoryEmitter();
-	let history: inspectorSchema.WorkflowHistory | null = null;
+	let history: WorkflowHistoryBytes | null = null;
 	let getState: () => Promise<WorkflowState | null> = async () => null;
 	let replayFromStep: (
 		entryId?: string,
-	) => Promise<inspectorSchema.WorkflowHistory | null> = async () => {
+	) => Promise<WorkflowHistoryBytes | null> = async () => {
 		throw new Error("Workflow replay controls are not initialized");
 	};
 

--- a/rivetkit-typescript/packages/rivetkit/tests/driver/actor-inspector.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/driver/actor-inspector.test.ts
@@ -5,6 +5,8 @@ import {
 	TO_CLIENT_VERSIONED,
 	TO_SERVER_VERSIONED,
 } from "../../src/inspector/client.browser";
+import type { WorkflowHistory as TransportWorkflowHistory } from "../../src/common/bare/transport/v1";
+import { decodeWorkflowHistoryTransport } from "../../src/common/inspector-transport";
 import { describeDriverMatrix } from "./shared-matrix";
 import { setupDriverTest, waitFor } from "./shared-utils";
 
@@ -770,6 +772,73 @@ describeDriverMatrix("Actor Inspector", (driverTestConfig) => {
 			expect(
 				Object.keys(data.history?.entryMetadata ?? {}).length,
 			).toBeGreaterThan(0);
+
+			await handle.release();
+			// Poll until the released workflow finishes because release() only unblocks the run handler.
+			await vi.waitFor(
+				async () => {
+					expect((await handle.getState()).finishedAt).not.toBeNull();
+				},
+				{ timeout: WORKFLOW_READY_TIMEOUT_MS, interval: 100 },
+			);
+		});
+
+		test("inspector websocket workflow history stays raw BARE", async (c) => {
+			const { client } = await setupDriverTest(c, driverTestConfig);
+			const handle = client.workflowRunningStepActor.getOrCreate([
+				"inspector-workflow-ws-bare",
+				crypto.randomUUID(),
+			]);
+			const gatewayUrl = await handle.getGatewayUrl();
+			const ws = new WebSocket(buildInspectorWebSocketUrl(gatewayUrl), [
+				"rivet",
+				"rivet_inspector_token.token",
+			]);
+			ws.binaryType = "arraybuffer";
+
+			try {
+				await waitForInspectorOpen(ws);
+				await waitForInspectorMessageWithTag(ws, "Init");
+
+				let raw: ArrayBuffer | undefined;
+				// Poll because history stays null until the run handler records its first entry.
+				await vi.waitFor(
+					async () => {
+						const pending = waitForInspectorMessageWithTag(
+							ws,
+							"WorkflowHistoryResponse",
+						);
+						ws.send(
+							TO_SERVER_VERSIONED.serialize(
+								{
+									body: {
+										tag: "WorkflowHistoryRequest",
+										val: { id: 1n },
+									},
+								},
+								INSPECTOR_PROTOCOL_VERSION,
+							),
+						);
+						const body = (await pending).body.val;
+						expect(body.isWorkflowEnabled).toBe(true);
+						expect(body.history).not.toBeNull();
+						raw = body.history as ArrayBuffer;
+					},
+					{
+						timeout: ACTIVE_WORKFLOW_INSPECTOR_TIMEOUT_MS,
+						interval: 250,
+					},
+				);
+
+				// Decoded outside the poll: CBOR-wrapped bytes are a hard
+				// failure, not something that becomes valid on a later attempt.
+				const decoded: TransportWorkflowHistory =
+					decodeWorkflowHistoryTransport(raw as ArrayBuffer);
+				expect(decoded.nameRegistry.length).toBeGreaterThan(0);
+				expect(decoded.entries.length).toBeGreaterThan(0);
+			} finally {
+				ws.close();
+			}
 
 			await handle.release();
 			// Poll until the released workflow finishes because release() only unblocks the run handler.

--- a/rivetkit-typescript/packages/rivetkit/tests/driver/actor-inspector.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/driver/actor-inspector.test.ts
@@ -840,6 +840,33 @@ describeDriverMatrix("Actor Inspector", (driverTestConfig) => {
 				ws.close();
 			}
 
+			// `Init` carries history from the same bridge call, so assert it too.
+			// It arrives once per connection, hence a second socket: history is
+			// only guaranteed to be recorded now that the request above saw it.
+			const initWs = new WebSocket(
+				buildInspectorWebSocketUrl(gatewayUrl),
+				["rivet", "rivet_inspector_token.token"],
+			);
+			initWs.binaryType = "arraybuffer";
+
+			try {
+				await waitForInspectorOpen(initWs);
+				const init = await waitForInspectorMessageWithTag(
+					initWs,
+					"Init",
+				);
+				expect(init.body.val.isWorkflowEnabled).toBe(true);
+				expect(init.body.val.workflowHistory).not.toBeNull();
+				// Throws if the bytes were CBOR-wrapped instead of BARE.
+				const initDecoded = decodeWorkflowHistoryTransport(
+					init.body.val.workflowHistory as ArrayBuffer,
+				);
+				expect(initDecoded.nameRegistry.length).toBeGreaterThan(0);
+				expect(initDecoded.entries.length).toBeGreaterThan(0);
+			} finally {
+				initWs.close();
+			}
+
 			await handle.release();
 			// Poll until the released workflow finishes because release() only unblocks the run handler.
 			await vi.waitFor(


### PR DESCRIPTION
The inspector Workflow tab failed to render workflow history, reporting `BareError: (byte:3) invalid UTF-8 string`.

The inspector wire format carries raw BARE workflow-history bytes, but the native bridge ran them through the CBOR compat encoder, which rewrites an `ArrayBuffer` as `["$ArrayBuffer", "<base64>"]`. The dashboard then read those CBOR bytes as BARE and failed at byte 3. Only the WebSocket/NAPI path was affected; the HTTP routes already serialized correctly.

- Pass workflow history across the native bridge as raw bytes instead of CBOR compat encoding it, for both the history and replay callbacks
- Add a branded `WorkflowHistoryBytes` type so these bytes cannot be handed to the CBOR compat encoder again, making a regression a compile error
- Add a driver test asserting the inspector WebSocket delivers history that decodes as BARE, covering both the `Init` message and an explicit `WorkflowHistoryRequest`
- Stop core from decoding workflow history as CBOR in its JSON inspector responses. Decoding BARE bytes as CBOR yields a garbage value rather than an error, so core now omits the field and logs instead, since the BARE codec lives in the TypeScript workflow engine
- Surface a decode failure in the dashboard Workflow tab instead of silently rendering it as an empty workflow
- Fix the dashboard's workflow replay request, which still expected the pre-2.1 response shape of raw history bytes and rejected the documented decoded JSON, so "Replay From Current Step" always failed. The tab already refreshes history over the websocket after a replay, so the response body no longer needs to carry it
