### PR TITLE
test(rivetkit): remove stale http stream coverage

### DIFF
--- a/rivetkit-typescript/packages/rivetkit-napi/tests/actor_factory.rs
+++ b/rivetkit-typescript/packages/rivetkit-napi/tests/actor_factory.rs
@@ -7,12 +7,10 @@ mod moved_tests {
 
 	use parking_lot::Mutex;
 	use rivet_error::{MacroMarker, RivetError, RivetErrorSchema};
-	use rivetkit_core::HttpRequestBodyStream as CoreHttpRequestBodyStream;
-	use tokio::sync::{mpsc, watch};
 	use tracing::Level;
 	use tracing_subscriber::fmt::MakeWriter;
 
-	use super::{BRIDGE_RIVET_ERROR_PREFIX, HttpRequestBodyStream, parse_bridge_rivet_error};
+	use super::{BRIDGE_RIVET_ERROR_PREFIX, parse_bridge_rivet_error};
 
 	static AUTH_FORBIDDEN_SCHEMA: RivetErrorSchema = RivetErrorSchema {
 		group: "auth",
@@ -132,26 +130,5 @@ mod moved_tests {
 		let logs = capture.output();
 		assert!(logs.contains("malformed BridgeRivetErrorPayload"));
 		assert!(logs.contains("parse_err"));
-	}
-
-	#[tokio::test]
-	async fn cancelling_http_request_body_drops_core_receiver() {
-		let (body_tx, body_rx) = mpsc::channel(1);
-		let (_abort_tx, abort_rx) = watch::channel(None);
-		let stream = HttpRequestBodyStream::new(
-			Vec::new(),
-			CoreHttpRequestBodyStream::new(body_rx, abort_rx),
-		);
-
-		stream.cancel().await.expect("cancel request body stream");
-
-		assert!(body_tx.is_closed());
-		assert!(
-			stream
-				.read()
-				.await
-				.expect("read cancelled request body")
-				.is_none()
-		);
 	}
 }


### PR DESCRIPTION
# Description

 - `cargo test -p rivetkit-napi` does not compile on main. The crate's test module still has `cancelling_http_request_body_drops_core_receiver`, which imports `HttpRequestBodyStream` from `rivetkit_core` and from the NAPI wrapper. 
 - Both types were removed when SSE streaming was cleaned up (e534b6e4a) and the dangling core re-export was dropped (d44805dae). The test outlived what it tested.
 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

```sh
# Before, on main:

$ cargo test -p rivetkit-napi --no-run
error[E0432]: unresolved import `rivetkit_core::HttpRequestBodyStream`
error[E0432]: unresolved import `super::HttpRequestBodyStream`
error: could not compile `rivetkit-napi` (lib test) due to 2 previous errors

# After:

$ cargo test -p rivetkit-napi --no-run
    Finished `test` profile [unoptimized + debuginfo] target(s) in 3.73s
```
       
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes