### PR TITLE
fix(guard): disable admission limits by default

### DIFF
--- a/docs/content/docs/limits.mdx
+++ b/docs/content/docs/limits.mdx
@@ -132,8 +132,8 @@ See [Actor Input](/actors/docs/input) for details.
 
 | Name | Soft Limit | Hard Limit | Description |
 |------|------------|------------|-------------|
-| Rate limit | — | 1200 requests/minute | Default rate limit per actor per IP address with a 1 minute time bucket. |
-| Max in-flight requests | — | 32 | Default maximum concurrent requests to an actor per IP address. |
+| Rate limit | — | — | Disabled by default. Configure `guard.rate_limit` to apply a fixed-window limit per source IP. |
+| Max in-flight requests | — | — | Disabled by default. Configure `guard.max_in_flight` to limit concurrent requests per source IP. |
 
 ### Timeouts
 

--- a/engine/artifacts/config-schema.json
+++ b/engine/artifacts/config-schema.json
@@ -542,6 +542,24 @@
           "format": "uint64",
           "minimum": 0.0
         },
+        "admission_client_state_cache_capacity": {
+          "description": "Maximum number of IP-keyed admission state entries when an admission limit is enabled.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "admission_client_state_cache_idle_timeout_ms": {
+          "description": "Idle timeout for IP-keyed admission state in milliseconds.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
         "enable_websocket_health_route": {
           "description": "Enables the internal websocket health route for debug and latency testing. This is intended for websocket ping/pong verification and should remain disabled in normal deployments.",
           "type": [
@@ -556,6 +574,15 @@
             "null"
           ],
           "format": "ip"
+        },
+        "http_client_pool_idle_timeout_ms": {
+          "description": "Idle timeout for pooled upstream HTTP connections in milliseconds.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
         },
         "http_max_request_body_size": {
           "description": "Max HTTP request body size in bytes (first line of defense).",
@@ -577,6 +604,15 @@
             }
           ]
         },
+        "max_in_flight": {
+          "description": "Maximum concurrent requests applied per client IP. Omit to disable the in-flight limit.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 1.0
+        },
         "port": {
           "description": "Port for HTTP traffic",
           "type": [
@@ -585,6 +621,35 @@
           ],
           "format": "uint16",
           "minimum": 0.0
+        },
+        "proxy_retry_initial_interval_ms": {
+          "description": "Initial exponential retry backoff in milliseconds.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "proxy_retry_max_attempts": {
+          "description": "Maximum number of proxy attempts, including the initial attempt.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 1.0
+        },
+        "rate_limit": {
+          "description": "Fixed-window request limit applied per client IP. Omit to disable request rate limiting.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/GuardRateLimit"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "route_api_public_timeout_ms": {
           "description": "Timeout for resolving api-public routes in milliseconds.",
@@ -699,6 +764,33 @@
             "null"
           ]
         },
+        "upstream_request_timeout_ms": {
+          "description": "Timeout for receiving upstream HTTP response headers in milliseconds.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "websocket_connect_attempt_timeout_ms": {
+          "description": "Timeout for each upstream WebSocket connection attempt in milliseconds.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "websocket_flush_timeout_ms": {
+          "description": "Timeout for flushing forwarded WebSocket messages in milliseconds.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
         "websocket_max_frame_size": {
           "description": "Max WebSocket frame size in bytes.",
           "type": [
@@ -716,6 +808,24 @@
           ],
           "format": "uint",
           "minimum": 0.0
+        },
+        "websocket_send_timeout_ms": {
+          "description": "Timeout for forwarding a WebSocket message in milliseconds.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "websocket_setup_timeout_ms": {
+          "description": "Timeout for completing the client WebSocket upgrade in milliseconds.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
         }
       },
       "additionalProperties": false
@@ -748,6 +858,28 @@
         "opportunistic",
         "on"
       ]
