### PR TITLE
chore(release): update version to 2.3.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,7 +1309,7 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "datacenter"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "depot"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "depot-client-embedded"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1684,7 +1684,7 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "epoxy"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "epoxy-protocol"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "rivet-vbare-compiler",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "gasoline"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "gasoline-macros"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "gasoline-runtime"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "epoxy",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "namespace"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "epoxy",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "pegboard"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "pegboard-envoy"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "pegboard-gateway"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "pegboard-gateway2"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4099,7 +4099,7 @@ dependencies = [
 
 [[package]]
 name = "pegboard-gateway3"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "pegboard-outbound"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "epoxy",
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "pegboard-runner"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-actor-runtime-socket-protocol"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "rivet-vbare-compiler",
@@ -5027,7 +5027,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-api-builder"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -5070,7 +5070,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-api-peer"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -5107,7 +5107,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-api-public"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -5145,7 +5145,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-api-public-openapi-gen"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "rivet-api-public",
  "serde_json",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-api-types"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "gasoline",
@@ -5169,7 +5169,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-api-util"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -5227,7 +5227,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-bootstrap"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "datacenter",
  "epoxy",
@@ -5248,7 +5248,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-cache"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -5291,14 +5291,14 @@ dependencies = [
 
 [[package]]
 name = "rivet-cache-result"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "rivet-util",
 ]
 
 [[package]]
 name = "rivet-cli"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-config"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-config-schema-gen"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "rivet-config",
  "schemars 0.8.22",
@@ -5348,7 +5348,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-container-runner"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-data"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "gasoline",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-depot-client"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5412,11 +5412,11 @@ dependencies = [
 
 [[package]]
 name = "rivet-depot-client-types"
-version = "2.3.11"
+version = "2.3.13"
 
 [[package]]
 name = "rivet-depot-protocol"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "rivet-vbare-compiler",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-engine"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5508,7 +5508,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-env"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "lazy_static",
  "uuid",
@@ -5516,7 +5516,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-envoy-client"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -5548,7 +5548,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-envoy-protocol"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "hex",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-error"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "indoc",
@@ -5575,7 +5575,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-error-macros"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "indoc",
  "proc-macro2",
@@ -5586,7 +5586,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-guard"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5648,7 +5648,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-guard-core"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5696,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-logs"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5710,7 +5710,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-metrics"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "lazy_static",
  "prometheus",
@@ -5718,7 +5718,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-metrics-server"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-perf"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "prometheus",
  "tokio",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-pools"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "clickhouse",
@@ -5778,7 +5778,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-postgres-util"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "rustls",
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-runner-protocol"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "gasoline",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-runtime"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "console-subscriber",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-service-manager"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-telemetry"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "rivet-config",
@@ -5878,7 +5878,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-term"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "console",
  "derive_builder 0.12.0",
@@ -5890,7 +5890,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-test-deps"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-test-deps-docker"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "portpicker",
@@ -5925,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-test-envoy"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5959,7 +5959,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-tracing-utils"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5969,7 +5969,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-types"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "gasoline",
@@ -5986,7 +5986,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-universaldb-commit"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "rivet-vbare-compiler",
@@ -6016,7 +6016,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-ups-protocol"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6028,7 +6028,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-util"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6058,7 +6058,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-util-id"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-util-serde"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "indexmap 2.14.0",
  "serde",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "rivet-workflow-worker"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "datacenter",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "rivetkit"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "rivetkit-actor-persist"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "rivet-vbare-compiler",
