### PR TITLE
fix(ci): Fix CI and simplify the setup

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,30 +17,9 @@ env:
   RUSTFLAGS: "--cfg tokio_unstable"
   CARGO_TERM_COLOR: always
 jobs:
-  # Detect if rust code changed
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      rust: ${{ steps.filter.outputs.rust }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          filters: |
-            rust:
-              - '**/*.rs'
-              - '**/*.bare'
-              - '**/Cargo.toml'
-              - '**/Cargo.lock'
-              - 'rivetkit-rust/packages/rivetkit-core/scripts/**/*.sh'
-              - '.github/workflows/rust.yml'
-
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.rust == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -53,8 +32,6 @@ jobs:
   # clippy:
   #   name: Clippy
   #   runs-on: depot-ubuntu-24.04-8
-  #   needs: changes
-  #   if: needs.changes.outputs.rust == 'true'
   #   steps:
   #     - uses: actions/checkout@v4
   #
@@ -74,16 +51,12 @@ jobs:
   check:
     name: Check
     runs-on: depot-ubuntu-24.04-8
-    needs: changes
-    if: needs.changes.outputs.rust == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "rust-ci"
+          cache-shared-key: rust-ci
           cache-on-failure: true
 
       - name: Check event-driven drain invariants
@@ -107,8 +80,6 @@ jobs:
   # test:
   #   name: Test
   #   runs-on: depot-ubuntu-24.04-8
-  #   needs: changes
-  #   if: needs.changes.outputs.rust == 'true'
   #   steps:
   #     - uses: actions/checkout@v4
   #
@@ -130,8 +101,6 @@ jobs:
   # deny:
   #   name: Deny
   #   runs-on: ubuntu-latest
-  #   needs: changes
-  #   if: needs.changes.outputs.rust == 'true'
   #   steps:
   #     - uses: actions/checkout@v4
   #     - name: cargo deny
@@ -143,19 +112,12 @@ jobs:
   status-check:
     name: Rust CI Status
     runs-on: ubuntu-latest
-    needs: [changes, fmt, check]
+    needs: [fmt, check]
     if: always()
     steps:
       - name: Check job status
         run: |
-          # If rust code didn't change, consider it a pass
-          if [ "${{ needs.changes.outputs.rust }}" != "true" ]; then
-            echo "No Rust changes detected, skipping checks"
-            exit 0
-          fi
-
-          # If rust code changed, verify all jobs passed
-          if [ "${{ needs.fmt.result }}" == "failure" ] || [ "${{ needs.check.result }}" == "failure" ]; then
+          if [ "${{ needs.fmt.result }}" != "success" ] || [ "${{ needs.check.result }}" != "success" ]; then
             echo "One or more required jobs failed"
             exit 1
           fi

--- a/rivetkit-rust/packages/rivetkit/src/event.rs
+++ b/rivetkit-rust/packages/rivetkit/src/event.rs
@@ -19,8 +19,6 @@ use serde::{
 
 use crate::{action, actor::Actor, context::ConnCtx, persist};
 
-const EVENT_SET_TUPLE_ARITY_MAX: usize = 16;
-
 pub trait Event: Serialize + DeserializeOwned + Send + Sync + 'static {
 	const NAME: &'static str;
 }
@@ -1429,6 +1427,8 @@ mod tests {
 
 	use super::*;
 	use crate::{action, actor::Actor, start::wrap_start};
+
+	const EVENT_SET_TUPLE_ARITY_MAX: usize = 16;
 
 	struct EmptyActor;
 

--- a/rivetkit-rust/packages/rivetkit/src/queue.rs
+++ b/rivetkit-rust/packages/rivetkit/src/queue.rs
@@ -12,7 +12,6 @@ use rivetkit_core::{
 use serde::{Serialize, de::DeserializeOwned};
 
 use crate::{actor::Actor, context::Ctx};
-const QUEUE_SET_TUPLE_ARITY_MAX: usize = 16;
 pub(crate) type BoxQueueFuture = Pin<Box<dyn Future<Output = Result<Option<Vec<u8>>>> + Send>>;
 
 pub trait QueueMessage: Serialize + DeserializeOwned + Send + Sync + 'static {
@@ -366,8 +365,10 @@ mod tests {
 	use anyhow::Result;
 	use serde::{Deserialize, Serialize};
 
-	use super::{HandlesQueue, QUEUE_SET_TUPLE_ARITY_MAX, QueueMessage, QueueSet};
+	use super::{HandlesQueue, QueueMessage, QueueSet};
 	use crate::{action, actor::Actor, context::Ctx};
+
+	const QUEUE_SET_TUPLE_ARITY_MAX: usize = 16;
 
 	struct TestActor;
 


### PR DESCRIPTION
- Run cached Rust validation on every pull request without third-party change detection.
- Keep event and queue tuple-limit expectations test-only so warning-denied builds pass.