### PR TITLE
fix(guard): allow path-based WebSocket requests without sec-websocket-protocol header

### DIFF
--- a/engine/packages/guard/src/routing/pegboard_gateway/mod.rs
+++ b/engine/packages/guard/src/routing/pegboard_gateway/mod.rs
@@ -905,16 +905,13 @@ fn read_gateway_token_for_path_based<'a>(
 	}
 
 	if req_ctx.is_websocket() {
-		let protocols_header = req_ctx
+		let Some(protocols_header) = req_ctx
 			.headers()
 			.get(SEC_WEBSOCKET_PROTOCOL)
 			.and_then(|protocols| protocols.to_str().ok())
-			.ok_or_else(|| {
-				crate::errors::MissingHeader {
-					header: "sec-websocket-protocol".to_string(),
-				}
-				.build()
-			})?;
+		else {
+			return Ok(None);
+		};
 
 		let protocols = protocols_header
 			.split(',')


### PR DESCRIPTION
In path-based WebSocket routing (\ead_gateway_token_for_path_based\), if \sec-websocket-protocol\ header is absent, return \Ok(None)\ instead of failing with a \MissingHeader\ error.

This allows path-based WebSocket connections (such as the Hub UI inspector console) to connect without requiring a token header when unauthenticated or when the token is omitted.

Fixes #5481.