@@ -6160,7 +6160,7 @@ dependencies = [
 
 [[package]]
 name = "rivetkit-client"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
@@ -6190,7 +6190,7 @@ dependencies = [
 
 [[package]]
 name = "rivetkit-client-protocol"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "rivet-vbare-compiler",
@@ -6201,7 +6201,7 @@ dependencies = [
 
 [[package]]
 name = "rivetkit-core"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6260,7 +6260,7 @@ dependencies = [
 
 [[package]]
 name = "rivetkit-engine-process"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "libc",
@@ -6277,7 +6277,7 @@ dependencies = [
 
 [[package]]
 name = "rivetkit-inspector-protocol"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "rivet-vbare-compiler",
@@ -6288,7 +6288,7 @@ dependencies = [
 
 [[package]]
 name = "rivetkit-napi"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6314,7 +6314,7 @@ dependencies = [
 
 [[package]]
 name = "rivetkit-shared-types"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -6322,7 +6322,7 @@ dependencies = [
 
 [[package]]
 name = "rivetkit-wasm"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -7515,7 +7515,7 @@ dependencies = [
 
 [[package]]
 name = "test-snapshot-gen"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8298,7 +8298,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universaldb"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8336,7 +8336,7 @@ dependencies = [
 
 [[package]]
 name = "universalpubsub"
-version = "2.3.11"
+version = "2.3.13"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ members = [
 ]
 
   [workspace.package]
-  version = "2.3.11"
+  version = "2.3.13"
   edition = "2024"
   authors = [ "Rivet Gaming, LLC <developer@rivet.dev>" ]
   license = "Apache-2.0"
@@ -463,11 +463,11 @@ members = [
 
     [workspace.dependencies.rivet-error]
     path = "engine/packages/error"
-    version = "=2.3.11"
+    version = "=2.3.13"
 
     [workspace.dependencies.rivet-error-macros]
     path = "engine/packages/error-macros"
-    version = "=2.3.11"
+    version = "=2.3.13"
 
     [workspace.dependencies.gasoline]
     path = "engine/packages/gasoline"
@@ -493,7 +493,7 @@ members = [
 
     [workspace.dependencies.rivet-metrics]
     path = "engine/packages/metrics"
-    version = "=2.3.11"
+    version = "=2.3.13"
 
     [workspace.dependencies.rivet-metrics-server]
     path = "engine/packages/metrics-server"
@@ -579,7 +579,7 @@ members = [
 
     [workspace.dependencies.rivet-util-serde]
     path = "engine/packages/util-serde"
-    version = "=2.3.11"
+    version = "=2.3.13"
 
     [workspace.dependencies.rivet-workflow-worker]
     path = "engine/packages/workflow-worker"
@@ -592,40 +592,40 @@ members = [
 
     [workspace.dependencies.rivet-envoy-client]
     path = "engine/sdks/rust/envoy-client"
-    version = "=2.3.11"
+    version = "=2.3.13"
     default-features = false
 
     [workspace.dependencies.rivet-envoy-protocol]
     path = "engine/sdks/rust/envoy-protocol"
-    version = "=2.3.11"
+    version = "=2.3.13"
 
     [workspace.dependencies.rivet-actor-runtime-socket-protocol]
     path = "engine/sdks/rust/actor-runtime-socket-protocol"
-    version = "=2.3.11"
+    version = "=2.3.13"
 
     [workspace.dependencies.rivet-depot-protocol]
     path = "engine/sdks/rust/depot-protocol"
 
     [workspace.dependencies.rivetkit-client-protocol]
     path = "rivetkit-rust/packages/client-protocol"
-    version = "=2.3.11"
+    version = "=2.3.13"
 
     [workspace.dependencies.rivetkit-client]
     path = "rivetkit-rust/packages/client"
-    version = "=2.3.11"
+    version = "=2.3.13"
 
     [workspace.dependencies.rivetkit-actor-persist]
     path = "rivetkit-rust/packages/actor-persist"
-    version = "=2.3.11"
+    version = "=2.3.13"
 
     [workspace.dependencies.rivetkit-inspector-protocol]
     path = "rivetkit-rust/packages/inspector-protocol"
-    version = "=2.3.11"
+    version = "=2.3.13"
 
     [workspace.dependencies.depot-client]
     package = "rivet-depot-client"
     path = "engine/packages/depot-client"
-    version = "=2.3.11"
+    version = "=2.3.13"
 
     [workspace.dependencies.depot-client-embedded]
     path = "engine/packages/depot-client-embedded"
@@ -633,23 +633,23 @@ members = [
     [workspace.dependencies.depot-client-types]
     package = "rivet-depot-client-types"
     path = "engine/packages/depot-client-types"
-    version = "=2.3.11"
+    version = "=2.3.13"
 
     [workspace.dependencies.rivetkit]
     path = "rivetkit-rust/packages/rivetkit"
-    version = "=2.3.11"
+    version = "=2.3.13"
 
     [workspace.dependencies.rivetkit-core]
     path = "rivetkit-rust/packages/rivetkit-core"
-    version = "=2.3.11"
+    version = "=2.3.13"
 
     [workspace.dependencies.rivetkit-engine-process]
     path = "rivetkit-rust/packages/engine-process"
-    version = "=2.3.11"
+    version = "=2.3.13"
 
     [workspace.dependencies.rivetkit-shared-types]
     path = "rivetkit-rust/packages/shared-types"
-    version = "=2.3.11"
+    version = "=2.3.13"
 
     [workspace.dependencies.epoxy-protocol]
     path = "engine/sdks/rust/epoxy-protocol"

--- a/engine/sdks/typescript/api-full/package.json
+++ b/engine/sdks/typescript/api-full/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rivetkit/engine-api-full",
-  "version": "2.3.11",
+  "version": "2.3.13",
   "repository": "https://github.com/rivet-dev/rivet/tree/main/engine/sdks/typescript",
   "files": [
     "dist",

--- a/engine/sdks/typescript/envoy-protocol/package.json
+++ b/engine/sdks/typescript/envoy-protocol/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/engine-envoy-protocol",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"license": "Apache-2.0",
 	"type": "module",
 	"exports": {

--- a/engine/sdks/typescript/test-runner/package.json
+++ b/engine/sdks/typescript/test-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/engine-test-runner",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"type": "module",
 	"scripts": {
 		"start": "tsx src/index.ts",

--- a/examples/actor-actions/package.json
+++ b/examples/actor-actions/package.json
@@ -23,10 +23,10 @@
 		"vitest": "^3.1.1"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"rivetkit": "^2.3.11"
+		"rivetkit": "^2.3.13"
 	},
 	"stableVersion": "0.8.0",
 	"license": "MIT"

--- a/examples/ai-agent/package.json
+++ b/examples/ai-agent/package.json
@@ -24,11 +24,11 @@
 	},
 	"dependencies": {
 		"@ai-sdk/openai": "^0.0.66",
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"ai": "^4.0.38",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"rivetkit": "^2.3.11"
+		"rivetkit": "^2.3.13"
 	},
 	"stableVersion": "0.8.0",
 	"license": "MIT"

--- a/examples/ai-and-user-generated-actors-freestyle/package.json
+++ b/examples/ai-and-user-generated-actors-freestyle/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@monaco-editor/react": "^4.7.0",
 		"@rivet-gg/cloud": "https://pkg.pr.new/rivet-dev/cloud/@rivet-gg/cloud@715f221",
-		"@rivetkit/engine-api-full": "^2.3.11",
+		"@rivetkit/engine-api-full": "^2.3.13",
 		"dotenv": "^17.2.2",
 		"execa": "^9.5.2",
 		"freestyle-sandboxes": "^0.0.95",

--- a/examples/ai-and-user-generated-actors-freestyle/template/package.json
+++ b/examples/ai-and-user-generated-actors-freestyle/template/package.json
@@ -10,12 +10,12 @@
 		"build:frontend": "vite build"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"hono": "4.9.8",
 		"on-change": "^5.0.1",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0",
-		"rivetkit": "^2.3.11"
+		"rivetkit": "^2.3.13"
 	},
 	"devDependencies": {
 		"@types/react": "^19.0.9",

--- a/examples/chat-room-render/package.json
+++ b/examples/chat-room-render/package.json
@@ -13,7 +13,7 @@
 		"check-types": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"@tailwindcss/postcss": "^4.2.2",
 		"@tailwindcss/typography": "^0.5.19",
 		"hono": "^4.7.7",
@@ -21,7 +21,7 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"render-dds": "github:R4ph-t/DDS#v0.8.6",
-		"rivetkit": "^2.3.11",
+		"rivetkit": "^2.3.13",
 		"tailwindcss": "^4.2.2",
 		"tsx": "^4.19.0"
 	},

--- a/examples/collaborative-document/package.json
+++ b/examples/collaborative-document/package.json
@@ -23,10 +23,10 @@
 		"vitest": "^3.1.1"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"rivetkit": "^2.3.11",
+		"rivetkit": "^2.3.13",
 		"y-protocols": "^1.0.6",
 		"yjs": "^13.6.24"
 	},

--- a/examples/cross-actor-actions/package.json
+++ b/examples/cross-actor-actions/package.json
@@ -23,10 +23,10 @@
 		"vitest": "^3.1.1"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"rivetkit": "^2.3.11"
+		"rivetkit": "^2.3.13"
 	},
 	"license": "MIT"
 }

--- a/examples/cursors-raw-websocket/package.json
+++ b/examples/cursors-raw-websocket/package.json
@@ -23,10 +23,10 @@
 		"vitest": "^3.1.1"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"rivetkit": "^2.3.11"
+		"rivetkit": "^2.3.13"
 	},
 	"stableVersion": "0.8.0",
 	"license": "MIT"

--- a/examples/cursors/package.json
+++ b/examples/cursors/package.json
@@ -23,10 +23,10 @@
 		"vitest": "^3.1.1"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"rivetkit": "^2.3.11"
+		"rivetkit": "^2.3.13"
 	},
 	"stableVersion": "0.8.0",
 	"license": "MIT"

--- a/examples/elysia/package.json
+++ b/examples/elysia/package.json
@@ -15,7 +15,7 @@
 	},
 	"dependencies": {
 		"elysia": "^1.4.0",
-		"rivetkit": "^2.3.11"
+		"rivetkit": "^2.3.13"
 	},
 	"stableVersion": "0.8.0",
 	"license": "MIT"

--- a/examples/experimental-durable-streams-ai-agent/package.json
+++ b/examples/experimental-durable-streams-ai-agent/package.json
@@ -27,11 +27,11 @@
 		"@durable-streams/client": "https://pkg.pr.new/rivet-dev/durable-streams/@durable-streams/client@0323b8b",
 		"@durable-streams/server": "https://pkg.pr.new/rivet-dev/durable-streams/@durable-streams/server@0323b8b",
 		"@durable-streams/writer": "https://pkg.pr.new/rivet-dev/durable-streams/@durable-streams/writer@0323b8b",
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"ai": "^4.0.38",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"rivetkit": "^2.3.11",
+		"rivetkit": "^2.3.13",
 		"zod": "^4.1.0"
 	},
 	"license": "MIT"

--- a/examples/hello-world-render/package.json
+++ b/examples/hello-world-render/package.json
@@ -13,13 +13,13 @@
 		"check-types": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"@tailwindcss/postcss": "^4.2.2",
 		"@tailwindcss/typography": "^0.5.19",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"render-dds": "github:R4ph-t/DDS#v0.8.6",
-		"rivetkit": "^2.3.11",
+		"rivetkit": "^2.3.13",
 		"tailwindcss": "^4.2.2",
 		"tsx": "^4.19.0"
 	},

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -23,10 +23,10 @@
 		"vitest": "^3.1.1"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"rivetkit": "^2.3.11"
+		"rivetkit": "^2.3.13"
 	},
 	"stableVersion": "0.8.0",
 	"license": "MIT"

--- a/examples/hono-react/package.json
+++ b/examples/hono-react/package.json
@@ -23,11 +23,11 @@
 		"vitest": "^3.1.1"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"hono": "^4.7.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"rivetkit": "^2.3.11"
+		"rivetkit": "^2.3.13"
 	},
 	"stableVersion": "0.8.0",
 	"license": "MIT"

--- a/examples/hono/package.json
+++ b/examples/hono/package.json
@@ -15,7 +15,7 @@
 	},
 	"dependencies": {
 		"hono": "^4.7.0",
-		"rivetkit": "^2.3.11"
+		"rivetkit": "^2.3.13"
 	},
 	"stableVersion": "0.8.0",
 	"license": "MIT"

--- a/examples/inspector-tabs/package.json
+++ b/examples/inspector-tabs/package.json
@@ -20,7 +20,7 @@
 		"typescript": "^5.5.2"
 	},
 	"dependencies": {
-		"rivetkit": "^2.3.11"
+		"rivetkit": "^2.3.13"
 	},
 	"license": "MIT"
 }

--- a/examples/native-websockets/package.json
+++ b/examples/native-websockets/package.json
@@ -25,10 +25,10 @@
 		"ws": "^8.16.0"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"rivetkit": "^2.3.11"
+		"rivetkit": "^2.3.13"
 	},
 	"license": "MIT"
 }

