### PR TITLE
fix(frontend): always send drain grace period in runner config upserts

### DIFF
--- a/frontend/src/app/dialogs/connect-manual-serverless-frame.tsx
+++ b/frontend/src/app/dialogs/connect-manual-serverless-frame.tsx
@@ -29,7 +29,7 @@ const stepper = defineStepper(
 		id: "step-1",
 		title: "Configure",
 		assist: false,
-		schema: ConnectServerlessForm.configurationSchema,
+		schema: ConnectServerlessForm.configurationStepSchema,
 	},
 	{
 		id: "step-2",
@@ -178,12 +178,13 @@ export const buildServerlessConfig = async (
 							headers,
 							maxRunners: 0,
 							slotsPerRunner: 1,
-							drainGracePeriod: values.drainGracePeriod,
+							drainGracePeriod: values.drainGracePeriod ?? 0,
 						}
 					: {
 							url: endpoint,
 							requestLifespan: values.requestLifespan,
 							headers,
+							drainGracePeriod: values.drainGracePeriod ?? 0,
 							maxRunners: values.maxRunners ?? 100_000,
 							slotsPerRunner: values.slotsPerRunner ?? 1,
 							runnersMargin: values.runnerMargin ?? 0,

--- a/frontend/src/app/dialogs/edit-runner-config.tsx
+++ b/frontend/src/app/dialogs/edit-runner-config.tsx
@@ -273,12 +273,13 @@ function SharedSettingsForm({
 						(existing as { metadata?: unknown }).metadata ??
 						sharedFallback;
 					if (mode === "serverless") {
+						const requestLifespan = values.requestLifespan ?? 300;
+						const drainGracePeriod = values.drainGracePeriod ?? 0;
 						const serverless: Rivet.RunnerConfigServerless =
 							isNewConfig
 								? {
 										url: values.url ?? "",
-										requestLifespan:
-											values.requestLifespan ?? 300,
+										requestLifespan,
 										headers: Object.fromEntries(
 											values.headers || [],
 										),
@@ -286,16 +287,15 @@ function SharedSettingsForm({
 										slotsPerRunner: 1,
 										maxConcurrentActors:
 											values.maxConcurrentActors,
-										drainGracePeriod:
-											values.drainGracePeriod,
+										drainGracePeriod,
 									}
 								: {
 										url: values.url ?? "",
-										requestLifespan:
-											values.requestLifespan ?? 300,
+										requestLifespan,
 										headers: Object.fromEntries(
 											values.headers || [],
 										),
+										drainGracePeriod,
 										maxRunners:
 											values.maxRunners ?? 100_000,
 										minRunners: values.minRunners ?? 0,
@@ -346,6 +346,7 @@ function SharedSettingsForm({
 				mode: detectedMode,
 				url: currentServerless.url,
 				requestLifespan: currentServerless.requestLifespan,
+				drainGracePeriod: currentServerless.drainGracePeriod,
 				headers: Object.entries(currentServerless.headers || {}).map(
 					([key, value]) => [key, value],
 				),
@@ -357,12 +358,8 @@ function SharedSettingsForm({
 				),
 				...(isNewConfig
 					? {
-							// eslint-disable-next-line @typescript-eslint/no-explicit-any
-							maxConcurrentActors: (currentServerless as any)
-								.maxConcurrentActors,
-							// eslint-disable-next-line @typescript-eslint/no-explicit-any
-							drainGracePeriod: (currentServerless as any)
-								.drainGracePeriod,
+							maxConcurrentActors:
+								currentServerless.maxConcurrentActors,
 							autoUpgrade:
 								currentDcConfig?.drainOnVersionUpgrade ?? false,
 						}
@@ -490,23 +487,24 @@ function DatacenterSettingsForm({
 						dcConfig;
 					if (mode === "serverless" || !mode) {
 						const isNew = dcHasProtocolVersion(existing);
+						const requestLifespan = rest.requestLifespan ?? 300;
+						const drainGracePeriod = rest.drainGracePeriod ?? 0;
 						const serverless: Rivet.RunnerConfigServerless = isNew
 							? {
 									url: rest.url ?? "",
-									requestLifespan:
-										rest.requestLifespan ?? 300,
+									requestLifespan,
 									headers: Object.fromEntries(headers || []),
 									maxRunners: 0,
 									slotsPerRunner: 1,
 									maxConcurrentActors:
 										rest.maxConcurrentActors,
-									drainGracePeriod: rest.drainGracePeriod,
+									drainGracePeriod,
 								}
 							: {
 									url: rest.url ?? "",
-									requestLifespan:
-										rest.requestLifespan ?? 300,
+									requestLifespan,
 									headers: Object.fromEntries(headers || []),
+									drainGracePeriod,
 									maxRunners: rest.maxRunners ?? 100_000,
 									minRunners: rest.minRunners ?? 0,
 									runnersMargin: rest.runnersMargin ?? 0,

--- a/frontend/src/app/forms/connect-manual-serverless-form.tsx
+++ b/frontend/src/app/forms/connect-manual-serverless-form.tsx
@@ -46,6 +46,34 @@ export const configurationSchema = z.object({
 	runnerMargin: z.coerce.number().min(0).optional(),
 });
 
+export function validateDrainGracePeriod(
+	data: { requestLifespan?: number; drainGracePeriod?: number },
+	ctx: z.RefinementCtx,
+) {
+	if (
+		data.drainGracePeriod !== undefined &&
+		data.requestLifespan !== undefined &&
+		data.drainGracePeriod >= data.requestLifespan
+	) {
+		const message =
+			"Drain grace period must be less than the request lifespan.";
+		ctx.addIssue({
+			path: ["drainGracePeriod"],
+			code: z.ZodIssueCode.custom,
+			message,
+		});
+		ctx.addIssue({
+			path: ["requestLifespan"],
+			code: z.ZodIssueCode.custom,
+			message,
+		});
+	}
+}
+
+export const configurationStepSchema = configurationSchema.superRefine(
+	validateDrainGracePeriod,
+);
+
 export const deploymentSchema = z.object({
 	success: z.boolean().refine((val) => val, "Connection failed"),
 	endpoint: endpointSchema,
@@ -57,7 +85,7 @@ export const stepper = defineStepper(
 		title: "Configure",
 		assist: false,
 		next: "Next",
-		schema: configurationSchema,
+		schema: configurationStepSchema,
 	},
 	{
 		id: "step-2",

--- a/frontend/src/app/forms/edit-shared-runner-config-form.tsx
+++ b/frontend/src/app/forms/edit-shared-runner-config-form.tsx
@@ -84,7 +84,12 @@ export const baseFormSchema = z.object({
 });
 
 export function validateRuntimeModeFields(
-	data: { mode?: RuntimeMode; url?: string },
+	data: {
+		mode?: RuntimeMode;
+		url?: string;
+		requestLifespan?: number;
+		drainGracePeriod?: number;
+	},
 	ctx: z.RefinementCtx,
 	pathPrefix: (string | number)[] = [],
 ) {
@@ -94,6 +99,24 @@ export function validateRuntimeModeFields(
 				path: [...pathPrefix, "url"],
 				code: z.ZodIssueCode.custom,
 				message: "Please enter a valid URL.",
+			});
+		}
+		if (
+			data.drainGracePeriod !== undefined &&
+			data.requestLifespan !== undefined &&
+			data.drainGracePeriod >= data.requestLifespan
+		) {
+			const message =
+				"Drain grace period must be less than the request lifespan.";
+			ctx.addIssue({
+				path: [...pathPrefix, "drainGracePeriod"],
+				code: z.ZodIssueCode.custom,
+				message,
+			});
+			ctx.addIssue({
+				path: [...pathPrefix, "requestLifespan"],
+				code: z.ZodIssueCode.custom,
+				message,
 			});
 		}
 	}


### PR DESCRIPTION
Fixes CLOUD-6P.

- Always send `drainGracePeriod` when upserting a serverless runner config. Omitting it made the engine apply its 1800s default, which is rejected whenever the request lifespan is lower (the dashboard sends 300s/900s), so onboarding a serverless runner in a fresh namespace failed with a 400.
- Preserve the stored drain grace period when editing an existing runner config, regardless of protocol version.
- Reject a drain grace period that is not below the request lifespan in the connect and edit forms instead of failing on submit.