### PR TITLE
ci(release): use node 24 for publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -55,7 +55,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: pnpm
       - name: Install publish scripts
         run: pnpm install --frozen-lockfile --filter=publish
@@ -287,7 +287,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: pnpm
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -397,11 +397,9 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
-      - name: Install OIDC-capable npm
-        run: npm install --global npm@11.16.0
       - run: pnpm install --frozen-lockfile
       - uses: ./.github/actions/docker-setup
         with:


### PR DESCRIPTION
- Run all Node-based publish workflow jobs on Node 24.
- Use the npm version bundled with Node 24 for trusted publishing.
- Remove the redundant global npm installation.