--- a/examples/per-tenant-database/package.json
+++ b/examples/per-tenant-database/package.json
@@ -23,10 +23,10 @@
 		"vitest": "^3.1.1"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"rivetkit": "^2.3.11"
+		"rivetkit": "^2.3.13"
 	},
 	"stableVersion": "0.8.0",
 	"license": "MIT"

--- a/examples/raw-fetch-handler/package.json
+++ b/examples/raw-fetch-handler/package.json
@@ -23,11 +23,11 @@
 		"vitest": "^3.1.1"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"hono": "^4.6.18",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"rivetkit": "^2.3.11"
+		"rivetkit": "^2.3.13"
 	},
 	"license": "MIT"
 }

--- a/examples/raw-websocket-handler-proxy/package.json
+++ b/examples/raw-websocket-handler-proxy/package.json
@@ -34,11 +34,11 @@
 	"dependencies": {
 		"@hono/node-server": "^1.19.1",
 		"@hono/node-ws": "^1.2.0",
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"hono": "^4.7.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"rivetkit": "^2.3.11",
+		"rivetkit": "^2.3.13",
 		"ws": "^8.18.0"
 	},
 	"license": "MIT"

--- a/examples/raw-websocket-handler/package.json
+++ b/examples/raw-websocket-handler/package.json
@@ -31,10 +31,10 @@
 		"vitest": "^3.1.1"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"rivetkit": "^2.3.11"
