### PR TITLE
fix(rivetkit): spawn the local Engine on the endpoint's port

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/registry/config/index.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/config/index.ts
@@ -225,7 +225,7 @@ export const RegistryConfigSchema = z
 		engineHost: z
 			.string()
 			.optional()
-			.default(() => getRivetRunEngineHost() ?? ENGINE_HOST),
+			.transform((value) => value ?? getRivetRunEngineHost()),
 		/**
 		 * @experimental
 		 *
@@ -237,7 +237,7 @@ export const RegistryConfigSchema = z
 			.min(1)
 			.max(65_535)
 			.optional()
-			.default(() => getRivetRunEnginePort() ?? ENGINE_PORT),
+			.transform((value) => value ?? getRivetRunEnginePort()),
 		/** @experimental */
 		engineVersion: z
 			.string()
@@ -347,8 +347,8 @@ export const RegistryConfigSchema = z
 
 		// Flatten the endpoint and apply defaults for namespace/token.
 		const localEngineEndpoint = buildEngineEndpoint(
-			config.engineHost,
-			config.enginePort,
+			config.engineHost ?? ENGINE_HOST,
+			config.enginePort ?? ENGINE_PORT,
 		);
 		const endpoint = config.startEngine
 			? localEngineEndpoint

--- a/rivetkit-typescript/packages/rivetkit/tests/registry-constructor.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/registry-constructor.test.ts
@@ -108,6 +108,24 @@ describe("Registry constructor", () => {
 		expect(config.publicEndpoint).toBe("http://127.0.0.1:7655");
 	});
 
+	test("does not override the bind address for an explicit engine endpoint", async () => {
+		const config = RegistryConfigSchema.parse({
+			use: {
+				test: testActor,
+			},
+			startEngine: false,
+			endpoint: "http://127.0.0.1:7656",
+		});
+
+		const serveConfig = await buildServeConfig(config);
+
+		expect(new URL(serveConfig.endpoint).origin).toBe(
+			"http://127.0.0.1:7656",
+		);
+		expect(serveConfig.engineHost).toBeUndefined();
+		expect(serveConfig.enginePort).toBeUndefined();
+	});
+
 	test("keeps endpoint separate from spawned local engine config", () => {
 		const result = RegistryConfigSchema.safeParse({
 			use: {


### PR DESCRIPTION
# Description

If you set `endpoint` to a local URL, RivetKit still spawned the Engine on port 6420. So the client waited on the port you asked for, and the health check failed.

```
endpoint: "http://127.0.0.1:54250"
├── client waits on    :54250
└── Engine listens on  :6420   <- hard-coded default
```

The fix: `engineHost` and `enginePort` stay unset unless you set them, so the Engine falls back to the endpoint's port.

- Nothing set: still 6420. Unchanged.
- Explicit `enginePort`: used as before. Unchanged.
- Only an `endpoint`: the Engine now listens on that endpoint's port. This never worked before.

This only affects local dev and tests. Deployed apps never spawn an Engine.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

```sh
# Before, RivetKit asked for port 54250:

$ pnpm exec vitest run tests/napi-runtime-integration.test.ts
target=rivetkit_napi::registry message="serving native registry" endpoint=http://127.0.0.1:54250/
target=rivetkit_engine_process message="spawned engine process (intentionally orphaned, will outlive this process)" pid=11147
[Error: {"code":"health_check_failed","group":"engine","message":"Engine health check failed after 14 attempts: error sending request for url (http://127.0.0.1:54250/health)"}]
 × native NAPI runtime integration > runs a TS actor through registry, NAPI, core, envoy, and engine

# The Engine's own log from that run shows where it bound:

 message="loaded config" config="Root { ... guard: Some(Guard { host: Some(127.0.0.1), port: Some(6420), ...
 message="HTTP server listening on 127.0.0.1:6420"

# After:

$ pnpm exec vitest run tests/napi-runtime-integration.test.ts
 ✓ native NAPI runtime integration > runs a TS actor through registry, NAPI, core, envoy, and engine  6825ms
 Test Files  1 passed (1)

message="loaded config" config="Root { ... guard: Some(Guard { host: Some(127.0.0.1), port: Some(54308), ...
message="HTTP server listening on 127.0.0.1:54308"

# Also:

$ pnpm exec vitest run tests/registry-constructor.test.ts
 Tests  6 passed (6)
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes