### PR TITLE
fix(frontend): theme xyflow controls so workflow visualizer icons are visible

### DIFF
--- a/frontend/.ladle/ladle.css
+++ b/frontend/.ladle/ladle.css
@@ -38,35 +38,6 @@
 	}
 }
 
-/* Dark theme overrides for xyflow Controls. */
-.react-flow__controls {
-	background: hsl(var(--card));
-	border: 1px solid hsl(var(--border));
-	border-radius: 6px;
-	box-shadow: none;
-}
-
-.react-flow__controls-button {
-	background: transparent;
-	border-bottom: 1px solid hsl(var(--border));
-	fill: hsl(var(--foreground));
-}
-
-.react-flow__controls-button:hover {
-	background: hsl(var(--accent));
-}
-
-.react-flow__controls-button:last-child {
-	border-bottom: none;
-}
-
-/* Dark theme overrides for xyflow MiniMap. */
-.react-flow__minimap {
-	background: hsl(var(--card)) !important;
-	border: 1px solid hsl(var(--border));
-	border-radius: 6px;
-}
-
 /* Remove Ladle story container padding and make it fill the full viewport. */
 .ladle-main {
 	padding: 0 !important;

--- a/frontend/src/components/actors/workflow/workflow-visualizer.tsx
+++ b/frontend/src/components/actors/workflow/workflow-visualizer.tsx
@@ -23,6 +23,7 @@ import {
 } from "react";
 import "@xyflow/react/dist/style.css";
 import { Button, cn, DiscreteCopyButton, WithTooltip } from "@/components";
+import { useTheme } from "@/lib/theme";
 import { ActorObjectInspector } from "../console/actor-inspector";
 import { workflowHistoryToXYFlow } from "./workflow-to-xyflow";
 import type { WorkflowHistory } from "./workflow-types";
@@ -444,6 +445,7 @@ function WorkflowGraph({
 }) {
 	const { fitView } = useReactFlow();
 	const nodesInitialized = useNodesInitialized();
+	const { theme } = useTheme();
 
 	useEffect(() => {
 		if (!nodesInitialized || nodes.length === 0) {
@@ -474,6 +476,7 @@ function WorkflowGraph({
 			nodesConnectable={false}
 			edgesReconnectable={false}
 			proOptions={{ hideAttribution: true }}
+			colorMode={theme}
 		>
 			<Background
 				variant={BackgroundVariant.Dots}

--- a/frontend/src/components/actors/workflow/xyflow-nodes.stories.tsx
+++ b/frontend/src/components/actors/workflow/xyflow-nodes.stories.tsx
@@ -49,6 +49,7 @@ function StoryCanvas({ nodes, edges = [] }: { nodes: Node[]; edges?: Edge[] }) {
 					panOnDrag={[1, 2]}
 					edgesFocusable={false}
 					proOptions={{ hideAttribution: true }}
+					colorMode="dark"
 				>
 					<Background
 						variant={BackgroundVariant.Dots}

--- a/frontend/src/components/theme.css
+++ b/frontend/src/components/theme.css
@@ -49,31 +49,31 @@
 	@apply bg-secondary/50;
 }
 
-/* Dark theme overrides for xyflow Controls. */
+/*
+ * xyflow theming. These map the library's own custom properties to dashboard
+ * tokens, which wins over `dist/style.css` regardless of bundle import order.
+ * Setting individual properties instead loses to the library stylesheet, and
+ * `fill` on the button never reaches the icon because `.react-flow__controls-button svg`
+ * is more specific and resolves `currentColor` from `color`.
+ */
+.react-flow {
+	--xy-controls-button-background-color: hsl(var(--card));
+	--xy-controls-button-background-color-hover: hsl(var(--accent));
+	--xy-controls-button-color: hsl(var(--foreground));
+	--xy-controls-button-color-hover: hsl(var(--accent-foreground));
+	--xy-controls-button-border-color: hsl(var(--border));
+	--xy-controls-box-shadow: none;
+	--xy-minimap-background-color: hsl(var(--card));
+	--xy-edge-stroke: hsl(var(--muted-foreground));
+}
+
 .react-flow__controls {
-	background: hsl(var(--card));
 	border: 1px solid hsl(var(--border));
 	border-radius: 6px;
-	box-shadow: none;
+	overflow: hidden;
 }
 
-.react-flow__controls-button {
-	background: transparent;
-	border-bottom: 1px solid hsl(var(--border));
-	fill: hsl(var(--foreground));
-}
-
-.react-flow__controls-button:hover {
-	background: hsl(var(--accent));
-}
-
-.react-flow__controls-button:last-child {
-	border-bottom: none;
-}
-
-/* Dark theme overrides for xyflow MiniMap. */
 .react-flow__minimap {
-	background: hsl(var(--card)) !important;
 	border: 1px solid hsl(var(--border));
 	border-radius: 6px;
 }
@@ -84,7 +84,3 @@
 	height: 100vh;
 }
 
-/* Dark theme for xyflow edges. */
-.react-flow__edge-path {
-	stroke: hsl(var(--muted-foreground));
-}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -212,36 +212,33 @@
 	}
 }
 
-/* Dark theme overrides for xyflow (React Flow). */
+/*
+ * xyflow theming. These map the library's own custom properties to dashboard
+ * tokens, which wins over `dist/style.css` regardless of bundle import order.
+ * Setting individual properties instead loses to the library stylesheet, and
+ * `fill` on the button never reaches the icon because `.react-flow__controls-button svg`
+ * is more specific and resolves `currentColor` from `color`.
+ */
+.react-flow {
+	--xy-controls-button-background-color: hsl(var(--card));
+	--xy-controls-button-background-color-hover: hsl(var(--accent));
+	--xy-controls-button-color: hsl(var(--foreground));
+	--xy-controls-button-color-hover: hsl(var(--accent-foreground));
+	--xy-controls-button-border-color: hsl(var(--border));
+	--xy-controls-box-shadow: none;
+	--xy-minimap-background-color: hsl(var(--card));
+	--xy-edge-stroke: hsl(var(--muted-foreground));
+}
+
 .react-flow__controls {
-	background: hsl(var(--card));
 	border: 1px solid hsl(var(--border));
 	border-radius: 6px;
-	box-shadow: none;
-}
-
-.react-flow__controls-button {
-	background: transparent;
-	border-bottom: 1px solid hsl(var(--border));
-	fill: hsl(var(--foreground));
-}
-
-.react-flow__controls-button:hover {
-	background: hsl(var(--accent));
-}
-
-.react-flow__controls-button:last-child {
-	border-bottom: none;
+	overflow: hidden;
 }
 
 .react-flow__minimap {
-	background: hsl(var(--card)) !important;
 	border: 1px solid hsl(var(--border));
 	border-radius: 6px;
-}
-
-.react-flow__edge-path {
-	stroke: hsl(var(--muted-foreground));
 }
 
 /*


### PR DESCRIPTION
The zoom, fit-view, and lock controls in the workflow visualizer rendered as blank squares. The buttons kept the library's light-mode background while the icons inherited a near-white foreground colour, so the icons were invisible against them.

`<ReactFlow>` was never told which colour mode to use, so xyflow stayed in light mode and its own dark palette never applied. The dashboard compensated with ad-hoc property overrides, but those set `fill` on the button, which never reaches the icon because `.react-flow__controls-button svg` is more specific and resolves `currentColor` from `color`. The background override also depended on stylesheet import order, since the library's rule has equal specificity.

- Pass the active theme to `<ReactFlow>` as `colorMode` so xyflow applies its own light and dark palettes
- Theme the controls, minimap, and edges through xyflow's own custom properties, which take precedence over the library defaults regardless of bundle import order
- Remove the duplicated xyflow override blocks, which had drifted across three stylesheets
- Set an explicit colour mode in the xyflow Ladle stories so they match the dashboard