+		"rivetkit": "^2.3.13"
 	},
 	"license": "MIT"
 }

--- a/examples/react-render/package.json
+++ b/examples/react-render/package.json
@@ -13,7 +13,7 @@
 		"check-types": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"@tailwindcss/postcss": "^4.2.2",
 		"@tailwindcss/typography": "^0.5.19",
 		"hono": "^4.7.7",
@@ -21,7 +21,7 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"render-dds": "github:R4ph-t/DDS#v0.8.6",
-		"rivetkit": "^2.3.11",
+		"rivetkit": "^2.3.13",
 		"tailwindcss": "^4.2.2",
 		"tsx": "^4.19.0"
 	},

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -23,10 +23,10 @@
 		"vitest": "^3.1.1"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"rivetkit": "^2.3.11"
+		"rivetkit": "^2.3.13"
 	},
 	"stableVersion": "0.8.0",
 	"license": "MIT"

--- a/examples/state-render/package.json
+++ b/examples/state-render/package.json
@@ -13,7 +13,7 @@
 		"check-types": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"@tailwindcss/postcss": "^4.2.2",
 		"@tailwindcss/typography": "^0.5.19",
 		"hono": "^4.7.7",
@@ -21,7 +21,7 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"render-dds": "github:R4ph-t/DDS#v0.8.6",
-		"rivetkit": "^2.3.11",
+		"rivetkit": "^2.3.13",
 		"tailwindcss": "^4.2.2",
 		"tsx": "^4.19.0"
 	},

