### PR TITLE
docs: remediate SEO audit findings

### DIFF
--- a/docs/content/docs/access-control.mdx
+++ b/docs/content/docs/access-control.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Access Control"
-description: "Authorize actions, queue publishes, and event subscriptions with explicit hooks."
+description: "Authorize Rivet Actor actions, queue publishes, and event subscriptions with hooks that enforce access rules for each client connection."
 skill: true
 ---
 

--- a/docs/content/docs/actions.mdx
+++ b/docs/content/docs/actions.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Actions"
-description: "Actions are how your backend, frontend, or other actors can communicate with actors."
+description: "Define Rivet Actor actions that let backends, frontends, and other actors call typed functions and receive results in real time."
 skill: true
 ---
 

--- a/docs/content/docs/actor-runtime-socket.mdx
+++ b/docs/content/docs/actor-runtime-socket.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Actor Runtime Socket"
-description: "Access an actor's SQLite database from another local process."
+description: "Access a Rivet Actor's embedded SQLite database from another local process through the Actor Runtime Socket protocol."
 skill: true
 ---
 

--- a/docs/content/docs/appearance.mdx
+++ b/docs/content/docs/appearance.mdx
@@ -1,10 +1,8 @@
 ---
 title: Icons & Names
-description: Customize actors with display names and icons for the Rivet inspector and dashboard.
+description: "Configure display names and icons for Rivet Actors so each instance is easy to recognize in the dashboard and inspector."
 skill: true
 ---
-
-# Icons & Names
 
 Actors can be customized with a display name and icon that appear in the Rivet inspector & dashboard. This helps identify actors at a glance when managing your application.
 

--- a/docs/content/docs/authentication.mdx
+++ b/docs/content/docs/authentication.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Authentication"
-description: "Secure your actors with authentication and authorization."
+description: "Authenticate Rivet Actor connections, validate credentials before clients connect, and carry trusted identity into actor actions."
 skill: true
 ---
 

--- a/docs/content/docs/cli.mdx
+++ b/docs/content/docs/cli.mdx
@@ -1,6 +1,7 @@
 ---
 title: "CLI"
-description: "Reference for the optional rivet CLI: deploy to Rivet Cloud and run local dev for serverless platforms."
+seoTitle: "CLI Deployment and Local Development"
+description: "Use the optional Rivet CLI to deploy Rivet Actors to Rivet Cloud and run local development for supported serverless platforms."
 skill: true
 ---
 

--- a/docs/content/docs/clients/index.mdx
+++ b/docs/content/docs/clients/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Clients"
-description: "SDKs and integrations for connecting to Rivet actors."
+description: "Choose a Rivet Actors client for JavaScript, React, Rust, Swift, or SwiftUI and connect applications to your actor backend."
 skill: false
 ---
 

--- a/docs/content/docs/clients/javascript.mdx
+++ b/docs/content/docs/clients/javascript.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Node.js & Bun"
-description: "Connect JavaScript apps to Rivet Actors."
+description: "Connect Node.js and Bun applications to Rivet Actors with typed handles, actions, events, and connection management."
 skill: true
 ---
 

--- a/docs/content/docs/clients/react.mdx
+++ b/docs/content/docs/clients/react.mdx
@@ -1,6 +1,7 @@
 ---
 title: "React"
-description: "Connect React apps to Rivet Actors."
+seoTitle: "React SDK Client for Rivet Actors"
+description: "Connect React applications to Rivet Actors with typed hooks for actor handles, actions, state, and realtime events."
 skill: true
 ---
 

--- a/docs/content/docs/clients/rust.mdx
+++ b/docs/content/docs/clients/rust.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Rust (Beta)"
-description: "Connect Rust apps to Rivet Actors."
+description: "Connect Rust applications to Rivet Actors with typed actor handles, actions, realtime events, and connection lifecycle APIs."
 skill: true
 ---
 

--- a/docs/content/docs/clients/swift.mdx
+++ b/docs/content/docs/clients/swift.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Swift"
-description: "Connect Swift apps to Rivet Actors."
+seoTitle: "Swift SDK Client for Rivet Actors"
+description: "Connect Swift applications to Rivet Actors with typed handles, actions, realtime events, and connection lifecycle support."
 skill: true
 ---
 

