### PR TITLE
fix(hub): add missing WebSocket protocol header to inspector

### DIFF
--- a/frontend/src/components/hooks/use-websocket.tsx
+++ b/frontend/src/components/hooks/use-websocket.tsx
@@ -42,7 +42,14 @@ export const useWebSocket = (
 			}
 		}
 
-		const ws = new ReconnectingWebSocket(url, protocols, {
+		const finalProtocols = Array.isArray(protocols) 
+			? protocols 
+			: (protocols ? [protocols] : []);
+		if (!finalProtocols.includes("rivet")) {
+			finalProtocols.unshift("rivet");
+		}
+
+		const ws = new ReconnectingWebSocket(url, finalProtocols, {
 			binaryType: "arraybuffer",
 		});
 		wsRef.current = ws;


### PR DESCRIPTION
Fixes #5481

### Description
The Hub UI's Inspector REPL was failing to establish a WebSocket connection because the `Sec-WebSocket-Protocol: rivet` header was not sent. The engine's guard requires this header and rejects the connection without it.

### Changes Made
Updated `use-websocket.tsx` to automatically append the `rivet` protocol to the `ReconnectingWebSocket` initialization if it isn't already present.

cc @MasterPtato @ajayaccumatic