--- a/examples/state/package.json
+++ b/examples/state/package.json
@@ -23,10 +23,10 @@
 		"vitest": "^3.1.1"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"rivetkit": "^2.3.11"
+		"rivetkit": "^2.3.13"
 	},
 	"license": "MIT"
 }

--- a/examples/stream-render/package.json
+++ b/examples/stream-render/package.json
@@ -13,7 +13,7 @@
 		"check-types": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"@tailwindcss/postcss": "^4.2.2",
 		"@tailwindcss/typography": "^0.5.19",
 		"hono": "^4.7.7",
@@ -21,7 +21,7 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"render-dds": "github:R4ph-t/DDS#v0.8.6",
-		"rivetkit": "^2.3.11",
+		"rivetkit": "^2.3.13",
 		"tailwindcss": "^4.2.2",
 		"tsx": "^4.19.0"
 	},

--- a/examples/stream/package.json
+++ b/examples/stream/package.json
@@ -22,10 +22,10 @@
 		"vitest": "^3.1.1"
 	},
 	"dependencies": {
-		"@rivetkit/react": "^2.3.11",
+		"@rivetkit/react": "^2.3.13",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"rivetkit": "^2.3.11"
+		"rivetkit": "^2.3.13"
 	},
 	"license": "MIT"
 }

--- a/examples/trpc/package.json
+++ b/examples/trpc/package.json
@@ -18,7 +18,7 @@
 		"@trpc/client": "^11.3.1",
 		"@trpc/server": "^11.4.2",
 		"hono": "^4.7.11",
-		"rivetkit": "^2.3.11",
+		"rivetkit": "^2.3.13",
 		"zod": "^3.25.76"
 	},
 	"stableVersion": "0.8.0",

--- a/integrations/workflow-world/package.json
+++ b/integrations/workflow-world/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivet-dev/workflow-world",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Vercel's Workflow SDK backed by Rivet Actors",
 	"license": "Apache-2.0",
 	"publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3454,8 +3454,8 @@ importers:
         specifier: ^0.1.1
         version: 0.1.1(pyodide@0.28.3)
       '@rivet-dev/services':
-        specifier: ^0.1.3
-        version: 0.1.3
+        specifier: ^0.1.5
+        version: 0.1.5
       '@rivetkit/bare-ts':
         specifier: ^0.6.2
         version: 0.6.2
@@ -8210,38 +8210,38 @@ packages:
     resolution: {integrity: sha512-MCwRS12jbgzIEjVYwHXpHjDrkBU6tjSVCIsepZY8SyBM+1VeZpKAfzLi9zOdMqowHftkOP1bx2Bn8RBr/tSeLQ==}
     engines: {node: '>=22.19.0'}
 
-  '@rivet-dev/services-darwin-arm64@0.1.3':
-    resolution: {integrity: sha512-LIHKFnIo+BryAN/3AXFs4hcBTCvA3h3bSEv7rG6ttdd98TaId38XrX9QyaTxlnDxoh9w6HBiCp9nuSxHC5AXew==}
+  '@rivet-dev/services-darwin-arm64@0.1.5':
+    resolution: {integrity: sha512-dQ06JPN0AU19TXcG3/FicscFm1JIgKw/ku0zrVIeEovXsvUl9c/fe6RncCsYwgW63LW9hift55IoTnqRjHAfpg==}
     engines: {node: '>=20'}
     cpu: [arm64]
     os: [darwin]
 
-  '@rivet-dev/services-darwin-x64@0.1.3':
-    resolution: {integrity: sha512-lbQlrr2PNpTk5MFmFuktcwFJqd9/ejuFDUdOV1vMYKv+s1Ovp/+bZPQuRu0RQjc/rlSU16HrZzRjvBdH6FDr9A==}
+  '@rivet-dev/services-darwin-x64@0.1.5':
+    resolution: {integrity: sha512-Sae45NZjEjjpM7b9MtThd619ts3UeLPPL6NvcGRQqJH8R4y0xUsJRzKpBfKIIkS5gVbWicipSpNWQNMwvkleSQ==}
     engines: {node: '>=20'}
     cpu: [x64]
     os: [darwin]
 
