### PR TITLE
fix(release): clear placeholder npm token for oidc

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -571,6 +571,9 @@ jobs:
 
       - name: Publish npm packages
         env:
+          # setup-node provides a dummy token value; clear it so token-only
+          # post-publish operations stay disabled for trusted publishing.
+          NODE_AUTH_TOKEN: ""
           SKIP_WASM_BUILD: "1"
         run: |
           pnpm --filter=publish exec tsx src/ci/bin.ts publish-npm \


### PR DESCRIPTION
- Clear the setup-node placeholder token from the npm publish step.
- Keep token-only preview dist-tag repair disabled during trusted publishing.
- Preserve OIDC authentication for npm publish.