--- a/docs/content/docs/clients/swiftui.mdx
+++ b/docs/content/docs/clients/swiftui.mdx
@@ -1,6 +1,6 @@
 ---
 title: "SwiftUI"
-description: "Build SwiftUI apps with Rivet Actors."
+description: "Build SwiftUI interfaces backed by Rivet Actors, subscribe to realtime state, and invoke typed actions from Apple platforms."
 skill: true
 ---
 

--- a/docs/content/docs/communicating-between-actors.mdx
+++ b/docs/content/docs/communicating-between-actors.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Communicating Between Actors"
-description: "Learn how actors can call other actors and share data"
+description: "Call Rivet Actors from other actors with typed clients, organize actor keys, and coordinate state across isolated instances."
 skill: true
 ---
 

--- a/docs/content/docs/connections.mdx
+++ b/docs/content/docs/connections.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Connections"
-description: "Connections represent client connections to your actor. They provide a way to handle client authentication, manage connection-specific data, and control the connection lifecycle."
+description: "Manage Rivet Actor client connections, authenticate callers, store connection-specific state, and respond to connect or disconnect lifecycle events."
 skill: true
 ---
 

--- a/docs/content/docs/container-runner.mdx
+++ b/docs/content/docs/container-runner.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Container Runner"
-description: "Run any containerized server as a Rivet Actor."
+description: "Package an existing containerized backend as a Rivet Actor worker and connect it to the Rivet control plane for lifecycle management."
 skill: true
 ---
 

--- a/docs/content/docs/crash-course.mdx
+++ b/docs/content/docs/crash-course.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Crash Course"
-description: "Learn the core concepts of Rivet Actors: state, actions, realtime events, and clients."
+description: "Learn the core Rivet Actors model through durable state, typed actions, realtime events, connections, and client integration."
 skill: false
 ---
 

--- a/docs/content/docs/design-patterns.mdx
+++ b/docs/content/docs/design-patterns.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Design Patterns"
-description: "Common patterns and anti-patterns for building scalable actor systems."
+description: "Apply proven Rivet Actors patterns for per-entity state, coordinators, sharding, fan-out, external databases, and scalable systems."
 skill: true
 ---
 

--- a/docs/content/docs/destroy.mdx
+++ b/docs/content/docs/destroy.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Destroying Actors"
-description: "Actors can be permanently destroyed. Common use cases include:"
+description: "Permanently destroy Rivet Actors and their stored state, use lifecycle cleanup hooks, and choose safe deletion patterns."
 skill: true
 ---
 

--- a/docs/content/docs/errors.mdx
+++ b/docs/content/docs/errors.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Errors"
-description: "Rivet provides robust error handling with security built in by default. Errors are handled differently based on whether they should be exposed to clients or kept private."
+seoTitle: "Error Handling in Rivet Actors"
+description: "Handle expected Rivet Actor failures with safe client errors while keeping internal exceptions private, structured, and useful for debugging."
 skill: true
 ---
 

--- a/docs/content/docs/events.mdx
+++ b/docs/content/docs/events.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Realtime"
-description: "Events enable realtime communication from actors to clients. While clients use actions to send data to actors, events allow actors to push updates to connected clients instantly."
+description: "Broadcast typed realtime events from Rivet Actors and subscribe from clients to receive state changes without polling or external pub-sub."
 skill: true
 ---
 

--- a/docs/content/docs/general/cors.mdx
+++ b/docs/content/docs/general/cors.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Cross-Origin Resource Sharing"
-description: "Cross-Origin Resource Sharing (CORS) controls which origins (domains) can access your actors. When actors are exposed to the public internet, proper origin validation is critical to prevent security breaches and denial of service attacks."
+description: "Validate browser origins before Rivet Actor connections to prevent unauthorized cross-origin access while allowing approved web applications."
 skill: true
 ---
 

--- a/docs/content/docs/general/edge.mdx
+++ b/docs/content/docs/general/edge.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Regions & Multi-Region"
-description: "Actors run near your users, in a region you can choose."
+description: "Select regions for Rivet Actors, place workloads near users, and design multi-region applications around actor location and keys."
 skill: true
 ---
 