-  '@rivet-dev/services-linux-arm64-musl@0.1.3':
-    resolution: {integrity: sha512-4UsPCiEkFIBWp22X/CVdLXS+RFzijm2N3JUzJioy/JqrpHI9mF7BybamGL2yZoJ8GdUpvK8Tv2TC8FHTvgjkCw==}
+  '@rivet-dev/services-linux-arm64-musl@0.1.5':
+    resolution: {integrity: sha512-W6MGrgLLhEELkd4RPhNz+dJyKPy6u3VIaswd8tTqIk5+NVza10MGC3IDATKKJTZfvx9p+DVrJeGUijcVdTXuuA==}
     engines: {node: '>=20'}
     cpu: [arm64]
     os: [linux]
 
-  '@rivet-dev/services-linux-x64-musl@0.1.3':
-    resolution: {integrity: sha512-Z8Jv4Ytzlyxzz9O5GRmr+UGcO1p8TFQrdJerCO2v43X428OrfDzWsF4TN3GvrGvFrQWJPPiTr69kn4lTxLmKyA==}
+  '@rivet-dev/services-linux-x64-musl@0.1.5':
+    resolution: {integrity: sha512-ZrVwAQY+w3rvQp48KhlQNF63SjQi4ljix1Td1xDGtFUGxa/xpOvgDR/vcuJ1wXOXhHYSRPTYd+nTDeDGG8GmqQ==}
     engines: {node: '>=20'}
     cpu: [x64]
     os: [linux]
 
-  '@rivet-dev/services-win32-x64@0.1.3':
-    resolution: {integrity: sha512-xarKwacvUqAgWgQac9gxteDcE7oPj9dtqOiiAU/XgNWp4PELOGjdGZ1CeLDQehb7hlZRWcouGmy5nkwDIXi3aA==}
+  '@rivet-dev/services-win32-x64@0.1.5':
+    resolution: {integrity: sha512-uQ+z0Zo9iAj7RnP0xxNAbXt8MVmAaTo8IlUxXrKk6D/ZpEOfuOe6diPlI58GGDJlC5u5xkKWvEkobjed7F4oSg==}
     engines: {node: '>=20'}
     cpu: [x64]
     os: [win32]
 
