### PR TITLE
fix(effect): forward all RivetKit actor options, not just name and icon

### DIFF
--- a/rivetkit-typescript/packages/effect/src/Actor.test.ts
+++ b/rivetkit-typescript/packages/effect/src/Actor.test.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from "@effect/vitest";
-import { Actor, State } from "@rivetkit/effect";
-import { Context, Effect, Layer } from "effect";
+import { Action, Actor, Registry, State } from "@rivetkit/effect";
+import { Context, Effect, Layer, Schema } from "effect";
 import type * as Rivetkit from "rivetkit";
 
 class Prefix extends Context.Service<Prefix, { readonly value: string }>()(
@@ -205,5 +205,87 @@ describe("Actor.toWakeHandler", () => {
 				assert.strictEqual(calls, 2);
 				assert.strictEqual(yield* second.Count(), 2);
 			}),
+	);
+});
+
+describe("Actor.toLayer options", () => {
+	const Optioned = Actor.make("Optioned", {
+		actions: [Action.make("Noop")],
+	});
+	const noop = { Noop: () => Effect.void };
+
+	/**
+	 * Builds an actor layer against a throwaway registry and hands back
+	 * the options the underlying RivetKit actor was actually created
+	 * with, after RivetKit has parsed them and filled in its defaults.
+	 */
+	const builtOptions = (
+		actorsLayer: Layer.Layer<never, never, Registry.Registry>,
+	) =>
+		Effect.gen(function* () {
+			const registry = yield* Registry.Registry;
+			const built = registry.rivetkitActors.get("Optioned");
+
+			assert.ok(built, "expected Optioned to be registered");
+
+			return built.config.options;
+		}).pipe(
+			Effect.provide(
+				actorsLayer.pipe(
+					Layer.provideMerge(Registry.layer({ noWelcome: true })),
+				),
+			),
+		);
+
+	it.effect("forwards instance options to the RivetKit actor", () =>
+		Effect.gen(function* () {
+			const options = yield* builtOptions(
+				Optioned.toLayer(noop, {
+					actionTimeout: 1_234,
+					sleepTimeout: 5_678,
+					maxQueueMessageSize: 128 * 1024,
+				}),
+			);
+
+			assert.strictEqual(options.actionTimeout, 1_234);
+			assert.strictEqual(options.sleepTimeout, 5_678);
+			assert.strictEqual(options.maxQueueMessageSize, 128 * 1024);
+		}),
+	);
+
+	it.effect("keeps forwarding the Inspector display options", () =>
+		Effect.gen(function* () {
+			const options = yield* builtOptions(
+				Optioned.toLayer(noop, { name: "Display", icon: "rocket" }),
+			);
+
+			assert.strictEqual(options.name, "Display");
+			assert.strictEqual(options.icon, "rocket");
+		}),
+	);
+
+	it.effect("leaves RivetKit's own defaults in place when unset", () =>
+		Effect.gen(function* () {
+			const options = yield* builtOptions(Optioned.toLayer(noop, {}));
+
+			assert.isNumber(options.actionTimeout);
+			assert.isNumber(options.sleepTimeout);
+		}),
+	);
+
+	it.effect("does not forward the SDK-only options", () =>
+		Effect.gen(function* () {
+			const options = yield* builtOptions(
+				Optioned.toLayer(noop, {
+					state: {
+						schema: Schema.Number,
+						initialValue: () => 0,
+					},
+				}),
+			);
+
+			assert.isFalse("state" in options);
+			assert.isFalse("db" in options);
+		}),
 	);
 });

--- a/rivetkit-typescript/packages/effect/src/Actor.ts
+++ b/rivetkit-typescript/packages/effect/src/Actor.ts
@@ -27,17 +27,15 @@ const TypeId = "~@rivetkit/effect/Actor";
 export const isActor = (u: unknown): u is Actor<any, any> =>
 	Predicate.hasProperty(u, TypeId);
 
-const rivetkitActorOptionsKeys = [
-	"name",
-	"icon",
-] as const satisfies ReadonlyArray<
-	keyof NonNullable<Rivetkit.ActorOptionsInput>
->;
+/**
+ * The option keys this SDK consumes itself instead of handing to
+ * RivetKit. Everything else in {@link Options} is forwarded verbatim,
+ * so a new RivetKit actor option is usable here as soon as it lands
+ * upstream, with no change to this file.
+ */
+const effectActorOptionsKeys = ["state", "db"] as const;
 
-export type RivetkitActorOptions = Pick<
-	NonNullable<Rivetkit.ActorOptionsInput>,
-	(typeof rivetkitActorOptionsKeys)[number]
->;
+export type RivetkitActorOptions = NonNullable<Rivetkit.ActorOptionsInput>;
 
 /**
  * Per-actor instance options. Combines the public
@@ -73,8 +71,8 @@ const splitOptions = <
 >(
 	options: Options<State, Database>,
 ) => ({
-	rivetkitOptions: Struct.pick(options, rivetkitActorOptionsKeys),
-	effectOptions: Struct.omit(options, rivetkitActorOptionsKeys),
+	rivetkitOptions: Struct.omit(options, effectActorOptionsKeys),
+	effectOptions: Struct.pick(options, effectActorOptionsKeys),
 });
 
 /**


### PR DESCRIPTION
I was observing an actor that awaits an LLM gets killed by the 60s default `actionTimeout` and there was no way to raise it — the option is accepted by the type system and then discarded

- Currently only `name` and `icon` get passed through. The intent of this PR is to properly pass through all config keys
- Unknown keys fail loudly at compile time (`ActorOptionsSchema` is .strict())
- Four tests added: instance options forwarded, display options (name/icon) still forwarded, RivetKit defaults
  intact when unset, and SDK-only options (state/db) kept out of the forwarded bag.
- [stagecraft]( https://github.com/AuthorOfTheSurf/stagecraft ) (ergonomic layer over Rivet & Effect) works around this today by writing onto config.options after the layer builds. That workaround disappears if this lands. I was able to solve my own personal case by increasing the default 60 second timeout to 600 seconds. The p99 for my simulation was 53.8s, so I'd get a couple failures per run without the ability to increase


The change

Eight lines of source. Rather than widen the allowlist, I inverted the split:

```ts
const effectActorOptionsKeys = ["state", "db"] as const;
export type RivetkitActorOptions = NonNullable<Rivetkit.ActorOptionsInput>;
// splitOptions:
rivetkitOptions: Struct.omit(options, effectActorOptionsKeys),
effectOptions:   Struct.pick(options, effectActorOptionsKeys),
```

- Widening the allow list is not the right approach, because developers that add config fields would need to remember to widen the allow list too. Failure to do so would result in the same exact bug of accepting config values and then silently doing nothing with them.