--- a/docs/content/docs/general/endpoints.mdx
+++ b/docs/content/docs/general/endpoints.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Endpoints"
-description: "Configure how your backend connects to Rivet and how clients reach your actors."
+description: "Configure private control plane and public client endpoints so backends, frontends, and Rivet Actors connect securely in production."
 skill: true
 ---
 
-export const imgEndpointEnvVars = { src: "https://assets.rivet.dev/website/actors/docs/general/endpoints/endpoint-env-vars.png", width: 1792, height: 1210, format: "png" };
+export const imgEndpointEnvVars = { src: "https://assets.rivet.dev/website/docs/general/endpoints/endpoint-env-vars.png", width: 1792, height: 1210, format: "png" };
 
 ## Local Development
 

--- a/docs/content/docs/general/environment-variables.mdx
+++ b/docs/content/docs/general/environment-variables.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Environment Variables"
-description: "This page documents all environment variables that configure RivetKit behavior."
+description: "Configure RivetKit behavior with environment variables for endpoints, authentication, runtime modes, logging, and deployment."
 skill: true
 ---
 

--- a/docs/content/docs/general/http-server.mdx
+++ b/docs/content/docs/general/http-server.mdx
@@ -1,6 +1,6 @@
 ---
 title: "HTTP Server"
-description: "Different ways to run your RivetKit HTTP server."
+description: "Expose RivetKit from Node.js, Bun, Hono, Express, or serverless handlers so the control plane can reach your backend."
 skill: true
 ---
 

--- a/docs/content/docs/general/logging.mdx
+++ b/docs/content/docs/general/logging.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Logging"
-description: "Actors provide a built-in way to log complex data to the console."
+description: "Log structured data from Rivet Actors, inspect runtime output during development, and troubleshoot deployed actor behavior."
 skill: true
 ---
 

--- a/docs/content/docs/general/production-checklist.mdx
+++ b/docs/content/docs/general/production-checklist.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Production Checklist"
-description: "Checklist for deploying Rivet Actors to production."
+description: "Prepare Rivet Actors for production by reviewing authentication, persistence, scaling, observability, deployment, and recovery."
 skill: true
 ---
 
@@ -28,7 +28,7 @@ actor, not before shipping it.
 ### State
 
 - **Verify `c.state` does not grow unbounded.** Avoid using arrays or objects that grow over time in state. Use [SQLite](/actors/docs/sqlite) for unbounded or append-heavy data instead.
