### PR TITLE
fix(effect): update to effect 4.0.0-rc.109 and replace TaggedErrorClass with TaggedError

### DIFF
--- a/rivetkit-typescript/packages/effect/package.json
+++ b/rivetkit-typescript/packages/effect/package.json
@@ -30,13 +30,13 @@
 		"coverage": "vitest run --coverage"
 	},
 	"peerDependencies": {
-		"effect": "^4.0.0-beta.66",
+		"effect": "^4.0.0-rc.109",
 		"rivetkit": "workspace:*"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.18.3",
 		"@effect/language-service": "^0.85.1",
-		"@effect/vitest": "^4.0.0-beta.66",
+		"@effect/vitest": "^4.0.0-rc.109",
 		"@types/node": "^22.18.1",
 		"@vitest/coverage-v8": "^4.1.7",
 		"publint": "^0.3.21",

--- a/rivetkit-typescript/packages/effect/src/Action.ts
+++ b/rivetkit-typescript/packages/effect/src/Action.ts
@@ -178,7 +178,7 @@ const makeProto = <
  * import { Schema } from "effect"
  * import { Action } from "@rivetkit/effect"
  *
- * class CounterOverflow extends Schema.TaggedErrorClass<CounterOverflow>()(
+ * class CounterOverflow extends Schema.TaggedError<CounterOverflow>()(
  *   "CounterOverflow",
  *   { limit: Schema.Number },
  * ) {}

--- a/rivetkit-typescript/packages/effect/src/Actor.test-d.ts
+++ b/rivetkit-typescript/packages/effect/src/Actor.test-d.ts
@@ -58,7 +58,7 @@ const ServiceDependentNumber = Schema.Number.pipe(
 	),
 );
 
-class ServiceDependentError extends Schema.TaggedErrorClass<ServiceDependentError>()(
+class ServiceDependentError extends Schema.TaggedError<ServiceDependentError>()(
 	"ServiceDependentError",
 	{
 		limit: ServiceDependentNumber,

--- a/rivetkit-typescript/packages/effect/src/RivetError.ts
+++ b/rivetkit-typescript/packages/effect/src/RivetError.ts
@@ -4,7 +4,7 @@ import * as RivetkitErrors from "rivetkit/errors";
 const ReasonTypeId = "~@rivetkit/effect/RivetError/Reason" as const;
 const TypeId = "~@rivetkit/effect/RivetError" as const;
 
-export class Forbidden extends Schema.TaggedErrorClass<Forbidden>(
+export class Forbidden extends Schema.TaggedError<Forbidden>(
 	`${ReasonTypeId}/Forbidden`,
 )("Forbidden", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -36,7 +36,7 @@ export class Forbidden extends Schema.TaggedErrorClass<Forbidden>(
 	}
 }
 
-export class ActorNotFound extends Schema.TaggedErrorClass<ActorNotFound>(
+export class ActorNotFound extends Schema.TaggedError<ActorNotFound>(
 	`${ReasonTypeId}/ActorNotFound`,
 )("ActorNotFound", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -68,7 +68,7 @@ export class ActorNotFound extends Schema.TaggedErrorClass<ActorNotFound>(
 	}
 }
 
-export class ActorStopping extends Schema.TaggedErrorClass<ActorStopping>(
+export class ActorStopping extends Schema.TaggedError<ActorStopping>(
 	`${ReasonTypeId}/ActorStopping`,
 )("ActorStopping", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -100,7 +100,7 @@ export class ActorStopping extends Schema.TaggedErrorClass<ActorStopping>(
 	}
 }
 
-export class ActorRestarting extends Schema.TaggedErrorClass<ActorRestarting>(
+export class ActorRestarting extends Schema.TaggedError<ActorRestarting>(
 	`${ReasonTypeId}/ActorRestarting`,
 )("ActorRestarting", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -140,7 +140,7 @@ export class ActorRestarting extends Schema.TaggedErrorClass<ActorRestarting>(
 	}
 }
 
-export class ActionNotFound extends Schema.TaggedErrorClass<ActionNotFound>(
+export class ActionNotFound extends Schema.TaggedError<ActionNotFound>(
 	`${ReasonTypeId}/ActionNotFound`,
 )("ActionNotFound", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -172,7 +172,7 @@ export class ActionNotFound extends Schema.TaggedErrorClass<ActionNotFound>(
 	}
 }
 
-export class ActionTimedOut extends Schema.TaggedErrorClass<ActionTimedOut>(
+export class ActionTimedOut extends Schema.TaggedError<ActionTimedOut>(
 	`${ReasonTypeId}/ActionTimedOut`,
 )("ActionTimedOut", { cause: Schema.instanceOf(RivetkitErrors.RivetError) }) {
 	readonly [ReasonTypeId] = ReasonTypeId;
@@ -202,7 +202,7 @@ export class ActionTimedOut extends Schema.TaggedErrorClass<ActionTimedOut>(
 	}
 }
 
-export class ActionAborted extends Schema.TaggedErrorClass<ActionAborted>(
+export class ActionAborted extends Schema.TaggedError<ActionAborted>(
 	`${ReasonTypeId}/ActionAborted`,
 )("ActionAborted", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -234,7 +234,7 @@ export class ActionAborted extends Schema.TaggedErrorClass<ActionAborted>(
 	}
 }
 
-export class ActorOverloaded extends Schema.TaggedErrorClass<ActorOverloaded>(
+export class ActorOverloaded extends Schema.TaggedError<ActorOverloaded>(
 	`${ReasonTypeId}/ActorOverloaded`,
 )("ActorOverloaded", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -266,7 +266,7 @@ export class ActorOverloaded extends Schema.TaggedErrorClass<ActorOverloaded>(
 	}
 }
 
-export class IncomingMessageTooLong extends Schema.TaggedErrorClass<IncomingMessageTooLong>(
+export class IncomingMessageTooLong extends Schema.TaggedError<IncomingMessageTooLong>(
 	`${ReasonTypeId}/IncomingMessageTooLong`,
 )("IncomingMessageTooLong", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -298,7 +298,7 @@ export class IncomingMessageTooLong extends Schema.TaggedErrorClass<IncomingMess
 	}
 }
 
-export class OutgoingMessageTooLong extends Schema.TaggedErrorClass<OutgoingMessageTooLong>(
+export class OutgoingMessageTooLong extends Schema.TaggedError<OutgoingMessageTooLong>(
 	`${ReasonTypeId}/OutgoingMessageTooLong`,
 )("OutgoingMessageTooLong", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -330,7 +330,7 @@ export class OutgoingMessageTooLong extends Schema.TaggedErrorClass<OutgoingMess
 	}
 }
 
-export class InvalidEncoding extends Schema.TaggedErrorClass<InvalidEncoding>(
+export class InvalidEncoding extends Schema.TaggedError<InvalidEncoding>(
 	`${ReasonTypeId}/InvalidEncoding`,
 )("InvalidEncoding", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -362,7 +362,7 @@ export class InvalidEncoding extends Schema.TaggedErrorClass<InvalidEncoding>(
 	}
 }
 
-export class InvalidRequest extends Schema.TaggedErrorClass<InvalidRequest>(
+export class InvalidRequest extends Schema.TaggedError<InvalidRequest>(
 	`${ReasonTypeId}/InvalidRequest`,
 )("InvalidRequest", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -394,7 +394,7 @@ export class InvalidRequest extends Schema.TaggedErrorClass<InvalidRequest>(
 	}
 }
 
-export class GuardActorReadyTimeout extends Schema.TaggedErrorClass<GuardActorReadyTimeout>(
+export class GuardActorReadyTimeout extends Schema.TaggedError<GuardActorReadyTimeout>(
 	`${ReasonTypeId}/GuardActorReadyTimeout`,
 )("GuardActorReadyTimeout", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -426,7 +426,7 @@ export class GuardActorReadyTimeout extends Schema.TaggedErrorClass<GuardActorRe
 	}
 }
 
-export class GuardActorWakeRetriesExceeded extends Schema.TaggedErrorClass<GuardActorWakeRetriesExceeded>(
+export class GuardActorWakeRetriesExceeded extends Schema.TaggedError<GuardActorWakeRetriesExceeded>(
 	`${ReasonTypeId}/GuardActorWakeRetriesExceeded`,
 )("GuardActorWakeRetriesExceeded", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -458,7 +458,7 @@ export class GuardActorWakeRetriesExceeded extends Schema.TaggedErrorClass<Guard
 	}
 }
 
-export class GuardActorRunnerFailed extends Schema.TaggedErrorClass<GuardActorRunnerFailed>(
+export class GuardActorRunnerFailed extends Schema.TaggedError<GuardActorRunnerFailed>(
 	`${ReasonTypeId}/GuardActorRunnerFailed`,
 )("GuardActorRunnerFailed", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -490,7 +490,7 @@ export class GuardActorRunnerFailed extends Schema.TaggedErrorClass<GuardActorRu
 	}
 }
 
-export class GuardServiceUnavailable extends Schema.TaggedErrorClass<GuardServiceUnavailable>(
+export class GuardServiceUnavailable extends Schema.TaggedError<GuardServiceUnavailable>(
 	`${ReasonTypeId}/GuardServiceUnavailable`,
 )("GuardServiceUnavailable", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -522,7 +522,7 @@ export class GuardServiceUnavailable extends Schema.TaggedErrorClass<GuardServic
 	}
 }
 
-export class GuardActorStoppedWhileWaiting extends Schema.TaggedErrorClass<GuardActorStoppedWhileWaiting>(
+export class GuardActorStoppedWhileWaiting extends Schema.TaggedError<GuardActorStoppedWhileWaiting>(
 	`${ReasonTypeId}/GuardActorStoppedWhileWaiting`,
 )("GuardActorStoppedWhileWaiting", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -554,7 +554,7 @@ export class GuardActorStoppedWhileWaiting extends Schema.TaggedErrorClass<Guard
 	}
 }
 
-export class GuardTunnelRequestAborted extends Schema.TaggedErrorClass<GuardTunnelRequestAborted>(
+export class GuardTunnelRequestAborted extends Schema.TaggedError<GuardTunnelRequestAborted>(
 	`${ReasonTypeId}/GuardTunnelRequestAborted`,
 )("GuardTunnelRequestAborted", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -586,7 +586,7 @@ export class GuardTunnelRequestAborted extends Schema.TaggedErrorClass<GuardTunn
 	}
 }
 
-export class GuardTunnelMessageTimeout extends Schema.TaggedErrorClass<GuardTunnelMessageTimeout>(
+export class GuardTunnelMessageTimeout extends Schema.TaggedError<GuardTunnelMessageTimeout>(
 	`${ReasonTypeId}/GuardTunnelMessageTimeout`,
 )("GuardTunnelMessageTimeout", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -618,7 +618,7 @@ export class GuardTunnelMessageTimeout extends Schema.TaggedErrorClass<GuardTunn
 	}
 }
 
-export class GuardTunnelResponseClosed extends Schema.TaggedErrorClass<GuardTunnelResponseClosed>(
+export class GuardTunnelResponseClosed extends Schema.TaggedError<GuardTunnelResponseClosed>(
 	`${ReasonTypeId}/GuardTunnelResponseClosed`,
 )("GuardTunnelResponseClosed", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -650,7 +650,7 @@ export class GuardTunnelResponseClosed extends Schema.TaggedErrorClass<GuardTunn
 	}
 }
 
-export class GuardGatewayResponseStartTimeout extends Schema.TaggedErrorClass<GuardGatewayResponseStartTimeout>(
+export class GuardGatewayResponseStartTimeout extends Schema.TaggedError<GuardGatewayResponseStartTimeout>(
 	`${ReasonTypeId}/GuardGatewayResponseStartTimeout`,
 )("GuardGatewayResponseStartTimeout", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -682,7 +682,7 @@ export class GuardGatewayResponseStartTimeout extends Schema.TaggedErrorClass<Gu
 	}
 }
 
-export class InternalError extends Schema.TaggedErrorClass<InternalError>(
+export class InternalError extends Schema.TaggedError<InternalError>(
 	`${ReasonTypeId}/InternalError`,
 )("InternalError", {
 	cause: Schema.instanceOf(RivetkitErrors.RivetError),
@@ -714,7 +714,7 @@ export class InternalError extends Schema.TaggedErrorClass<InternalError>(
 	}
 }
 
-export class ActionErrorDecodeFailed extends Schema.TaggedErrorClass<ActionErrorDecodeFailed>(
+export class ActionErrorDecodeFailed extends Schema.TaggedError<ActionErrorDecodeFailed>(
 	`${ReasonTypeId}/ActionErrorDecodeFailed`,
 )("ActionErrorDecodeFailed", {
 	cause: Schema.instanceOf(Schema.SchemaError),
@@ -757,7 +757,7 @@ export class ActionErrorDecodeFailed extends Schema.TaggedErrorClass<ActionError
  * receive those errors **typed** in the error channel; this reason is
  * the catch-all for everything else.
  */
-export class UnknownUserError extends Schema.TaggedErrorClass<UnknownUserError>(
+export class UnknownUserError extends Schema.TaggedError<UnknownUserError>(
 	`${ReasonTypeId}/UnknownUserError`,
 )("UnknownUserError", { cause: Schema.instanceOf(RivetkitErrors.RivetError) }) {
 	readonly [ReasonTypeId] = ReasonTypeId;
@@ -792,7 +792,7 @@ export class UnknownUserError extends Schema.TaggedErrorClass<UnknownUserError>(
  * not recognize yet, and for malformed non-Rivet failures. Known wire
  * fields are mirrored when present, while `cause` preserves the raw input.
  */
-export class UnknownError extends Schema.TaggedErrorClass<UnknownError>(
+export class UnknownError extends Schema.TaggedError<UnknownError>(
 	`${ReasonTypeId}/UnknownError`,
 )("UnknownError", {
 	message: Schema.String,
@@ -941,7 +941,7 @@ export const isRivetErrorReason = (u: unknown): u is RivetErrorReason =>
  * arrive in the typed error channel separately and do NOT flow through
  * `RivetError`.
  */
-export class RivetError extends Schema.TaggedErrorClass<RivetError>(
+export class RivetError extends Schema.TaggedError<RivetError>(
 	"@rivetkit/effect/RivetError",
 )("RivetError", {
 	reason: RivetErrorReason,

--- a/rivetkit-typescript/packages/effect/test/fixtures/actors.ts
+++ b/rivetkit-typescript/packages/effect/test/fixtures/actors.ts
@@ -14,7 +14,7 @@ import { db } from "rivetkit/db";
 
 // --- Counter ---
 
-export class CounterOverflowError extends Schema.TaggedErrorClass<CounterOverflowError>()(
+export class CounterOverflowError extends Schema.TaggedError<CounterOverflowError>()(
 	"CounterOverflowError",
 	{
 		limit: Schema.Number,
@@ -121,7 +121,7 @@ const ScaledNumber = Schema.Number.pipe(
 	),
 );
 
-export class ScaledOverflowError extends Schema.TaggedErrorClass<ScaledOverflowError>()(
+export class ScaledOverflowError extends Schema.TaggedError<ScaledOverflowError>()(
 	"ScaledOverflowError",
 	{
 		limit: ScaledNumber,


### PR DESCRIPTION
Fixes #5583

### Description
The `@rivetkit/effect` package was incompatible with the `effect` 4.0.0-rc.x releases because `Schema.TaggedErrorClass` was removed in `effect` rc.108+. Since `@rivetkit/effect` publishes raw TypeScript, this caused type-check and import failures for consumers using newer versions of `effect`.

### Changes Made
- Upgraded `effect` and `@effect/vitest` in `@rivetkit/effect`'s `package.json` to `^4.0.0-rc.109`.
- Performed a mechanical rename of all usages of `Schema.TaggedErrorClass` to `Schema.TaggedError` across the codebase to ensure compatibility.

cc @nathanflurry @kevinmichaelchen