### PR TITLE
fix(frontend): dashboard audit polish — inspector defaults, empty states, OSS theme toggle

### DIFF
--- a/frontend/src/app/runner-config-table.tsx
+++ b/frontend/src/app/runner-config-table.tsx
@@ -87,7 +87,7 @@ export function RunnerConfigsTable({
 					<TableRow>
 						<TableCell colSpan={6}>
 							<Text className="text-center">
-								There's no providers matching criteria.
+								No providers added yet.
 							</Text>
 						</TableCell>
 					</TableRow>

--- a/frontend/src/app/runners-table.tsx
+++ b/frontend/src/app/runners-table.tsx
@@ -412,8 +412,8 @@ function EmptyState() {
 					</>
 				) : (
 					<Text className="text-center">
-						There are no runners connected. You will not be able to
-						run actors until a runner appears here.
+						No runners connected yet. Actors can't run until a
+						runner appears here.
 					</Text>
 				)}
 			</TableCell>

--- a/frontend/src/app/settings-drawer.tsx
+++ b/frontend/src/app/settings-drawer.tsx
@@ -92,8 +92,9 @@ const TAB_META: Record<SettingsTab, { title: string; description?: string }> = {
 	},
 	settings: {
 		title: "Settings",
-		description:
-			"Connect your RivetKit application to Rivet Cloud. Use your cloud of choice to run Rivet Actors.",
+		description: features.platform
+			? "Connect your RivetKit application to Rivet Cloud. Use your cloud of choice to run Rivet Actors."
+			: "Connect providers and runners to this namespace. Use your cloud of choice to run Rivet Actors.",
 	},
 	compute: {
 		title: "Compute",

--- a/frontend/src/app/settings-pages/namespace-settings.tsx
+++ b/frontend/src/app/settings-pages/namespace-settings.tsx
@@ -109,7 +109,7 @@ function Providers() {
 	return (
 		<SettingsCard
 			title="Providers"
-			description="Clouds connected to Rivet for running Rivet Actors."
+			description="Clouds connected to this namespace for running Rivet Actors."
 			action={
 				<ProviderDropdown>
 					<Button
@@ -190,7 +190,7 @@ function Runners() {
 	return (
 		<SettingsCard
 			title="Runners"
-			description="Processes connected to Rivet Cloud and ready to start running Rivet Actors."
+			description="Processes connected to this namespace and ready to run Rivet Actors."
 		>
 			<div className="border border-foreground/10 rounded-md overflow-hidden">
 				<RunnersTable

--- a/frontend/src/app/top-bar-actions.tsx
+++ b/frontend/src/app/top-bar-actions.tsx
@@ -1,9 +1,16 @@
-import { faBook, Icon } from "@rivet-gg/icons";
+import { faBook, faMoon, faSun, Icon } from "@rivet-gg/icons";
 import { type ComponentPropsWithoutRef, forwardRef } from "react";
-import { Avatar, AvatarFallback, AvatarImage, Button } from "@/components";
+import {
+	Avatar,
+	AvatarFallback,
+	AvatarImage,
+	Button,
+	WithTooltip,
+} from "@/components";
 import { authClient } from "@/lib/auth";
 import { features } from "@/lib/features";
 import { orgConicGradient, paletteForLetter } from "@/lib/org-palette";
+import { useTheme } from "@/lib/theme";
 import { FeedbackButton } from "./feedback-button";
 import { HelpButton } from "./help-button";
 import { UserDropdown } from "./user-dropdown";
@@ -23,8 +30,38 @@ export function TopBarActions() {
 						<UserAvatarTrigger />
 					</UserDropdown>
 				</>
-			) : null}
+			) : (
+				// Signed-in users switch themes from the account menu. Without
+				// auth (OSS / self-hosted) there is no menu, so expose the
+				// toggle directly.
+				<ThemeToggleButton />
+			)}
 		</div>
+	);
+}
+
+function ThemeToggleButton() {
+	const { theme, toggle } = useTheme();
+	const label =
+		theme === "dark" ? "Switch to light mode" : "Switch to dark mode";
+	return (
+		<WithTooltip
+			content={label}
+			trigger={
+				<Button
+					variant="ghost"
+					size="icon-sm"
+					aria-label={label}
+					className="text-muted-foreground hover:text-foreground"
+					onClick={toggle}
+				>
+					<Icon
+						icon={theme === "dark" ? faSun : faMoon}
+						className="size-4"
+					/>
+				</Button>
+			}
+		/>
 	);
 }
 

--- a/frontend/src/components/actors/actor-connections-tab.tsx
+++ b/frontend/src/components/actors/actor-connections-tab.tsx
@@ -1,6 +1,14 @@
-import { faSpinnerThird, Icon } from "@rivet-gg/icons";
+import { faPlug, faSpinnerThird, Icon } from "@rivet-gg/icons";
 import { useQuery } from "@tanstack/react-query";
-import { LiveBadge, ScrollArea } from "@/components";
+import { DiscreteCopyButton, LiveBadge, ScrollArea } from "@/components";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
 import { useActorInspector } from "./actor-inspector-context";
 import { Info } from "./actor-state-tab";
 import { ActorObjectInspector } from "./console/actor-inspector";
@@ -9,6 +17,21 @@ import type { ActorId } from "./queries";
 
 interface ActorConnectionsTabProps {
 	actorId: ActorId;
+}
+
+/**
+ * Shape of the CBOR-decoded `details` payload sent by RivetKit. Kept loose on
+ * purpose: older runtimes send `type` instead of `connectionType`, and the
+ * inspector should still render whatever it gets.
+ */
+interface ConnectionDetails {
+	connectionType?: string | null;
+	type?: string | null;
+	params?: unknown;
+	state?: unknown;
+	stateEnabled?: boolean;
+	subscriptions?: number;
+	isHibernatable?: boolean;
 }
 
 export function ActorConnectionsTab({ actorId }: ActorConnectionsTabProps) {
@@ -41,17 +64,112 @@ export function ActorConnectionsTab({ actorId }: ActorConnectionsTabProps) {
 	}
 
 	return (
-		<ScrollArea className="flex-1 w-full min-h-0 h-full">
-			<div className="flex  justify-between items-center gap-1 border-b sticky top-0 p-2 z-[1] h-[45px]">
+		<div className="flex h-full min-h-0 flex-1 flex-col">
+			<div className="flex justify-between items-center gap-1 border-b p-2 h-[45px]">
 				<LiveBadge />
+				<div className="text-xs text-muted-foreground">
+					{data.length}{" "}
+					{data.length === 1 ? "connection" : "connections"}
+				</div>
 			</div>
-			<div className="p-2">
-				<ActorObjectInspector
-					name="connections"
-					data={data}
-					expandPaths={["$"]}
-				/>
+			{data.length === 0 ? (
+				<EmptyConnections />
+			) : (
+				<ScrollArea className="flex-1 w-full min-h-0">
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Connection ID</TableHead>
+								<TableHead>Type</TableHead>
+								<TableHead>Hibernatable</TableHead>
+								<TableHead>Params</TableHead>
+								<TableHead>State</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{data.map((connection) => {
+								const details = (connection.details ??
+									{}) as ConnectionDetails;
+								const type =
+									details.connectionType ??
+									details.type ??
+									"—";
+								return (
+									<TableRow
+										key={connection.id}
+										className="align-top"
+									>
+										<TableCell className="whitespace-nowrap align-top">
+											<DiscreteCopyButton
+												size="xs"
+												className="font-mono-console text-xs -ml-2"
+												value={connection.id}
+											>
+												{connection.id}
+											</DiscreteCopyButton>
+										</TableCell>
+										<TableCell className="text-muted-foreground align-top">
+											{type}
+										</TableCell>
+										<TableCell className="text-muted-foreground align-top">
+											{details.isHibernatable
+												? "Yes"
+												: "No"}
+										</TableCell>
+										<TableCell className="w-1/4 min-w-48 align-top">
+											<ConnectionValue
+												name="params"
+												value={details.params}
+											/>
+										</TableCell>
+										<TableCell className="w-1/4 min-w-48 align-top">
+											{details.stateEnabled === false ? (
+												<span className="text-muted-foreground">
+													Disabled
+												</span>
+											) : (
+												<ConnectionValue
+													name="state"
+													value={details.state}
+												/>
+											)}
+										</TableCell>
+									</TableRow>
+								);
+							})}
+						</TableBody>
+					</Table>
+				</ScrollArea>
+			)}
+		</div>
+	);
+}
+
+function ConnectionValue({ name, value }: { name: string; value: unknown }) {
+	if (value === undefined || value === null) {
+		return <span className="text-muted-foreground">—</span>;
+	}
+	return (
+		<ActorObjectInspector
+			name={name}
+			data={value}
+			expandPaths={["$"]}
+			className="text-xs"
+		/>
+	);
+}
+
+function EmptyConnections() {
+	return (
+		<div className="flex flex-1 flex-col items-center justify-center p-8 text-center">
+			<div className="mb-3 flex size-11 items-center justify-center rounded-full bg-muted">
+				<Icon icon={faPlug} className="text-muted-foreground" />
 			</div>
-		</ScrollArea>
+			<h3 className="font-medium">No active connections</h3>
+			<p className="mt-1 max-w-sm text-sm text-muted-foreground">
+				Clients connected to this actor, their params, and connection
+				state will appear here.
+			</p>
+		</div>
 	);
 }

--- a/frontend/src/components/actors/actor-database.tsx
+++ b/frontend/src/components/actors/actor-database.tsx
@@ -20,12 +20,14 @@ import {
 	Textarea,
 	WithTooltip,
 } from "@/components";
-import { ShimmerLine } from "../shimmer-line";
 import { formatValue } from "@/lib/format-value";
+import { ShimmerLine } from "../shimmer-line";
 import {
 	Select,
 	SelectContent,
+	SelectGroup,
 	SelectItem,
+	SelectLabel,
 	SelectTrigger,
 	SelectValue,
 } from "../ui/select";
@@ -105,18 +107,33 @@ export function ActorDatabase({ actorId }: ActorDatabaseProps) {
 	);
 }
 
+/**
+ * Tables created by Rivet itself (actor metadata, workflow KV, migration
+ * bookkeeping). They are still browsable but should not be the first thing a
+ * user sees when opening the Database tab.
+ */
+function isInternalTable(name: string) {
+	return name.startsWith("_rivet");
+}
+
+function defaultTableName(names: string[] | undefined) {
+	if (!names?.length) return undefined;
+	return names.find((name) => !isInternalTable(name)) ?? names[0];
+}
+
 function ActorDatabaseBrowser({ actorId }: ActorDatabaseProps) {
 	const actorInspector = useActorInspector();
 	const queryClient = useQueryClient();
 	const { data, refetch } = useQuery(
 		actorInspector.actorDatabaseQueryOptions(actorId),
 	);
-	const [table, setTable] = useState<string | undefined>(
-		() => data?.tables?.[0]?.table.name,
+	const [table, setTable] = useState<string | undefined>(() =>
+		defaultTableName(data?.tables?.map((t) => t.table.name)),
 	);
 	const [page, setPage] = useState(0);
 
-	const selectedTable = table || data?.tables?.[0]?.table.name;
+	const selectedTable =
+		table || defaultTableName(data?.tables?.map((t) => t.table.name));
 
 	const {
 		data: rows,
@@ -811,6 +828,10 @@ function TableSelect({
 	const { data: tables } = useQuery(
 		actorInspector.actorDatabaseTablesQueryOptions(actorId),
 	);
+	const userTables =
+		tables?.filter((table) => !isInternalTable(table.name)) ?? [];
+	const internalTables =
+		tables?.filter((table) => isInternalTable(table.name)) ?? [];
 
 	return (
 		<Select onValueChange={onSelect} value={value}>
@@ -826,7 +847,7 @@ function TableSelect({
 						</Flex>
 					</SelectItem>
 				) : null}
-				{tables?.map((table) => (
+				{userTables.map((table) => (
 					<SelectItem key={table.name} value={table.name}>
 						<div className="flex items-center gap-2">
 							<Icon icon={faTable} className="text-foreground" />
@@ -834,6 +855,24 @@ function TableSelect({
 						</div>
 					</SelectItem>
 				))}
+				{internalTables.length > 0 ? (
+					<SelectGroup>
+						<SelectLabel className="text-muted-foreground font-normal">
+							Internal
+						</SelectLabel>
+						{internalTables.map((table) => (
+							<SelectItem key={table.name} value={table.name}>
+								<div className="flex items-center gap-2">
+									<Icon
+										icon={faTable}
+										className="text-muted-foreground"
+									/>
+									{table.name}
+								</div>
+							</SelectItem>
+						))}
+					</SelectGroup>
+				) : null}
 			</SelectContent>
 		</Select>
 	);

--- a/frontend/src/components/actors/actor-details-iframe.tsx
+++ b/frontend/src/components/actors/actor-details-iframe.tsx
@@ -22,6 +22,7 @@ import { useTimeout } from "../hooks/use-timeout";
 import { ActorDetailsLegacy } from "./actor-details-legacy";
 import {
 	CLOUD_TABS,
+	orderInspectorTabs,
 	SKELETON_INSPECTOR_TABS,
 	useHasManagedPool,
 	useShowTabLabels,
@@ -575,7 +576,7 @@ function ActorDetailsIframePath({
 				return;
 			}
 			if (msg.type === "tabs-available") {
-				setInspectorTabs(msg.tabs);
+				setInspectorTabs(orderInspectorTabs(msg.tabs));
 				return;
 			}
 			if (msg.type === "token-refresh-needed") {

--- a/frontend/src/components/actors/actor-details-shared.tsx
+++ b/frontend/src/components/actors/actor-details-shared.tsx
@@ -145,10 +145,40 @@ export const CLOUD_TABS: readonly CloudTabSpec[] = [
  */
 export const SKELETON_INSPECTOR_TABS: readonly InspectorTabDescriptor[] = [
 	{ id: "workflow", label: "Workflow", icon: "workflow" },
-	{ id: "database", label: "Database", icon: "database" },
 	{ id: "state", label: "State", icon: "state" },
+	{ id: "database", label: "Database", icon: "database" },
 	{ id: "queue", label: "Queue", icon: "queue" },
 	{ id: "schedules", label: "Schedules", icon: "calendar" },
 	{ id: "connections", label: "Connections", icon: "plug" },
 	{ id: "console", label: "Console", icon: "terminal" },
 ];
+
+const KNOWN_INSPECTOR_TAB_ORDER = new Map(
+	SKELETON_INSPECTOR_TABS.map((tab, index) => [tab.id, index]),
+);
+
+/**
+ * Orders tabs advertised by an actor's inspector bundle to match the
+ * dashboard's canonical order. The bundle is shipped with the runner, so older
+ * runners may advertise tabs in a different order (e.g. Database before
+ * State); the dashboard owns the strip and picks `displayedTabs[0]` as the
+ * default, so it also owns the order. Custom tabs the dashboard doesn't know
+ * keep their advertised order and follow the built-in ones.
+ */
+export function orderInspectorTabs<T extends { id: string }>(
+	tabs: readonly T[],
+): T[] {
+	return tabs
+		.map((tab, index) => ({ tab, index }))
+		.sort((a, b) => {
+			const aKnown = KNOWN_INSPECTOR_TAB_ORDER.get(a.tab.id);
+			const bKnown = KNOWN_INSPECTOR_TAB_ORDER.get(b.tab.id);
+			if (aKnown !== undefined && bKnown !== undefined) {
+				return aKnown - bKnown;
+			}
+			if (aKnown !== undefined) return -1;
+			if (bKnown !== undefined) return 1;
+			return a.index - b.index;
+		})
+		.map(({ tab }) => tab);
+}

--- a/frontend/src/components/actors/actor-details-skeleton.tsx
+++ b/frontend/src/components/actors/actor-details-skeleton.tsx
@@ -13,8 +13,8 @@ const PLACEHOLDER_TABS: ReadonlyArray<{
 	icon: string;
 }> = [
 	{ id: "workflow", label: "Workflow", icon: "workflow" },
-	{ id: "database", label: "Database", icon: "database" },
 	{ id: "state", label: "State", icon: "state" },
+	{ id: "database", label: "Database", icon: "database" },
 	{ id: "queue", label: "Queue", icon: "queue" },
 	{ id: "connections", label: "Connections", icon: "plug" },
 	{ id: "console", label: "Console", icon: "terminal" },

--- a/frontend/src/components/actors/actor-general.tsx
+++ b/frontend/src/components/actors/actor-general.tsx
@@ -18,7 +18,6 @@ import {
 	ActorSleepButton,
 	ActorStopButton,
 } from "./actor-stop-button";
-import { ActorObjectInspector } from "./console/actor-inspector";
 import { useDataProvider } from "./data-provider";
 import type { ActorId } from "./queries";
 
@@ -91,19 +90,19 @@ export function ActorGeneral({ actorId }: ActorGeneralProps) {
 								actorId={actorId}
 							/>
 						</Dd>
-						<Dt>Keys</Dt>
-						<Dd>
-							<Flex
-								direction="col"
-								gap="2"
-								className="flex-1 min-w-0"
-								w="full"
-							>
-								<ActorObjectInspector
-									data={keys}
-									expandPaths={["$"]}
-								/>
-							</Flex>
+						<Dt>Key</Dt>
+						<Dd className="text-mono">
+							{keys ? (
+								<DiscreteCopyButton
+									size="xs"
+									value={keys}
+									className="-mx-2 h-auto"
+								>
+									{keys}
+								</DiscreteCopyButton>
+							) : (
+								<span className="text-muted-foreground">-</span>
+							)}
 						</Dd>
 						{runner ? (
 							<>
@@ -129,7 +128,7 @@ export function ActorGeneral({ actorId }: ActorGeneralProps) {
 						) : null}
 						{connectableTs ? (
 							<>
-								<Dt>Connectable</Dt>
+								<Dt>Connectable since</Dt>
 								<Dd>
 									<TimestampValue ts={connectableTs} />
 								</Dd>
@@ -137,7 +136,7 @@ export function ActorGeneral({ actorId }: ActorGeneralProps) {
 						) : null}
 						{sleepTs ? (
 							<>
-								<Dt>Sleeping</Dt>
+								<Dt>Sleeping since</Dt>
 								<Dd>
 									<TimestampValue ts={sleepTs} />
 								</Dd>

--- a/frontend/src/components/actors/actor-queue.tsx
+++ b/frontend/src/components/actors/actor-queue.tsx
@@ -1,4 +1,4 @@
-import { faSpinnerThird, Icon } from "@rivet-gg/icons";
+import { faInbox, faSpinnerThird, Icon } from "@rivet-gg/icons";
 import { useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { LiveBadge, ScrollArea } from "@/components";
@@ -53,8 +53,18 @@ export function ActorQueue({ actorId }: { actorId: ActorId }) {
 			</div>
 			<div className="p-3 space-y-2">
 				{status.messages.length === 0 ? (
-					<div className="text-sm text-muted-foreground">
-						Queue is empty.
+					<div className="flex flex-col items-center justify-center p-8 text-center">
+						<div className="mb-3 flex size-11 items-center justify-center rounded-full bg-muted">
+							<Icon
+								icon={faInbox}
+								className="text-muted-foreground"
+							/>
+						</div>
+						<h3 className="font-medium">Queue is empty</h3>
+						<p className="mt-1 max-w-sm text-sm text-muted-foreground">
+							Messages waiting to be processed by this actor will
+							appear here.
+						</p>
 					</div>
 				) : (
 					status.messages.map((message) => (

--- a/frontend/src/components/actors/actors-list.tsx
+++ b/frontend/src/components/actors/actors-list.tsx
@@ -517,11 +517,13 @@ function EmptyState({ count }: { count: number }) {
 						</Button>
 					</>
 				)
-			) : (
+			) : count > RECORDS_PER_PAGE ? (
+				// Only worth saying once the user has actually scrolled through
+				// more than one page; for short lists it is just noise.
 				<SmallText className="text-muted-foreground text-center text-xs">
 					{copy.noMoreActors}
 				</SmallText>
-			)}
+			) : null}
 		</div>
 	);
 }

--- a/frontend/src/components/actors/inspector-tab-registry.tsx
+++ b/frontend/src/components/actors/inspector-tab-registry.tsx
@@ -75,9 +75,13 @@ interface TabRegistration {
 	render: (actorId: ActorId) => ReactNode;
 }
 
-// Tab list — preserved order matches the dashboard tab strip. Adding a new
-// inspector tab here automatically advertises it to the dashboard (in the
-// iframe path) and renders it inline (in the legacy path).
+// Tab list — preserved order matches the dashboard tab strip, and the first
+// available tab is the default the dashboard opens. State sits before
+// Database on purpose: every actor has a SQLite database (so Database would
+// otherwise always win), but the state object is what the actor's code
+// actually defines. Adding a new inspector tab here automatically advertises
+// it to the dashboard (in the iframe path) and renders it inline (in the
+// legacy path).
 export const INSPECTOR_TAB_REGISTRATIONS: readonly TabRegistration[] = [
 	{
 		descriptor: { id: "workflow", label: "Workflow", icon: "workflow" },
@@ -85,14 +89,14 @@ export const INSPECTOR_TAB_REGISTRATIONS: readonly TabRegistration[] = [
 		render: (actorId) => <ActorWorkflowTab actorId={actorId} />,
 	},
 	{
-		descriptor: { id: "database", label: "Database", icon: "database" },
-		available: (caps) => caps.isDatabaseEnabled,
-		render: (actorId) => <ActorDatabaseTab actorId={actorId} />,
-	},
-	{
 		descriptor: { id: "state", label: "State", icon: "state" },
 		available: (caps) => caps.isStateEnabled,
 		render: (actorId) => <ActorStateTab actorId={actorId} />,
+	},
+	{
+		descriptor: { id: "database", label: "Database", icon: "database" },
+		available: (caps) => caps.isDatabaseEnabled,
+		render: (actorId) => <ActorDatabaseTab actorId={actorId} />,
 	},
 	{
 		descriptor: { id: "queue", label: "Queue", icon: "queue" },

--- a/frontend/src/components/actors/no-providers-alert.tsx
+++ b/frontend/src/components/actors/no-providers-alert.tsx
@@ -1,4 +1,4 @@
-import { faBook, faExclamationTriangle, faPlus, Icon } from "@rivet-gg/icons";
+import { faBook, faPlug, faPlus, Icon } from "@rivet-gg/icons";
 import { Link } from "@tanstack/react-router";
 import { ProviderDropdown } from "@/app/provider-dropdown";
 import { docsLinks } from "@/content/data";
@@ -16,14 +16,14 @@ export function NoProvidersAlert({
 			<div>
 				<H4>
 					<Icon
-						icon={faExclamationTriangle}
+						icon={faPlug}
 						className="mr-2 text-muted-foreground"
 					/>
-					No Providers Connected
+					No providers connected
 				</H4>
 				<p className="text-sm text-muted-foreground mt-1 mb-2 pl-7">
-					You can't run any Actors yet. Use provider of your choice to
-					connect and start deploying and running Rivet Actors.
+					Actors need somewhere to run. Add a provider to connect a
+					cloud of your choice and start running Rivet Actors.
 				</p>
 			</div>
 			<div className="flex flex-col items-center justify-center gap-2">
@@ -65,7 +65,7 @@ export function NoProvidersAlert({
 							size="sm"
 							className="w-full"
 						>
-							Connect Provider
+							Add Provider
 						</Button>
 					</ProviderDropdown>
 				)}

--- a/frontend/src/components/live-badge.tsx
+++ b/frontend/src/components/live-badge.tsx
@@ -11,7 +11,8 @@ export function LiveBadge({ className }: LiveBadgeProps) {
 			className={cn(className, "flex justify-center items-center")}
 			variant="outline"
 		>
-			<div className="mr-2 bg-destructive rounded-full animate-pulse size-2" />
+			{/* Accent, not destructive: red reads as an error elsewhere in the app. */}
+			<div className="mr-2 bg-primary rounded-full animate-pulse size-2" />
 			Live
 		</Badge>
 	);

--- a/frontend/src/routes/_context.tsx
+++ b/frontend/src/routes/_context.tsx
@@ -44,7 +44,16 @@ const searchSchema = z
 export const Route = createFileRoute("/_context")({
 	component: RouteComponent,
 	validateSearch: (search) => {
-		const validated = searchSchema.parse(search);
+		// Hand-typed and shared links often carry `?n=counter` instead of the
+		// serialized array form. Accept both so a bare string never surfaces
+		// as a raw validation error page. Normalized before parsing because
+		// the schema is an intersection, and a per-field transform would
+		// conflict with the untouched value from the `z.record` half.
+		const normalized =
+			typeof search.n === "string"
+				? { ...search, n: [search.n] }
+				: search;
+		const validated = searchSchema.parse(normalized);
 		// `pool` is scoped to the pages that actually use it: the Logs route
 		// re-declares it in its own validateSearch, and the compute settings tab
 		// needs it while open. Drop it everywhere else so the selected pool does


### PR DESCRIPTION
# Description

Follow-ups from a design/flow audit of the OSS dashboard and actor Inspector. Small, self-contained polish; no API or schema changes. Product-constant and brand SVG changes were deliberately left out to avoid conflicting with #5633 and #5672.

**Inspector**
- **State is the default tab** (Workflow for workflow actors). Every actor has a SQLite DB, so Database always won before. The dashboard now canonicalizes the tab order advertised by the runner's inspector bundle (`orderInspectorTabs`), so older runners get the same order without a rebuild; custom tabs keep their advertised order after the built-ins.
- **Database tab**: user tables first, `_rivet_*` tables grouped under an "Internal" label, first user table selected by default.
- **Connections tab**: table (ID, type, hibernatable, params, state) with a proper empty state instead of a raw object tree.
- **Queue tab**: empty state matches Schedules (icon + heading + hint).
- **Metadata**: Key rendered as copyable mono text instead of a JSON tree; "Connectable since" / "Sleeping since" labels.

**Dashboard shell**
- OSS top bar gets a light/dark toggle (cloud keeps it in the user dropdown).
- `?n=counter` (plain string instead of the serialized array) renders instead of a Zod error page. Normalized in `validateSearch` because the search schema is an intersection with `z.record`, which rejects a per-field transform.
- Provider/runner copy no longer references "Rivet Cloud" in OSS; no-providers alert uses a plug icon and "Add Provider"; settings drawer description is flavor-aware; empty-row text is consistent between the Providers and Runners tables.
- Live badge dot uses `primary` instead of `destructive`.
- "No more Actors to load." only shows once more than one page has been loaded.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- `tsc --noEmit` in `frontend/`: same 42 pre-existing error lines before and after (none in touched files).
- `biome check` on all touched files: formatting clean; remaining lint findings are on untouched lines.
- Visual verification against a local engine (rivetkit 2.3.15) with seeded actors, OSS flavor. Tab reorder verified on the real iframe path; the in-iframe tab components (Database/Queue/Connections) are compiled into the rivetkit NAPI bundle, so they were verified by temporarily forcing the dashboard's legacy inline path (not committed).
- Cloud flavor compiles; not rendered (no cloud login available).

### Before / after

Default tab + list footer
![default](https://ampcode.com/user-content/artifacts/a371a2892fd03e0350947258c0172e5d7085c43d52abbf8cfea4178f2e10b49c-file.png)

Database tab
![database](https://ampcode.com/user-content/artifacts/ee24e386cb22710f8bd108d9783d13f210cecbc337f945e541ff1507b4e17a01-file.png)

Connections tab (the 2 vs 1 count is from re-running the seed client between shots, not a UI difference)
![connections](https://ampcode.com/user-content/artifacts/7490859b502884d0fd1665bd255f41a840c91731619f0170c5a927c859d1bb19-file.png)

Queue empty state
![queue](https://ampcode.com/user-content/artifacts/1398f095b67f7e86e8bb6e952a2512dabc2b6344a909c9e82b66188a5d9e8703-file.png)

Metadata
![metadata](https://ampcode.com/user-content/artifacts/e6180d99dad6509c994113a516f119e53f6d52599811c1ad2238cae5fc3256b3-file.png)

Namespace settings (empty namespace) + theme toggle
![settings](https://ampcode.com/user-content/artifacts/91caff606bfb55ae4713f3ee1dc4cb1867e1deb7cdbfeb2d44dd364edd8e8f98-file.png)

`?n=counter`
![n-string](https://ampcode.com/user-content/artifacts/81d43b778acd3c8349cce374acf2ff1476d852255e5e94d84dd65f0e2b5ab4bb-file.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
