### PR TITLE
ci(release): migrate npm publishing to oidc

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -381,7 +381,8 @@ jobs:
       needs.build.result == 'success' &&
       needs.build-wasm.result == 'success' &&
       needs.docker-images.result == 'success'
-    runs-on: depot-ubuntu-24.04-8
+    # npm trusted publishing currently requires a GitHub-hosted runner.
+    runs-on: ubuntu-24.04
     permissions:
       contents: write # git tag + gh release (release only)
       id-token: write
@@ -399,6 +400,8 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
+      - name: Install OIDC-capable npm
+        run: npm install --global npm@11.16.0
       - run: pnpm install --frozen-lockfile
       - uses: ./.github/actions/docker-setup
         with:
@@ -568,7 +571,6 @@ jobs:
 
       - name: Publish npm packages
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           SKIP_WASM_BUILD: "1"
         run: |
           pnpm --filter=publish exec tsx src/ci/bin.ts publish-npm \

--- a/scripts/publish/src/ci/bin.ts
+++ b/scripts/publish/src/ci/bin.ts
@@ -187,6 +187,10 @@ program
 		"--version-only",
 		"Only rewrite package.json version fields without publish-time dependency injection",
 	)
+	.option(
+		"--repository <owner/repo>",
+		"GitHub repository recorded in publish-time package metadata (defaults to GITHUB_REPOSITORY)",
+	)
 	.option("--dry-run", "Do not write, only report")
 	.action(async (opts) => {
 		const repoRoot = findRepoRoot();
@@ -196,6 +200,7 @@ program
 			dryRun: !!opts.dryRun,
 			includeReleaseOnlyPackages: ctx.trigger === "release",
 			versionOnly: !!opts.versionOnly,
+			repository: opts.repository ?? process.env.GITHUB_REPOSITORY,
 		});
 		await bumpCargoVersions(repoRoot, version, {
 			dryRun: !!opts.dryRun,

--- a/scripts/publish/src/lib/npm.ts
+++ b/scripts/publish/src/lib/npm.ts
@@ -220,6 +220,15 @@ export async function repairBranchPreviewLatestTags(
 	opts: Required<Pick<PublishAllOptions, "tag" | "version">> &
 		Pick<PublishAllOptions, "includeReleaseOnlyPackages">,
 ): Promise<void> {
+	// npm trusted publishing only authenticates `npm publish`; commands such as
+	// `npm dist-tag add` still require a traditional token. Preserve the repair
+	// for manual/token-authenticated runs, but do not make OIDC publishes fail
+	// after their packages have already been published successfully.
+	if (!process.env.NODE_AUTH_TOKEN) {
+		log.warn("skipping preview latest-tag repair during tokenless OIDC publish");
+		return;
+	}
+
 	const previewPrefix = `0.0.0-${opts.tag}.`;
 	const packages = discoverPackages(repoRoot, {
 		includeReleaseOnly: opts.includeReleaseOnlyPackages,

--- a/scripts/publish/src/lib/version.ts
+++ b/scripts/publish/src/lib/version.ts
@@ -32,6 +32,11 @@ const log = scoped("version");
 interface PackageJson {
 	name?: string;
 	version?: string;
+	repository?: {
+		type: "git";
+		url: string;
+		directory: string;
+	};
 	dependencies?: Record<string, string>;
 	devDependencies?: Record<string, string>;
 	peerDependencies?: Record<string, string>;
@@ -80,6 +85,26 @@ export interface BumpOptions {
 	 * the publish-time mode used by CI — never committed.
 	 */
 	versionOnly?: boolean;
+	/** GitHub repository slug recorded in publish-time package metadata. */
+	repository?: string;
+}
+
+export function githubRepositoryUrl(repository: string): string {
+	if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+		throw new Error(
+			`invalid GitHub repository ${JSON.stringify(repository)}; expected owner/repo`,
+		);
+	}
+	return `https://github.com/${repository}.git`;
+}
+
+function requirePublishRepository(repository: string | undefined): string {
+	if (!repository) {
+		throw new Error(
+			"publish-time package metadata requires a GitHub repository",
+		);
+	}
+	return repository;
 }
 
 /**
@@ -119,6 +144,12 @@ export async function bumpPackageJsons(
 		pkgJson.version = version;
 
 		if (!versionOnly) {
+			pkgJson.repository = {
+				type: "git",
+				url: githubRepositoryUrl(requirePublishRepository(opts.repository)),
+				directory: pkg.relDir,
+			};
+
 			// Inject optionalDependencies on meta packages so end users get the
 			// correct platform-specific binary via npm's os/cpu/libc resolution.
 			const platformPkgs = metaPlatformMap.get(pkg.name);


### PR DESCRIPTION
- Publish npm packages through trusted publishing on a GitHub-hosted runner instead of a long-lived npm token.
- Populate publish-time package repository metadata from GitHub's repository claim.
- Preserve preview tag repair for token-authenticated publishing while skipping it for tokenless OIDC publishing.
