### PR TITLE
fix(rivetkit): omit native engine path for wasm runtime

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/registry/native.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/native.ts
@@ -5066,6 +5066,7 @@ export function buildNativeFactory(
 
 export async function buildServeConfig(
 	config: RegistryConfig,
+	runtimeKind: CoreRuntime["kind"],
 ): Promise<RuntimeServeConfig> {
 	if (!config.endpoint) {
 		throw nativeEndpointNotConfiguredError();
@@ -5087,26 +5088,19 @@ export async function buildServeConfig(
 		serverlessMaxStartPayloadBytes: config.serverless.maxStartPayloadBytes,
 	};
 
-	// Always best-effort resolve the npm-installed engine binary and hand its
-	// path to the core. The core alone decides whether to actually spawn a local
-	// engine (its `should_manage_engine`, based on the endpoint + spawn mode), so
-	// JS must not duplicate that decision here. Only JS knows the npm
-	// `node_modules` layout, so it resolves the path; if no binary is available
-	// (remote-only install, unsupported platform, optional deps skipped), leave
-	// it unset and let the core report `engine.binary_unavailable` if it actually
-	// needs one.
-	try {
-		const { getEnginePath } = await loadEngineCli();
-		serveConfig.engineBinaryPath = getEnginePath();
-	} catch (error) {
-		// The npm-installed engine binary could not be resolved. The core still
-		// decides whether it needs to spawn a local engine; if it does, it will
-		// fail with engine.binary_unavailable (auto-download is off in the napi
-		// runtime). Warn so the cause is actionable.
-		logger().warn({
-			msg: "could not resolve a local engine binary; if a local engine must be spawned it will fail with engine.binary_unavailable — set RIVET_ENGINE_BINARY_PATH or install the @rivetkit/engine-cli platform package",
-			error: stringifyError(error),
-		});
+	if (runtimeKind === "napi") {
+		// Best-effort resolve the npm-installed engine binary for the native core.
+		// Only JS knows the npm node_modules layout, while the native core decides
+		// whether it actually needs to spawn a local engine.
+		try {
+			const { getEnginePath } = await loadEngineCli();
+			serveConfig.engineBinaryPath = getEnginePath();
+		} catch (error) {
+			logger().warn({
+				msg: "could not resolve a local engine binary; if a local engine must be spawned it will fail with engine.binary_unavailable — set RIVET_ENGINE_BINARY_PATH or install the @rivetkit/engine-cli platform package",
+				error: stringifyError(error),
+			});
+		}
 	}
 	serveConfig.engineHost = config.engineHost;
 	serveConfig.enginePort = config.enginePort;
@@ -5153,7 +5147,7 @@ export async function buildRegistryWithRuntime(
 	return {
 		runtime,
 		registry,
-		serveConfig: await buildServeConfig(config),
+		serveConfig: await buildServeConfig(config, runtime.kind),
 	};
 }
 

--- a/rivetkit-typescript/packages/rivetkit/tests/registry-constructor.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/registry-constructor.test.ts
@@ -87,11 +87,26 @@ describe("Registry constructor", () => {
 		expect(config.endpoint).toBe("http://127.0.0.1:7654");
 		expect(config.publicEndpoint).toBe("http://127.0.0.1:7654");
 
-		const serveConfig = await buildServeConfig(config);
+		const serveConfig = await buildServeConfig(config, "napi");
 
 		expect(serveConfig.endpoint).toBe("http://127.0.0.1:7654");
 		expect(serveConfig.engineHost).toBe("127.0.0.1");
 		expect(serveConfig.enginePort).toBe(7654);
+		expect(serveConfig.engineBinaryPath).toBe("/tmp/rivet-engine");
+	});
+
+	test("does not pass the native engine binary path to the wasm runtime", async () => {
+		const config = RegistryConfigSchema.parse({
+			use: {
+				test: testActor,
+			},
+			startEngine: false,
+			endpoint: "http://127.0.0.1:7654",
+		});
+
+		const serveConfig = await buildServeConfig(config, "wasm");
+
+		expect(serveConfig.engineBinaryPath).toBeUndefined();
 	});
 
 	test("uses the configured local engine port without an explicit spawn flag", () => {


### PR DESCRIPTION
- Pass the npm Engine binary path only to the native runtime.
- Preserve native local-Engine startup while allowing configured WASM registries to initialize.