-  '@rivet-dev/services@0.1.3':
-    resolution: {integrity: sha512-5mNf04wexw9D4WNWt3bcQSMCISMRsfINp1TyihwedtHXnqQI62gqwbgbEmeSlnoS2nl2WZbrPbM8rhndzc+0sQ==}
+  '@rivet-dev/services@0.1.5':
+    resolution: {integrity: sha512-jAZ+RKTD/dIkCeiIUwLKSYh0JLvZbAPS+jFZnMYxMKbfT6Sn14/EYzTQyrIk7Lw2d99r3YeDKb9LhfFil80fRw==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -24290,28 +24290,28 @@ snapshots:
       - zod-openapi
       - zod-to-json-schema
 
-  '@rivet-dev/services-darwin-arm64@0.1.3':
+  '@rivet-dev/services-darwin-arm64@0.1.5':
     optional: true
 
-  '@rivet-dev/services-darwin-x64@0.1.3':
+  '@rivet-dev/services-darwin-x64@0.1.5':
     optional: true
 
-  '@rivet-dev/services-linux-arm64-musl@0.1.3':
+  '@rivet-dev/services-linux-arm64-musl@0.1.5':
     optional: true
 
-  '@rivet-dev/services-linux-x64-musl@0.1.3':
+  '@rivet-dev/services-linux-x64-musl@0.1.5':
     optional: true
 
-  '@rivet-dev/services-win32-x64@0.1.3':
+  '@rivet-dev/services-win32-x64@0.1.5':
     optional: true
 
-  '@rivet-dev/services@0.1.3':
+  '@rivet-dev/services@0.1.5':
     optionalDependencies:
-      '@rivet-dev/services-darwin-arm64': 0.1.3
-      '@rivet-dev/services-darwin-x64': 0.1.3
-      '@rivet-dev/services-linux-arm64-musl': 0.1.3
-      '@rivet-dev/services-linux-x64-musl': 0.1.3
-      '@rivet-dev/services-win32-x64': 0.1.3
+      '@rivet-dev/services-darwin-arm64': 0.1.5
+      '@rivet-dev/services-darwin-x64': 0.1.5
+      '@rivet-dev/services-linux-arm64-musl': 0.1.5
+      '@rivet-dev/services-linux-x64-musl': 0.1.5
+      '@rivet-dev/services-win32-x64': 0.1.5
 
   '@rivet-gg/cloud@https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@87a84c0':
     dependencies:

--- a/rivetkit-typescript/packages/cli/npm/darwin-arm64/package.json
+++ b/rivetkit-typescript/packages/cli/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/cli-darwin-arm64",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Rivet CLI for macOS arm64 (Apple Silicon)",
 	"license": "LicenseRef-RivetEnterprise",
 	"os": [

--- a/rivetkit-typescript/packages/cli/npm/darwin-x64/package.json
+++ b/rivetkit-typescript/packages/cli/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/cli-darwin-x64",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Rivet CLI for macOS x64",
 	"license": "LicenseRef-RivetEnterprise",
 	"os": [

--- a/rivetkit-typescript/packages/cli/npm/linux-arm64-musl/package.json
+++ b/rivetkit-typescript/packages/cli/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/cli-linux-arm64-musl",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Rivet CLI for Linux arm64 musl (static)",
 	"license": "LicenseRef-RivetEnterprise",
 	"os": [

--- a/rivetkit-typescript/packages/cli/npm/linux-x64-musl/package.json
+++ b/rivetkit-typescript/packages/cli/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/cli-linux-x64-musl",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Rivet CLI for Linux x64 musl (static)",
 	"license": "LicenseRef-RivetEnterprise",
 	"os": [

--- a/rivetkit-typescript/packages/cli/npm/win32-x64/package.json
+++ b/rivetkit-typescript/packages/cli/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/cli-win32-x64",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Rivet CLI for Windows x64",
 	"license": "LicenseRef-RivetEnterprise",
 	"os": [

--- a/rivetkit-typescript/packages/cli/package.json
+++ b/rivetkit-typescript/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/cli",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Rivet Cloud CLI",
 	"license": "LicenseRef-RivetEnterprise",
 	"main": "index.js",

--- a/rivetkit-typescript/packages/cloudflare-workers/package.json
+++ b/rivetkit-typescript/packages/cloudflare-workers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/cloudflare-workers",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Cloudflare Workers integration for RivetKit actors",
 	"license": "Apache-2.0",
 	"keywords": [

--- a/rivetkit-typescript/packages/effect/package.json
+++ b/rivetkit-typescript/packages/effect/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/effect",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Effect SDK for Rivet Actors",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/rivetkit-typescript/packages/engine-cli/npm/darwin-arm64/package.json
+++ b/rivetkit-typescript/packages/engine-cli/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/engine-cli-darwin-arm64",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Rivet Engine binary for macOS arm64 (Apple Silicon)",
 	"license": "Apache-2.0",
 	"os": [

--- a/rivetkit-typescript/packages/engine-cli/npm/darwin-x64/package.json
+++ b/rivetkit-typescript/packages/engine-cli/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/engine-cli-darwin-x64",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Rivet Engine binary for macOS x64",
 	"license": "Apache-2.0",
 	"os": [

--- a/rivetkit-typescript/packages/engine-cli/npm/linux-arm64-musl/package.json
+++ b/rivetkit-typescript/packages/engine-cli/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/engine-cli-linux-arm64-musl",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Rivet Engine binary for Linux arm64 musl (static)",
 	"license": "Apache-2.0",
 	"os": [

--- a/rivetkit-typescript/packages/engine-cli/npm/linux-x64-musl/package.json
+++ b/rivetkit-typescript/packages/engine-cli/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/engine-cli-linux-x64-musl",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Rivet Engine binary for Linux x64 musl (static)",
 	"license": "Apache-2.0",
 	"os": [

--- a/rivetkit-typescript/packages/engine-cli/npm/win32-x64/package.json
+++ b/rivetkit-typescript/packages/engine-cli/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/engine-cli-win32-x64",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Rivet Engine binary for Windows x64",
 	"license": "Apache-2.0",
 	"os": [

--- a/rivetkit-typescript/packages/engine-cli/package.json
+++ b/rivetkit-typescript/packages/engine-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/engine-cli",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Rivet Engine binary distributed as platform-specific npm packages",
 	"license": "Apache-2.0",
 	"main": "index.js",

--- a/rivetkit-typescript/packages/engine-runner-protocol/package.json
+++ b/rivetkit-typescript/packages/engine-runner-protocol/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/engine-runner-protocol",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"license": "Apache-2.0",
 	"type": "module",
 	"exports": {

--- a/rivetkit-typescript/packages/engine-runner/package.json
+++ b/rivetkit-typescript/packages/engine-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/engine-runner",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"type": "module",
 	"files": [
 		"dist",

--- a/rivetkit-typescript/packages/framework-base/package.json
+++ b/rivetkit-typescript/packages/framework-base/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/framework-base",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Base framework utilities for RivetKit client integrations",
 	"license": "Apache-2.0",
 	"keywords": [

--- a/rivetkit-typescript/packages/next-js/package.json
+++ b/rivetkit-typescript/packages/next-js/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/next-js",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Next.js integration for RivetKit actors and client",
 	"license": "Apache-2.0",
 	"keywords": [

--- a/rivetkit-typescript/packages/react/package.json
+++ b/rivetkit-typescript/packages/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/react",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "React hooks and components for RivetKit client applications",
 	"license": "Apache-2.0",
 	"keywords": [

--- a/rivetkit-typescript/packages/rivetkit-napi/npm/darwin-arm64/package.json
+++ b/rivetkit-typescript/packages/rivetkit-napi/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/rivetkit-napi-darwin-arm64",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"os": [
 		"darwin"
 	],

--- a/rivetkit-typescript/packages/rivetkit-napi/npm/darwin-x64/package.json
+++ b/rivetkit-typescript/packages/rivetkit-napi/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/rivetkit-napi-darwin-x64",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"os": [
 		"darwin"
 	],

--- a/rivetkit-typescript/packages/rivetkit-napi/npm/linux-arm64-gnu/package.json
+++ b/rivetkit-typescript/packages/rivetkit-napi/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/rivetkit-napi-linux-arm64-gnu",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"os": [
 		"linux"
 	],

--- a/rivetkit-typescript/packages/rivetkit-napi/npm/linux-arm64-musl/package.json
+++ b/rivetkit-typescript/packages/rivetkit-napi/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/rivetkit-napi-linux-arm64-musl",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"os": [
 		"linux"
 	],

--- a/rivetkit-typescript/packages/rivetkit-napi/npm/linux-x64-gnu/package.json
+++ b/rivetkit-typescript/packages/rivetkit-napi/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/rivetkit-napi-linux-x64-gnu",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"os": [
 		"linux"
 	],

--- a/rivetkit-typescript/packages/rivetkit-napi/npm/linux-x64-musl/package.json
+++ b/rivetkit-typescript/packages/rivetkit-napi/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/rivetkit-napi-linux-x64-musl",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"os": [
 		"linux"
 	],

--- a/rivetkit-typescript/packages/rivetkit-napi/npm/win32-x64-msvc/package.json
+++ b/rivetkit-typescript/packages/rivetkit-napi/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/rivetkit-napi-win32-x64-msvc",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Native N-API addon for RivetKit - Windows x64 (MinGW-built, loadable by MSVC Node)",
 	"license": "Apache-2.0",
 	"os": [

--- a/rivetkit-typescript/packages/rivetkit-napi/package.json
+++ b/rivetkit-typescript/packages/rivetkit-napi/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/rivetkit-napi",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Native N-API addon for RivetKit providing envoy client and SQLite access",
 	"license": "Apache-2.0",
 	"main": "index.js",

--- a/rivetkit-typescript/packages/rivetkit-wasm/package.json
+++ b/rivetkit-typescript/packages/rivetkit-wasm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/rivetkit-wasm",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "WebAssembly bindings for RivetKit core on edge JavaScript runtimes",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/rivetkit-typescript/packages/rivetkit/package.json
+++ b/rivetkit-typescript/packages/rivetkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rivetkit",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Lightweight libraries for building stateful actors on edge platforms",
 	"license": "Apache-2.0",
 	"keywords": [
@@ -210,7 +210,7 @@
 	"dependencies": {
 		"@hono/zod-openapi": "^1.1.5",
 		"@rivet-dev/agent-os-core": "^0.1.1",
-		"@rivet-dev/services": "^0.1.3",
+		"@rivet-dev/services": "^0.1.5",
 		"@rivetkit/bare-ts": "^0.6.2",
 		"@rivetkit/engine-cli": "workspace:*",
 		"@rivetkit/engine-envoy-protocol": "workspace:*",

--- a/rivetkit-typescript/packages/sql-loader/package.json
+++ b/rivetkit-typescript/packages/sql-loader/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/sql-loader",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "SQL file loader and migration utilities for RivetKit",
 	"license": "Apache-2.0",
 	"sideEffects": [

--- a/rivetkit-typescript/packages/supabase/package.json
+++ b/rivetkit-typescript/packages/supabase/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/supabase",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Supabase Edge Functions integration for RivetKit actors",
 	"license": "Apache-2.0",
 	"keywords": [

--- a/rivetkit-typescript/packages/traces/package.json
+++ b/rivetkit-typescript/packages/traces/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/traces",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Generic tracing storage and OTLP export for RivetKit",
 	"license": "Apache-2.0",
 	"type": "module",

--- a/rivetkit-typescript/packages/workflow-engine/package.json
+++ b/rivetkit-typescript/packages/workflow-engine/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/workflow-engine",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Durable workflow engine with reentrant execution",
 	"license": "Apache-2.0",
 	"keywords": [

--- a/shared/typescript/virtual-websocket/package.json
+++ b/shared/typescript/virtual-websocket/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivetkit/virtual-websocket",
-	"version": "2.3.11",
+	"version": "2.3.13",
 	"description": "Virtual WebSocket implementation for creating linked WebSocket pairs",
 	"license": "Apache-2.0",
 	"type": "module",


### PR DESCRIPTION
- Bump RivetKit packages and Rust crates to 2.3.13.
- Require Services 0.1.5 and refresh its locked platform artifacts.