-- **Verify actor data does not exceed 10 GB.** Contact [enterprise support](https://rivet.dev/sales) if you need more storage.
+- **Verify actor data does not exceed 10 GB.** Contact [enterprise support](/talk-to-an-engineer/) if you need more storage.
 - **Use input parameters and `createState` for actor initialization.** See [Input Parameters](/actors/docs/input).
 
 ### Events

--- a/docs/content/docs/general/runtime-modes.mdx
+++ b/docs/content/docs/general/runtime-modes.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Runtime Modes"
-description: "RivetKit supports two runtime modes for running your actors:"
+description: "Choose a long-running worker or serverless runtime mode for Rivet Actors based on your hosting platform and scaling model."
 skill: true
 ---
 
-export const imgServerless = { src: "https://assets.rivet.dev/website/actors/docs/general/runtime-modes/serverless.png", width: 2533, height: 744, format: "png" };
-export const imgRunners = { src: "https://assets.rivet.dev/website/actors/docs/general/runtime-modes/runners.png", width: 2568, height: 1553, format: "png" };
+export const imgServerless = { src: "https://assets.rivet.dev/website/docs/general/runtime-modes/serverless.png", width: 2533, height: 744, format: "png" };
+export const imgRunners = { src: "https://assets.rivet.dev/website/docs/general/runtime-modes/runners.png", width: 2568, height: 1553, format: "png" };
 
 - **Runner**: Default mode. Runs your actors as a long-lived process that connects out to Rivet. Used for local development and most deployments.
 - **Serverless**: Responds to HTTP requests from Rivet and scales automatically. Used for serverless platforms (Vercel, Cloudflare Workers, etc.) and set automatically by Rivet Cloud.

--- a/docs/content/docs/general/skill.mdx
+++ b/docs/content/docs/general/skill.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Skills"
-description: "Learn how to use Rivet skills with AI coding assistants for enhanced development."
+seoTitle: "Rivet Skills for Coding Assistants"
+description: "Install and use Rivet's coding-assistant skill to give supported tools current Rivet Actors guidance and implementation patterns."
 skill: false
 ---
 

--- a/docs/content/docs/general/wasm-vs-native-sdk.mdx
+++ b/docs/content/docs/general/wasm-vs-native-sdk.mdx
@@ -1,6 +1,6 @@
 ---
 title: "WASM vs Native SDK"
-description: "RivetKit runs your actors on a native or a WebAssembly runtime depending on your platform."
+description: "Compare native and WebAssembly RivetKit runtimes, including platform compatibility, performance tradeoffs, and deployment constraints."
 skill: true
 ---
 

--- a/docs/content/docs/helper-types.mdx
+++ b/docs/content/docs/helper-types.mdx
@@ -1,6 +1,0 @@
----
-title: "Helper Types"
-description: "This page has moved to [Types](/actors/docs/types)."
-skill: true
----
-

--- a/docs/content/docs/http-api.mdx
+++ b/docs/content/docs/http-api.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Vanilla HTTP API"
-description: "Use the low-level HTTP handler to send and receive requests from actors."
+description: "Use the low-level HTTP API to create, connect to, and call Rivet Actors without installing a language-specific client SDK."
 skill: true
 ---
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Introduction"
-description: "Actors for long-lived processes with durable state, realtime, and hibernate when not in use."
+description: "Build stateful backends with Rivet Actors using durable state, realtime connections, automatic sleep, and globally addressable instances."
 skill: false
 ---
 

--- a/docs/content/docs/input.mdx
+++ b/docs/content/docs/input.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Input Parameters"
-description: "Pass initialization data to actors when creating instances"
+description: "Pass typed initialization input when creating Rivet Actors and use createState to derive each instance's persistent starting state."
 skill: true
 ---
 

--- a/docs/content/docs/inspector-tabs.mdx
+++ b/docs/content/docs/inspector-tabs.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Custom Inspector Tabs"
-description: "Ship your own UI tabs alongside a Rivet Actor — embedded directly in the dashboard inspector."
+description: "Build custom dashboard inspector tabs for Rivet Actors to visualize state, expose controls, and support application-specific debugging."
 skill: true
 ---
 

--- a/docs/content/docs/keys.mdx
+++ b/docs/content/docs/keys.mdx
@@ -28,7 +28,7 @@ You can create actors without specifying a key in situations where there is a si
 
 <CodeSnippet file="examples/docs/actors-keys/omitting-keys.ts" />
 
-This pattern should be avoided, since a singleton actor usually means you have a single actor serving all traffic & your application will not scale. See [scaling documentation](/actors/docs/scaling) for more information.
+This pattern should be avoided, since a singleton actor usually means you have a single actor serving all traffic & your application will not scale. See [design patterns](/actors/docs/design-patterns) for more information.
 
 ### Key Uniqueness
 

--- a/docs/content/docs/lifecycle.mdx
+++ b/docs/content/docs/lifecycle.mdx
@@ -1,10 +1,8 @@
 ---
 title: Lifecycle
-description: Learn about actor lifecycle hooks for initialization, state management, and cleanup.
+description: "Understand Rivet Actor creation, wake, sleep, connection, state-change, migration, and destruction hooks across an instance's lifecycle."
 skill: true
 ---
-
-# Lifecycle
 
 Actors follow a well-defined lifecycle with hooks at each stage. Understanding these hooks is essential for proper initialization, state management, and cleanup.
 

--- a/docs/content/docs/limits.mdx
+++ b/docs/content/docs/limits.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Limits"
-description: "Limits and constraints for Rivet Actors."
+seoTitle: "Rivet Actors Limits and Constraints"
+description: "Review Rivet Actors limits for state, messages, connections, execution, and storage so applications stay within supported bounds."
 skill: true
 ---
 
@@ -169,4 +170,4 @@ These timeouts control how actors are shut down when a serverless request reache
 
 ## Increasing Limits
 
-These limits are sane defaults designed to protect your application from exploits and accidental runaway bugs. If you have a use case that requires different limits, [contact us](https://rivet.dev/sales) to discuss your requirements.
+These limits are sane defaults designed to protect your application from exploits and accidental runaway bugs. If you have a use case that requires different limits, [contact us](/talk-to-an-engineer/) to discuss your requirements.

--- a/docs/content/docs/metadata.mdx
+++ b/docs/content/docs/metadata.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Metadata"
-description: "Metadata provides information about the currently running actor."
+description: "Use metadata to identify a running Rivet Actor and access instance details needed by actions, hooks, logging, and diagnostics."
 skill: true
 ---
 

--- a/docs/content/docs/queues.mdx
+++ b/docs/content/docs/queues.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Queues & Run Loops"
-description: "Use actor-local durable queues for serial run loops and request/response workflows."
+description: "Process durable messages in order with Rivet Actor queues and run loops, including typed payloads, replies, and workflow integration."
 skill: true
 ---
 

--- a/docs/content/docs/quickstart/backend.mdx
+++ b/docs/content/docs/quickstart/backend.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Node.js & Bun Quickstart"
-description: "Get started with Rivet Actors in Node.js and Bun"
+description: "Create and run your first Rivet Actor with Node.js or Bun, define typed actions, and connect through the JavaScript client."
 skill: true
 ---
 

--- a/docs/content/docs/quickstart/cloudflare.mdx
+++ b/docs/content/docs/quickstart/cloudflare.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Cloudflare Workers Quickstart"
-description: "Set up a Rivet project locally targeting Cloudflare Workers."
+description: "Deploy Rivet Actors on Cloudflare Workers, configure a serverless handler, and connect your application to the control plane."
 skill: true
 ---
 

--- a/docs/content/docs/quickstart/effect.mdx
+++ b/docs/content/docs/quickstart/effect.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Effect.ts Quickstart (Beta)"
-description: "Build a Rivet Actor with the Effect SDK"
+description: "Build a Rivet Actor with Effect, define typed services and actions, and connect an Effect application to durable actor state."
 skill: true
 ---
 

--- a/docs/content/docs/quickstart/next-js.mdx
+++ b/docs/content/docs/quickstart/next-js.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Next.js Quickstart"
-description: "Get started with Rivet Actors in Next.js"
+description: "Add Rivet Actors to a Next.js application, expose the serverless handler, and call typed actions from client components."
 skill: true
 ---
 

--- a/docs/content/docs/quickstart/react.mdx
+++ b/docs/content/docs/quickstart/react.mdx
@@ -1,6 +1,6 @@
 ---
 title: "React Quickstart"
-description: "Build realtime React applications with Rivet Actors"
+description: "Build a realtime React application with Rivet Actors, subscribe to events, and invoke typed actions through the React client."
 skill: true
 ---
 

--- a/docs/content/docs/quickstart/rust.mdx
+++ b/docs/content/docs/quickstart/rust.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Rust Quickstart (Beta)"
-description: "Build a Rivet Actor in Rust"
+description: "Build and run a Rivet Actor in Rust, define state and actions, then connect a client to the actor during local development."
 skill: true
 ---
 

--- a/docs/content/docs/quickstart/supabase.mdx
+++ b/docs/content/docs/quickstart/supabase.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Supabase Functions Quickstart"
-description: "Set up a Rivet project locally targeting Supabase Edge Functions."
+description: "Deploy Rivet Actors with Supabase Edge Functions, configure a serverless handler, and connect clients to the published backend."
 skill: true
 ---
 

--- a/docs/content/docs/request-handler.mdx
+++ b/docs/content/docs/request-handler.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Low-Level HTTP Request Handler"
-description: "Actors can handle HTTP requests through the `onRequest` handler."
+seoTitle: "Low-Level HTTP Request Handlers"
+description: "Handle raw HTTP requests inside a Rivet Actor with onRequest for custom routes, protocols, and framework integrations."
 skill: true
 ---
 

--- a/docs/content/docs/scaling.mdx
+++ b/docs/content/docs/scaling.mdx
@@ -1,6 +1,0 @@
----
-title: "Scaling & Concurrency"
-description: "This page has moved to [design patterns](/actors/docs/design-patterns)."
-skill: true
----
-

--- a/docs/content/docs/schedule.mdx
+++ b/docs/content/docs/schedule.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Schedule & Cron"
-description: "Run durable one-shot and recurring actor actions on a schedule."
+description: "Schedule durable Rivet Actor actions to run once or on recurring cron expressions, with timing that survives restarts and sleep."
 skill: true
 ---
 

--- a/docs/content/docs/sharing-and-joining-state.mdx
+++ b/docs/content/docs/sharing-and-joining-state.mdx
@@ -1,6 +1,0 @@
----
-title: "Sharing and Joining State"
-description: "This page has moved to [design patterns](/actors/docs/design-patterns)."
-skill: true
----
-

--- a/docs/content/docs/sqlite-drizzle.mdx
+++ b/docs/content/docs/sqlite-drizzle.mdx
@@ -1,6 +1,6 @@
 ---
 title: "SQLite + Drizzle"
-description: "Use Drizzle ORM with embedded SQLite in Rivet Actors."
+description: "Use Drizzle ORM with a Rivet Actor's embedded SQLite database for typed schemas, queries, migrations, and durable relational data."
 skill: true
 ---
 

--- a/docs/content/docs/sqlite.mdx
+++ b/docs/content/docs/sqlite.mdx
@@ -1,6 +1,7 @@
 ---
 title: "SQLite"
-description: "Use embedded SQLite in Rivet Actors with raw SQL queries."
+seoTitle: "SQLite Storage for Rivet Actors"
+description: "Store relational data inside each Rivet Actor with embedded SQLite, raw SQL queries, transactions, and durable local persistence."
 skill: true
 ---
 

--- a/docs/content/docs/state.mdx
+++ b/docs/content/docs/state.mdx
@@ -136,7 +136,7 @@ const counter = actor({
 
 ## State Isolation
 
-Each actor's state is fully isolated. Other actors and clients can't touch it directly; all reads and writes go through the actor's own [Actions](/actors/docs/actions). To share state across actors, see [sharing and joining state](/actors/docs/sharing-and-joining-state).
+Each actor's state is fully isolated. Other actors and clients can't touch it directly; all reads and writes go through the actor's own [Actions](/actors/docs/actions). To coordinate state across actors, see [design patterns](/actors/docs/design-patterns).
 
 ## Durable State
 

--- a/docs/content/docs/testing.mdx
+++ b/docs/content/docs/testing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Testing"
-description: "Rivet provides a straightforward testing framework to build reliable and maintainable applications. This guide covers how to write effective tests for your actor-based services."
+description: "Test Rivet Actors with the built-in framework, create isolated actor instances, invoke actions, and verify state, events, and lifecycle behavior."
 skill: true
 ---
 

--- a/docs/content/docs/troubleshooting.mdx
+++ b/docs/content/docs/troubleshooting.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Troubleshooting"
-description: "Common issues with Rivet Actors and how to resolve them."
+description: "Diagnose common Rivet Actors setup, connection, deployment, and runtime problems with targeted checks and corrective steps."
 skill: true
 ---
 

--- a/docs/content/docs/types.mdx
+++ b/docs/content/docs/types.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Types"
-description: "TypeScript types for working with Rivet Actors. This page covers context types used in lifecycle hooks and actions, as well as helper types for extracting types from actor definitions."
+seoTitle: "TypeScript Types for Rivet Actors"
+description: "Use Rivet Actors TypeScript context and helper types to derive actor state, actions, events, connections, queues, and registry interfaces."
 skill: true
 ---
 

--- a/docs/content/docs/versions.mdx
+++ b/docs/content/docs/versions.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Versions & Upgrades"
-description: "When you deploy new code, Rivet ensures actors are upgraded seamlessly without downtime."
+description: "Version Rivet Actor deployments, route new instances to current code, and drain or upgrade older workers without application downtime."
 skill: true
 ---
 

--- a/docs/content/docs/websocket-handler.mdx
+++ b/docs/content/docs/websocket-handler.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Low-Level WebSocket Handler"
-description: "Actors can handle WebSocket connections through the `onWebSocket` handler."
+description: "Handle raw WebSocket connections inside a Rivet Actor with onWebSocket for custom protocols and direct bidirectional messaging."
 skill: true
 ---
 


### PR DESCRIPTION
## Summary\n\n- improve current Actors documentation SEO titles and descriptions\n- restore three valid documentation image URLs and remove duplicate body H1s\n- retire three empty moved-page stubs so the website can serve one-hop redirects\n- update current documentation links to canonical destinations\n\n## Validation\n\n- consumed these sources through the website docs assembler\n- production website build, sitemap validation, and built SEO crawl pass\n- git diff --check passes