+    },
+    "GuardRateLimit": {
+      "type": "object",
+      "required": [
+        "period_ms",
+        "requests"
+      ],
+      "properties": {
+        "period_ms": {
+          "description": "Fixed-window duration in milliseconds.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "requests": {
+          "description": "Number of requests allowed during each fixed window.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 1.0
+        }
+      },
+      "additionalProperties": false
     },
     "Https": {
       "type": "object",

--- a/engine/artifacts/errors/guard.max_in_flight.json
+++ b/engine/artifacts/errors/guard.max_in_flight.json
@@ -1,0 +1,5 @@
+{
+  "code": "max_in_flight",
+  "group": "guard",
+  "message": "Too many concurrent requests. Try again later."
+}

--- a/engine/packages/config/src/config/guard.rs
+++ b/engine/packages/config/src/config/guard.rs
@@ -1,9 +1,21 @@
+use anyhow::{Result, bail};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{net::IpAddr, path::PathBuf};
 
 pub const DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
 pub const DEFAULT_WEBSOCKET_MAX_FRAME_SIZE: usize = 32 * 1024 * 1024;
+
+const DEFAULT_PROXY_RETRY_MAX_ATTEMPTS: u32 = 7;
+const DEFAULT_PROXY_RETRY_INITIAL_INTERVAL_MS: u64 = 150;
+const DEFAULT_UPSTREAM_REQUEST_TIMEOUT_MS: u64 = 30_000;
+const DEFAULT_WEBSOCKET_SETUP_TIMEOUT_MS: u64 = 30_000;
+const DEFAULT_WEBSOCKET_CONNECT_ATTEMPT_TIMEOUT_MS: u64 = 5_000;
+const DEFAULT_WEBSOCKET_SEND_TIMEOUT_MS: u64 = 5_000;
+const DEFAULT_WEBSOCKET_FLUSH_TIMEOUT_MS: u64 = 2_000;
+const DEFAULT_HTTP_CLIENT_POOL_IDLE_TIMEOUT_MS: u64 = 30_000;
+const DEFAULT_ADMISSION_CLIENT_STATE_CACHE_CAPACITY: u64 = 10_000;
+const DEFAULT_ADMISSION_CLIENT_STATE_CACHE_IDLE_TIMEOUT_MS: u64 = 60 * 60 * 1_000;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -44,6 +56,43 @@ pub struct Guard {
 	pub actor_ready_timeout_ms: Option<u64>,
 	/// Timeout sent with actor force-wake requests in milliseconds.
 	pub actor_force_wake_pending_timeout_ms: Option<i64>,
+
+	/// Fixed-window request limit applied per client IP. Omit to disable request rate limiting.
+	pub rate_limit: Option<GuardRateLimit>,
+	/// Maximum concurrent requests applied per client IP. Omit to disable the in-flight limit.
+	#[schemars(range(min = 1))]
+	pub max_in_flight: Option<usize>,
+	/// Maximum number of proxy attempts, including the initial attempt.
+	#[schemars(range(min = 1))]
+	pub proxy_retry_max_attempts: Option<u32>,
+	/// Initial exponential retry backoff in milliseconds.
+	#[schemars(range(min = 1))]
+	pub proxy_retry_initial_interval_ms: Option<u64>,
+	/// Timeout for receiving upstream HTTP response headers in milliseconds.
+	#[schemars(range(min = 1))]
+	pub upstream_request_timeout_ms: Option<u64>,
+	/// Timeout for completing the client WebSocket upgrade in milliseconds.
+	#[schemars(range(min = 1))]
+	pub websocket_setup_timeout_ms: Option<u64>,
+	/// Timeout for each upstream WebSocket connection attempt in milliseconds.
+	#[schemars(range(min = 1))]
+	pub websocket_connect_attempt_timeout_ms: Option<u64>,
+	/// Timeout for forwarding a WebSocket message in milliseconds.
+	#[schemars(range(min = 1))]
+	pub websocket_send_timeout_ms: Option<u64>,
+	/// Timeout for flushing forwarded WebSocket messages in milliseconds.
+	#[schemars(range(min = 1))]
+	pub websocket_flush_timeout_ms: Option<u64>,
+	/// Idle timeout for pooled upstream HTTP connections in milliseconds.
+	#[schemars(range(min = 1))]
+	pub http_client_pool_idle_timeout_ms: Option<u64>,
+	/// Maximum number of IP-keyed admission state entries when an admission limit is enabled.
+	#[schemars(range(min = 1))]
+	pub admission_client_state_cache_capacity: Option<u64>,
+	/// Idle timeout for IP-keyed admission state in milliseconds.
+	#[schemars(range(min = 1))]
+	pub admission_client_state_cache_idle_timeout_ms: Option<u64>,
+
 	/// Enable & configure HTTPS
 	pub https: Option<Https>,
 
@@ -60,6 +109,67 @@ pub struct Guard {
 }
 
 impl Guard {
+	pub fn validate(&self) -> Result<()> {
+		if let Some(rate_limit) = &self.rate_limit {
+			if rate_limit.requests == 0 {
+				bail!("guard.rate_limit.requests must be greater than 0");
+			}
+			if rate_limit.period_ms == 0 {
+				bail!("guard.rate_limit.period_ms must be greater than 0");
+			}
+		}
+
+		if self.max_in_flight == Some(0) {
+			bail!("guard.max_in_flight must be greater than 0");
+		}
+
+		for (name, value) in [
+			(
+				"proxy_retry_max_attempts",
+				self.proxy_retry_max_attempts.map(u64::from),
+			),
+			(
+				"proxy_retry_initial_interval_ms",
+				self.proxy_retry_initial_interval_ms,
+			),
+			(
+				"upstream_request_timeout_ms",
+				self.upstream_request_timeout_ms,
+			),
+			(
+				"websocket_setup_timeout_ms",
+				self.websocket_setup_timeout_ms,
+			),
+			(
+				"websocket_connect_attempt_timeout_ms",
+				self.websocket_connect_attempt_timeout_ms,
+			),
+			("websocket_send_timeout_ms", self.websocket_send_timeout_ms),
+			(
+				"websocket_flush_timeout_ms",
+				self.websocket_flush_timeout_ms,
+			),
+			(
+				"http_client_pool_idle_timeout_ms",
+				self.http_client_pool_idle_timeout_ms,
+			),
+			(
+				"admission_client_state_cache_capacity",
+				self.admission_client_state_cache_capacity,
+			),
+			(
+				"admission_client_state_cache_idle_timeout_ms",
+				self.admission_client_state_cache_idle_timeout_ms,
+			),
+		] {
+			if value == Some(0) {
+				bail!("guard.{name} must be greater than 0");
+			}
+		}
+
+		Ok(())
+	}
+
 	pub fn host(&self) -> IpAddr {
 		self.host.unwrap_or(crate::defaults::hosts::GUARD)
 	}
@@ -138,6 +248,78 @@ impl Guard {
 			.unwrap_or(60 * 1000)
 	}
 
+	pub fn rate_limit(&self) -> Option<&GuardRateLimit> {
+		self.rate_limit.as_ref()
+	}
+
+	pub fn max_in_flight(&self) -> Option<usize> {
+		self.max_in_flight
+	}
+
+	pub fn proxy_retry_max_attempts(&self) -> u32 {
+		self.proxy_retry_max_attempts
+			.unwrap_or(DEFAULT_PROXY_RETRY_MAX_ATTEMPTS)
+	}
+
+	pub fn proxy_retry_initial_interval_ms(&self) -> u64 {
+		self.proxy_retry_initial_interval_ms
+			.unwrap_or(DEFAULT_PROXY_RETRY_INITIAL_INTERVAL_MS)
+	}
+
+	pub fn upstream_request_timeout(&self) -> std::time::Duration {
+		std::time::Duration::from_millis(
+			self.upstream_request_timeout_ms
+				.unwrap_or(DEFAULT_UPSTREAM_REQUEST_TIMEOUT_MS),
+		)
+	}
+
+	pub fn websocket_setup_timeout(&self) -> std::time::Duration {
+		std::time::Duration::from_millis(
+			self.websocket_setup_timeout_ms
+				.unwrap_or(DEFAULT_WEBSOCKET_SETUP_TIMEOUT_MS),
+		)
+	}
+
+	pub fn websocket_connect_attempt_timeout(&self) -> std::time::Duration {
+		std::time::Duration::from_millis(
+			self.websocket_connect_attempt_timeout_ms
+				.unwrap_or(DEFAULT_WEBSOCKET_CONNECT_ATTEMPT_TIMEOUT_MS),
+		)
+	}
+
+	pub fn websocket_send_timeout(&self) -> std::time::Duration {
+		std::time::Duration::from_millis(
+			self.websocket_send_timeout_ms
+				.unwrap_or(DEFAULT_WEBSOCKET_SEND_TIMEOUT_MS),
+		)
+	}
+
+	pub fn websocket_flush_timeout(&self) -> std::time::Duration {
+		std::time::Duration::from_millis(
+			self.websocket_flush_timeout_ms
+				.unwrap_or(DEFAULT_WEBSOCKET_FLUSH_TIMEOUT_MS),
+		)
+	}
+
+	pub fn http_client_pool_idle_timeout(&self) -> std::time::Duration {
+		std::time::Duration::from_millis(
+			self.http_client_pool_idle_timeout_ms
+				.unwrap_or(DEFAULT_HTTP_CLIENT_POOL_IDLE_TIMEOUT_MS),
+		)
+	}
+
+	pub fn admission_client_state_cache_capacity(&self) -> u64 {
+		self.admission_client_state_cache_capacity
+			.unwrap_or(DEFAULT_ADMISSION_CLIENT_STATE_CACHE_CAPACITY)
+	}
+
+	pub fn admission_client_state_cache_idle_timeout(&self) -> std::time::Duration {
+		std::time::Duration::from_millis(
+			self.admission_client_state_cache_idle_timeout_ms
+				.unwrap_or(DEFAULT_ADMISSION_CLIENT_STATE_CACHE_IDLE_TIMEOUT_MS),
+		)
+	}
+
 	pub fn http_max_request_body_size(&self) -> usize {
 		self.http_max_request_body_size.unwrap_or(20 * 1024 * 1024) // 20 MiB
 	}
@@ -159,6 +341,17 @@ impl Guard {
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 #[serde(deny_unknown_fields)]
+pub struct GuardRateLimit {
+	/// Number of requests allowed during each fixed window.
+	#[schemars(range(min = 1))]
+	pub requests: u64,
+	/// Fixed-window duration in milliseconds.
+	#[schemars(range(min = 1))]
+	pub period_ms: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
 #[derive(Default)]
 pub struct Https {
 	pub port: u16, // Port for HTTPS traffic
@@ -173,4 +366,72 @@ pub struct Tls {
 	pub actor_key_path: PathBuf,
 	pub api_cert_path: PathBuf,
 	pub api_key_path: PathBuf,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn admission_limits_are_disabled_by_default() {
+		let guard = Guard::default();
+
+		assert!(guard.rate_limit().is_none());
+		assert!(guard.max_in_flight().is_none());
+	}
+
+	#[test]
+	fn proxy_operational_defaults_preserve_existing_behavior() {
+		let guard = Guard::default();
+
+		assert_eq!(guard.proxy_retry_max_attempts(), 7);
+		assert_eq!(guard.proxy_retry_initial_interval_ms(), 150);
+		assert_eq!(
+			guard.upstream_request_timeout(),
+			std::time::Duration::from_secs(30)
+		);
+		assert_eq!(
+			guard.websocket_setup_timeout(),
+			std::time::Duration::from_secs(30)
+		);
+		assert_eq!(
+			guard.websocket_connect_attempt_timeout(),
+			std::time::Duration::from_secs(5)
+		);
+		assert_eq!(
+			guard.websocket_send_timeout(),
+			std::time::Duration::from_secs(5)
+		);
+		assert_eq!(
+			guard.websocket_flush_timeout(),
+			std::time::Duration::from_secs(2)
+		);
+		assert_eq!(
+			guard.http_client_pool_idle_timeout(),
+			std::time::Duration::from_secs(30)
+		);
+		assert_eq!(guard.admission_client_state_cache_capacity(), 10_000);
+		assert_eq!(
+			guard.admission_client_state_cache_idle_timeout(),
+			std::time::Duration::from_secs(60 * 60)
+		);
+	}
+
+	#[test]
+	fn admission_limits_reject_zero_values() {
+		let guard = Guard {
+			rate_limit: Some(GuardRateLimit {
+				requests: 0,
+				period_ms: 60_000,
+			}),
+			..Default::default()
+		};
+		assert!(guard.validate().is_err());
+
+		let guard = Guard {
+			max_in_flight: Some(0),
+			..Default::default()
+		};
+		assert!(guard.validate().is_err());
+	}
 }

--- a/engine/packages/config/src/config/mod.rs
+++ b/engine/packages/config/src/config/mod.rs
@@ -262,6 +262,7 @@ impl Root {
 			pg.nats = Some(nats);
 		}
 
+		self.guard().validate()?;
 		self.pegboard().validate()?;
 		self.features().validate()?;
 		self.sqlite().validate()?;

--- a/engine/packages/guard-core/src/errors.rs
+++ b/engine/packages/guard-core/src/errors.rs
@@ -28,12 +28,28 @@ pub struct InvalidResponseBody {
 	"guard",
 	"rate_limit",
 	"Too many requests. Try again later.",
-	"Too many requests to '{method} {path}' from IP {ip}."
+	"Too many requests to '{method} {path}' from IP {ip}; limit is {requests} requests per {period_ms} ms."
 )]
 pub struct RateLimit {
 	pub method: String,
 	pub path: String,
 	pub ip: String,
+	pub requests: u64,
+	pub period_ms: u64,
+}
+
+#[derive(RivetError, Serialize, Deserialize)]
+#[error(
+	"guard",
+	"max_in_flight",
+	"Too many concurrent requests. Try again later.",
+	"Too many concurrent requests to '{method} {path}' from IP {ip}; limit is {max_in_flight}."
+)]
+pub struct MaxInFlight {
+	pub method: String,
+	pub path: String,
+	pub ip: String,
+	pub max_in_flight: usize,
 }
 
 #[derive(RivetError, Serialize, Deserialize)]

--- a/engine/packages/guard-core/src/proxy_service.rs
+++ b/engine/packages/guard-core/src/proxy_service.rs
@@ -35,7 +35,7 @@ use crate::RouteTarget;
 use crate::request_context::RequestContext;
 use crate::response_body::ResponseBody;
 use crate::route::{CacheKeyFn, ResolveRouteOutput, RouteCache, RoutingFn, RoutingOutput};
-use crate::utils::{ClientState, InFlightPermit};
+use crate::utils::{AdmissionRejection, ClientState, InFlightPermit};
 use crate::{
 	WebSocketHandle, custom_serve::HibernationResult, errors, metrics, task_group::TaskGroup, utils,
 };
@@ -43,13 +43,6 @@ use crate::{
 pub const X_FORWARDED_FOR: HeaderName = HeaderName::from_static("x-forwarded-for");
 pub const X_RIVET_ERROR: HeaderName = HeaderName::from_static("x-rivet-error");
 
-/// How long a client's throttling state is kept after its last request.
-///
-/// This is an idle timeout rather than a live timeout so that a client which keeps sending traffic
-/// keeps its rate limit window and in-flight count. Expiring an active client would refill its rate
-/// limit window early, and would reset its in-flight count to zero while its existing requests are
-/// still running.
-const CLIENT_STATE_CACHE_IDLE_TIMEOUT: Duration = Duration::from_secs(60 * 60); // 1 hour
 const WEBSOCKET_CLOSE_LINGER: Duration = Duration::from_millis(5); // Keep TCP connection open briefly after WebSocket close
 
 fn websocket_config(guard_config: &rivet_config::config::guard::Guard) -> WebSocketConfig {
@@ -71,10 +64,9 @@ pub struct ProxyState {
 	>,
 	route_cache: RouteCache,
 	// We use moka::Cache instead of scc::HashMap because it automatically handles TTL and capacity
-	client_states: Cache<std::net::IpAddr, Arc<parking_lot::Mutex<ClientState>>>,
-	// Entries are owned by an InFlightPermit, so this is bounded by the per-client in-flight limits
-	// and does not need its own capacity or TTL eviction. Evicting a live entry here would let its
-	// request id be handed out to a second concurrent request.
+	client_states: Option<Cache<std::net::IpAddr, Arc<parking_lot::Mutex<ClientState>>>>,
+	// Entries are owned by an InFlightPermit for the lifetime of each active request, so live IDs
+	// cannot be evicted and handed out to a second concurrent request.
 	in_flight_requests: Arc<scc::HashSet<protocol::RequestId>>,
 
 	tasks: Arc<TaskGroup>,
@@ -86,6 +78,7 @@ impl ProxyState {
 		routing_fn: RoutingFn,
 		cache_key_fn: CacheKeyFn,
 	) -> Self {
+		let guard_config = config.guard();
 		let https_connector_builder =
 			match hyper_rustls::HttpsConnectorBuilder::new().with_native_roots() {
 				Ok(builder) => builder,
@@ -103,9 +96,22 @@ impl ProxyState {
 			.enable_http2()
 			.build();
 		let client = Client::builder(TokioExecutor::new())
-			.pool_idle_timeout(Duration::from_secs(30))
+			.pool_idle_timeout(guard_config.http_client_pool_idle_timeout())
 			.build(https_connector);
-		let route_cache_ttl = config.guard().route_cache_ttl();
+		let route_cache_ttl = guard_config.route_cache_ttl();
+		let client_states =
+			if guard_config.rate_limit().is_some() || guard_config.max_in_flight().is_some() {
+				Some(
+					Cache::builder()
+						.max_capacity(guard_config.admission_client_state_cache_capacity())
+						.time_to_idle(guard_config.admission_client_state_cache_idle_timeout())
+						.build(),
+				)
+			} else {
+				metrics::RATE_LIMITER_COUNT.set(0);
+				metrics::IN_FLIGHT_COUNTER_COUNT.set(0);
+				None
+			};
 
 		Self {
 			config,
@@ -113,10 +119,7 @@ impl ProxyState {
 			cache_key_fn,
 			client,
 			route_cache: RouteCache::new(route_cache_ttl),
-			client_states: Cache::builder()
-				.max_capacity(10_000)
-				.time_to_idle(CLIENT_STATE_CACHE_IDLE_TIMEOUT)
-				.build(),
+			client_states,
 			in_flight_requests: Arc::new(scc::HashSet::new()),
 			tasks: TaskGroup::new(),
 		}
@@ -224,40 +227,56 @@ impl ProxyState {
 
 	/// Get the throttling state for a client, creating it if it does not exist yet.
 	#[tracing::instrument(level = "debug", skip_all)]
-	async fn client_state(&self, req_ctx: &RequestContext) -> Arc<parking_lot::Mutex<ClientState>> {
-		let entry = self
-			.client_states
+	async fn client_state(
+		&self,
+		req_ctx: &RequestContext,
+	) -> Option<Arc<parking_lot::Mutex<ClientState>>> {
+		let client_states = self.client_states.as_ref()?;
+		let guard_config = self.config.guard();
+		let entry = client_states
 			.entry(req_ctx.client_ip)
 			.or_insert_with(async {
 				Arc::new(parking_lot::Mutex::new(ClientState::new(
-					req_ctx.rate_limit.requests,
-					req_ctx.rate_limit.period,
-					req_ctx.max_in_flight.amount,
+					guard_config.rate_limit().map(|rate_limit| {
+						(
+							rate_limit.requests,
+							Duration::from_millis(rate_limit.period_ms),
+						)
+					}),
+					guard_config.max_in_flight(),
 				)))
 			})
 			.await;
 
 		if entry.is_fresh() {
-			// Each entry holds both a rate limiter and an in-flight counter
-			let count = self.client_states.entry_count() as i64;
-			metrics::RATE_LIMITER_COUNT.set(count);
-			metrics::IN_FLIGHT_COUNTER_COUNT.set(count);
+			let count = client_states.entry_count() as i64;
+			if guard_config.rate_limit().is_some() {
+				metrics::RATE_LIMITER_COUNT.set(count);
+			}
+			if guard_config.max_in_flight().is_some() {
+				metrics::IN_FLIGHT_COUNTER_COUNT.set(count);
+			}
 		}
 
-		entry.into_value()
+		Some(entry.into_value())
 	}
 
-	/// Admits a request under the client's rate limit and in-flight limit, assigning it a unique
-	/// request id. Returns false if either limit was hit.
+	/// Applies configured admission controls and assigns a unique protocol request ID. Request IDs
+	/// are allocated even when both admission controls are disabled.
 	///
 	/// On success the in-flight slot and the request id are owned by the permit stored on the
 	/// request context, and are released once every clone of that context is dropped.
 	#[tracing::instrument(level = "debug", skip_all)]
-	async fn try_admit_request(&self, req_ctx: &mut RequestContext) -> Result<bool> {
+	async fn admit_request(
+		&self,
+		req_ctx: &mut RequestContext,
+	) -> Result<Option<AdmissionRejection>> {
 		let client_state = self.client_state(req_ctx).await;
 
-		if !client_state.lock().try_admit() {
-			return Ok(false);
+		if let Some(client_state) = &client_state
+			&& let Err(rejection) = client_state.lock().try_admit()
+		{
+			return Ok(Some(rejection));
 		}
 
 		// The in-flight slot is held but not owned by anything yet. There are no await points before
@@ -266,7 +285,9 @@ impl ProxyState {
 		let request_id = match self.generate_unique_in_flight_request_id() {
 			Ok(request_id) => request_id,
 			Err(err) => {
-				client_state.lock().release_in_flight();
+				if let Some(client_state) = &client_state {
+					client_state.lock().release_in_flight();
+				}
 				return Err(err);
 			}
 		};
@@ -277,7 +298,7 @@ impl ProxyState {
 			request_id,
 		)));
 
-		Ok(true)
+		Ok(None)
 	}
 
 	/// Generate a request ID that is not currently in flight.
@@ -420,6 +441,7 @@ impl ProxyService {
 			client_ip,
 			start_time,
 			self.client_disconnect.clone(),
+			self.state.config.guard(),
 		);
 		req_ctx.set_request_body_metadata(request_body_exact_size, request_body_is_end_stream);
 
@@ -694,16 +716,41 @@ impl ProxyService {
 
 		let target = target_res?;
 
-		// Apply rate limiting and in-flight limits, and assign the protocol request ID. The permit
-		// lives on the request context and releases the in-flight slot and request ID when the
-		// context is dropped.
-		if !self.state.try_admit_request(req_ctx).await? {
-			return Err(errors::RateLimit {
-				method: req_ctx.method.to_string(),
-				path: req_ctx.path.clone(),
-				ip: req_ctx.client_ip.to_string(),
-			}
-			.build());
+		// Apply configured admission controls and assign the protocol request ID. The permit lives
+		// on the request context and releases any in-flight slot plus the request ID when the context
+		// is dropped.
+		if let Some(rejection) = self.state.admit_request(req_ctx).await? {
+			return match rejection {
+				AdmissionRejection::RateLimit => {
+					let rate_limit = self
+						.state
+						.config
+						.guard()
+						.rate_limit()
+						.context("rate limit rejected request without rate limit config")?;
+					Err(errors::RateLimit {
+						method: req_ctx.method.to_string(),
+						path: req_ctx.path.clone(),
+						ip: req_ctx.client_ip.to_string(),
+						requests: rate_limit.requests,
+						period_ms: rate_limit.period_ms,
+					}
+					.build())
+				}
+				AdmissionRejection::MaxInFlight => {
+					let max_in_flight =
+						self.state.config.guard().max_in_flight().context(
+							"in-flight limit rejected request without max-in-flight config",
+						)?;
+					Err(errors::MaxInFlight {
+						method: req_ctx.method.to_string(),
+						path: req_ctx.path.clone(),
+						ip: req_ctx.client_ip.to_string(),
+						max_in_flight,
+					}
+					.build())
+				}
+			};
 		}
 
 		// Increment metrics
@@ -739,7 +786,7 @@ impl ProxyService {
 		resolved_route: ResolveRouteOutput,
 	) -> Result<Response<ResponseBody>> {
 		// Set up retry with backoff
-		let timeout_duration = Duration::from_secs(req_ctx.timeout.request_timeout);
+		let timeout_duration = req_ctx.timeout.request_timeout;
 
 		match resolved_route {
 			ResolveRouteOutput::Target(mut target) => {
@@ -1075,8 +1122,7 @@ impl ProxyService {
 						let _active_guard = active_guard;
 						let req_ctx = &mut req_ctx;
 
-						// Set up a timeout for the entire operation
-						let timeout_duration = Duration::from_secs(30); // 30 seconds timeout
+						let timeout_duration = state.config.guard().websocket_setup_timeout();
 						tracing::debug!(
 							"WebSocket proxy task started with {}s timeout",
 							timeout_duration.as_secs()
@@ -1183,7 +1229,7 @@ impl ProxyService {
 							}
 
 							match tokio::time::timeout(
-								Duration::from_secs(5), // 5 second timeout per connection attempt
+								state.config.guard().websocket_connect_attempt_timeout(),
 								tokio_tungstenite::connect_async_with_config(
 									ws_request,
 									Some(websocket_config(state.config.guard())),
@@ -1227,8 +1273,13 @@ impl ProxyService {
 								Err(_) => {
 									last_error_code = Some("websocket_connect_timeout".to_owned());
 									tracing::debug!(
-										"WebSocket request attempt {} timed out after 5s",
-										attempts
+										attempts,
+										timeout_ms = state
+											.config
+											.guard()
+											.websocket_connect_attempt_timeout()
+											.as_millis() as u64,
+										"WebSocket request attempt timed out"
 									);
 								}
 							}
@@ -1415,7 +1466,7 @@ impl ProxyService {
 												// Send the message with a timeout
 												tracing::trace!("Sending message to upstream server");
 												let send_result = tokio::time::timeout(
-													Duration::from_secs(5),
+													state.config.guard().websocket_send_timeout(),
 													sink.send(upstream_msg)
 												).await;
 
@@ -1425,7 +1476,7 @@ impl ProxyService {
 														// Flush the sink with a timeout
 														tracing::trace!("Flushing upstream sink");
 														let flush_result = tokio::time::timeout(
-															Duration::from_secs(2),
+															state.config.guard().websocket_flush_timeout(),
 															sink.flush()
 														).await;
 
@@ -1447,10 +1498,10 @@ impl ProxyService {
 														break;
 													},
 													Err(_) => {
-														tracing::trace!("Timeout sending message to upstream after 5s");
+														tracing::trace!("Timeout sending message to upstream");
 														let _ = shutdown_tx.send(true);
 														break;
-													}
+													},
 												}
 											},
 											Some(Err(err)) => {
@@ -1566,7 +1617,7 @@ impl ProxyService {
 												// Send the message with a timeout
 												tracing::trace!("Sending message to client");
 												let send_result = tokio::time::timeout(
-													Duration::from_secs(5),
+													state.config.guard().websocket_send_timeout(),
 													sink.send(client_msg)
 												).await;
 
@@ -1576,7 +1627,7 @@ impl ProxyService {
 														// Flush the sink with a timeout
 														tracing::trace!("Flushing client sink");
 														let flush_result = tokio::time::timeout(
-															Duration::from_secs(2),
+															state.config.guard().websocket_flush_timeout(),
 															sink.flush()
 														).await;
 
@@ -1598,10 +1649,10 @@ impl ProxyService {
 														break;
 													},
 													Err(_) => {
-														tracing::trace!("Timeout sending message to client after 5s");
+														tracing::trace!("Timeout sending message to client");
 														let _ = shutdown_tx.send(true);
 														break;
-													}
+													},
 												}
 											},
 											Some(Err(err)) => {
@@ -1922,6 +1973,79 @@ impl ProxyServiceFactory {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	fn test_state(guard: rivet_config::config::guard::Guard) -> ProxyState {
+		let config = rivet_config::Config::from_root(rivet_config::config::Root {
+			guard: Some(guard),
+			..Default::default()
+		});
+		let routing_fn: RoutingFn =
+			Arc::new(|_| Box::pin(async { anyhow::bail!("routing is not used by this test") }));
+		let cache_key_fn: CacheKeyFn = Arc::new(|_| Ok(0));
+
+		ProxyState::new(config, routing_fn, cache_key_fn)
+	}
+
+	fn test_request_context(state: &ProxyState) -> RequestContext {
+		RequestContext::new(
+			"127.0.0.1:12345".parse().unwrap(),
+			Id::v1(uuid::Uuid::nil(), 0),
+			Id::v1(uuid::Uuid::nil(), 1),
+			"example.com".to_owned(),
+			"/actors".to_owned(),
+			hyper::Method::GET,
+			hyper::HeaderMap::new(),
+			false,
+			"127.0.0.1".parse().unwrap(),
+			Instant::now(),
+			CancellationToken::new(),
+			state.config.guard(),
+		)
+	}
+
+	#[tokio::test]
+	async fn default_admission_is_unlimited_and_still_allocates_request_ids() {
+		let state = test_state(Default::default());
+		assert!(state.client_states.is_none());
+
+		let mut contexts = Vec::with_capacity(10_001);
+		for _ in 0..10_001 {
+			let mut req_ctx = test_request_context(&state);
+			assert_eq!(state.admit_request(&mut req_ctx).await.unwrap(), None);
+			assert!(req_ctx.in_flight_request_id().is_ok());
+			contexts.push(req_ctx);
+		}
+	}
+
+	#[tokio::test]
+	async fn configured_admission_limits_are_enforced_independently() {
+		let state = test_state(rivet_config::config::guard::Guard {
+			rate_limit: Some(rivet_config::config::guard::GuardRateLimit {
+				requests: 1,
+				period_ms: 60_000,
+			}),
+			..Default::default()
+		});
+		let mut first = test_request_context(&state);
+		let mut second = test_request_context(&state);
+		assert_eq!(state.admit_request(&mut first).await.unwrap(), None);
+		assert_eq!(
+			state.admit_request(&mut second).await.unwrap(),
+			Some(AdmissionRejection::RateLimit)
+		);
+
+		let state = test_state(rivet_config::config::guard::Guard {
+			max_in_flight: Some(1),
+			..Default::default()
+		});
+		let mut first = test_request_context(&state);
+		let mut second = test_request_context(&state);
+		assert_eq!(state.admit_request(&mut first).await.unwrap(), None);
+		assert_eq!(
+			state.admit_request(&mut second).await.unwrap(),
+			Some(AdmissionRejection::MaxInFlight)
+		);
+	}
 
 	#[test]
 	fn websocket_config_uses_documented_limit() {

--- a/engine/packages/guard-core/src/request_context.rs
+++ b/engine/packages/guard-core/src/request_context.rs
@@ -31,8 +31,6 @@ pub struct RequestContext {
 	pub(crate) request_body_is_end_stream: bool,
 	pub(crate) client_disconnect: CancellationToken,
 
-	pub(crate) rate_limit: RateLimitConfig,
-	pub(crate) max_in_flight: MaxInFlightConfig,
 	pub(crate) retry: RetryConfig,
 	pub(crate) timeout: TimeoutConfig,
 
@@ -55,6 +53,7 @@ impl RequestContext {
 		client_ip: IpAddr,
 		start_time: Instant,
 		client_disconnect: CancellationToken,
+		guard_config: &rivet_config::config::guard::Guard,
 	) -> Self {
 		let hostname = host.split(':').next().unwrap_or(&host).to_string();
 
@@ -74,19 +73,12 @@ impl RequestContext {
 			request_body_is_end_stream: true,
 			client_disconnect,
 
-			rate_limit: RateLimitConfig {
-				requests: 10000, // 10000 requests
-				period: 60,      // per 60 seconds
-			},
-			max_in_flight: MaxInFlightConfig {
-				amount: 2000, // 2000 concurrent requests
-			},
 			retry: RetryConfig {
-				max_attempts: 7,       // 7 retry attempts
-				initial_interval: 150, // 150ms initial interval
+				max_attempts: guard_config.proxy_retry_max_attempts(),
+				initial_interval: guard_config.proxy_retry_initial_interval_ms(),
 			},
 			timeout: TimeoutConfig {
-				request_timeout: 30, // 30 seconds for requests
+				request_timeout: guard_config.upstream_request_timeout(),
 			},
 
 			in_flight_permit: None,
@@ -164,17 +156,6 @@ impl RequestContext {
 }
 
 #[derive(Clone, Debug)]
-pub struct RateLimitConfig {
-	pub requests: u64,
-	pub period: u64, // in seconds
-}
-
-#[derive(Clone, Debug)]
-pub struct MaxInFlightConfig {
-	pub amount: usize,
-}
-
-#[derive(Clone, Debug)]
 pub struct RetryConfig {
 	pub max_attempts: u32,
 	pub initial_interval: u64, // in milliseconds
@@ -182,7 +163,7 @@ pub struct RetryConfig {
 
 #[derive(Clone, Debug)]
 pub struct TimeoutConfig {
-	pub request_timeout: u64, // in seconds
+	pub request_timeout: Duration,
 }
 
 #[derive(Clone, Debug)]

--- a/engine/packages/guard-core/src/utils.rs
+++ b/engine/packages/guard-core/src/utils.rs
@@ -26,58 +26,74 @@ const X_RIVET_TARGET: HeaderName = HeaderName::from_static("x-rivet-target");
 const X_RIVET_ACTOR: HeaderName = HeaderName::from_static("x-rivet-actor");
 const X_RIVET_TOKEN: HeaderName = HeaderName::from_static("x-rivet-token");
 
-/// Throttling state for a single client IP. Both the rate limiter and the in-flight counter are
-/// keyed by client IP, so they share one cache entry and one lock.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AdmissionRejection {
+	RateLimit,
+	MaxInFlight,
+}
+
+/// Optional admission state for a single client IP. The cache containing this state is not created
+/// when both admission controls are disabled.
 pub(crate) struct ClientState {
-	rate_limiter: RateLimiter,
-	in_flight: InFlightCounter,
+	rate_limiter: Option<RateLimiter>,
+	in_flight: Option<InFlightCounter>,
 }
 
 impl ClientState {
-	pub(crate) fn new(
-		rate_limit_requests: u64,
-		rate_limit_period: u64,
-		max_in_flight: usize,
-	) -> Self {
+	pub(crate) fn new(rate_limit: Option<(u64, Duration)>, max_in_flight: Option<usize>) -> Self {
 		Self {
-			rate_limiter: RateLimiter::new(RateLimitMethod::FixedWindow {
-				requests: rate_limit_requests,
-				period: Duration::from_secs(rate_limit_period),
+			rate_limiter: rate_limit.map(|(requests, period)| {
+				RateLimiter::new(RateLimitMethod::FixedWindow { requests, period })
 			}),
-			in_flight: InFlightCounter::new(max_in_flight),
+			in_flight: max_in_flight.map(InFlightCounter::new),
 		}
 	}
 
-	/// Consumes one rate limit token and one in-flight slot, returning false if either limit was
-	/// hit. A rate limit token is still consumed when the in-flight limit rejects the request.
-	pub(crate) fn try_admit(&mut self) -> bool {
-		self.rate_limiter.try_acquire() && self.in_flight.try_acquire()
+	/// Consumes one rate limit token and one in-flight slot when those controls are configured. A
+	/// rate limit token is still consumed when the in-flight limit rejects the request.
+	pub(crate) fn try_admit(&mut self) -> std::result::Result<(), AdmissionRejection> {
+		if let Some(rate_limiter) = &mut self.rate_limiter
+			&& !rate_limiter.try_acquire()
+		{
+			return Err(AdmissionRejection::RateLimit);
+		}
+
+		if let Some(in_flight) = &mut self.in_flight
+			&& !in_flight.try_acquire()
+		{
+			return Err(AdmissionRejection::MaxInFlight);
+		}
+
+		Ok(())
 	}
 
 	pub(crate) fn release_in_flight(&mut self) {
-		self.in_flight.release();
+		if let Some(in_flight) = &mut self.in_flight {
+			in_flight.release();
+		}
 	}
 }
 
-/// Owns one slot in a client's in-flight counter together with the request id registered in the
-/// global in-flight request set and the matching increment on `IN_FLIGHT_REQUEST_COUNT`. All three
-/// are released in `Drop`, so a cancelled or panicking request cannot leak any of them.
+/// Owns an optional slot in a client's in-flight counter together with the request id registered in
+/// the global in-flight request set and the matching increment on `IN_FLIGHT_REQUEST_COUNT`. All
+/// configured resources are released in `Drop`, so a cancelled or panicking request cannot leak
+/// any of them.
 ///
 /// The permit is held behind an `Arc` on `RequestContext`. Tasks that outlive the initial response,
 /// such as a proxied websocket, clone the context and therefore keep the slot and request id
 /// reserved for as long as they are still using them.
 pub(crate) struct InFlightPermit {
-	client_state: Arc<Mutex<ClientState>>,
+	client_state: Option<Arc<Mutex<ClientState>>>,
 	in_flight_requests: Arc<scc::HashSet<protocol::RequestId>>,
 	request_id: protocol::RequestId,
 	_in_flight_metric: IntGaugeGuard,
 }
 
 impl InFlightPermit {
-	/// Takes ownership of a slot already acquired from `client_state` and a request id already
-	/// inserted into `in_flight_requests`.
+	/// Takes ownership of an optional slot already acquired from `client_state` and a request id
+	/// already inserted into `in_flight_requests`.
 	pub(crate) fn new(
-		client_state: Arc<Mutex<ClientState>>,
+		client_state: Option<Arc<Mutex<ClientState>>>,
 		in_flight_requests: Arc<scc::HashSet<protocol::RequestId>>,
 		request_id: protocol::RequestId,
 	) -> Self {
@@ -96,7 +112,9 @@ impl InFlightPermit {
 
 impl Drop for InFlightPermit {
 	fn drop(&mut self) {
-		self.client_state.lock().release_in_flight();
+		if let Some(client_state) = &self.client_state {
+			client_state.lock().release_in_flight();
+		}
 		self.in_flight_requests.remove_sync(&self.request_id);
 	}
 }

--- a/engine/packages/guard-core/src/utils/tests.rs
+++ b/engine/packages/guard-core/src/utils/tests.rs
@@ -3,6 +3,33 @@ use hyper::header::HeaderValue;
 use super::*;
 
 #[test]
+fn client_state_without_limits_admits_repeated_requests() {
+	let mut state = ClientState::new(None, None);
+
+	for _ in 0..10_001 {
+		assert_eq!(state.try_admit(), Ok(()));
+	}
+}
+
+#[test]
+fn client_state_reports_rate_limit_separately() {
+	let mut state = ClientState::new(Some((1, Duration::from_secs(60))), None);
+
+	assert_eq!(state.try_admit(), Ok(()));
+	assert_eq!(state.try_admit(), Err(AdmissionRejection::RateLimit));
+}
+
+#[test]
+fn client_state_reports_max_in_flight_separately() {
+	let mut state = ClientState::new(None, Some(1));
+
+	assert_eq!(state.try_admit(), Ok(()));
+	assert_eq!(state.try_admit(), Err(AdmissionRejection::MaxInFlight));
+	state.release_in_flight();
+	assert_eq!(state.try_admit(), Ok(()));
+}
+
+#[test]
 fn labels_rivet_errors_by_group_and_code() {
 	let err = crate::errors::UriParseError("http://actor-9f3b.example/path".to_owned()).build();
 


### PR DESCRIPTION
- Disable per-IP request-rate and in-flight admission limits by default while preserving opt-in controls.
- Expose Guard retry, timeout, connection-pool, and admission-state settings through the configuration schema.
- Report request-rate and maximum-in-flight rejections as distinct errors with configured thresholds.
- Add focused coverage and document the self-hosted admission defaults.