### PR TITLE
fix(ci): repair shared workflow checks

### DIFF
--- a/.github/workflows/mirror-swift.yml
+++ b/.github/workflows/mirror-swift.yml
@@ -5,12 +5,13 @@ name: Mirror rivetkit-swift
 on:
   push:
     branches:
-      - "**"
+      - main
     tags:
       - "**"
 
 jobs:
   mirror:
+    if: github.repository == 'rivet-dev/actors'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,6 +59,10 @@ jobs:
           cache-shared-key: rust-ci
           cache-on-failure: true
 
+      - name: Set up repository-specific Rust dependencies
+        if: ${{ hashFiles('scripts/ci/pre-rust-check.sh') != '' }}
+        run: scripts/ci/pre-rust-check.sh
+
       - name: Check event-driven drain invariants
         run: rivetkit-rust/packages/rivetkit-core/scripts/check-event-driven-drains.sh
 

--- a/rivetkit-rust/packages/rivetkit-core/tests/inspector_bundle.rs
+++ b/rivetkit-rust/packages/rivetkit-core/tests/inspector_bundle.rs
@@ -26,7 +26,11 @@ fn embedded_bundle_serves_index_when_required() {
 		!text.contains("ui_asset_not_found"),
 		"embedded inspector bundle is empty: GET /inspector/ui/ served ui_asset_not_found",
 	);
-	assert_eq!(resp.status, 200, "expected 200 for index.html, got {}", resp.status);
+	assert_eq!(
+		resp.status, 200,
+		"expected 200 for index.html, got {}",
+		resp.status
+	);
 
 	let lower = text.to_ascii_lowercase();
 	assert!(

--- a/rivetkit-rust/packages/rivetkit/src/lib.rs
+++ b/rivetkit-rust/packages/rivetkit/src/lib.rs
@@ -48,8 +48,7 @@ pub use rivetkit_core::{
 	HTTP_BODY_STREAM_CHANNEL_CAPACITY, KeepAwakeRegion, ListOpts, QueueMessage as CoreQueueMessage,
 	QueueNextBatchOpts, QueueNextOpts, QueueTryNextBatchOpts, QueueTryNextOpts, QueueWaitOpts,
 	Request, RequestSaveOpts, Response, ResponseChunk, RuntimeMode, SaveStateOpts,
-	SerializeStateReason,
-	ServeConfig, SqliteBatchStatement, SqliteDb, SqliteTransaction, StateDelta, StreamingResponse,
-	WebSocket, WsMessage,
+	SerializeStateReason, ServeConfig, SqliteBatchStatement, SqliteDb, SqliteTransaction,
+	StateDelta, StreamingResponse, WebSocket, WsMessage,
 	sqlite::{BindParam, ColumnValue, ExecResult, QueryResult},
 };

--- a/rivetkit-rust/packages/rivetkit/src/serverless_listener.rs
+++ b/rivetkit-rust/packages/rivetkit/src/serverless_listener.rs
@@ -11,16 +11,14 @@ use std::io;
 use std::net::{Ipv4Addr, SocketAddr};
 
 use anyhow::{Context, Result};
+use axum::Router;
 use axum::body::{Body, to_bytes};
 use axum::extract::{Request, State};
 use axum::response::Response;
-use axum::Router;
 use bytes::Bytes;
 use futures::StreamExt;
 use http::StatusCode;
-use rivetkit_core::serverless::{
-	CoreServerlessRuntime, ServerlessRequest, ServerlessResponse,
-};
+use rivetkit_core::serverless::{CoreServerlessRuntime, ServerlessRequest, ServerlessResponse};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
 
@@ -125,7 +123,10 @@ fn into_response_with_guard(
 /// Builds an axum response that streams the runtime's response chunks. `guard`,
 /// when present, is held for the lifetime of the stream so dropping the body
 /// cancels the in-flight request.
-fn build_response(response: ServerlessResponse, guard: Option<tokio_util::sync::DropGuard>) -> Response {
+fn build_response(
+	response: ServerlessResponse,
+	guard: Option<tokio_util::sync::DropGuard>,
+) -> Response {
 	let ServerlessResponse {
 		status,
 		headers,
@@ -145,11 +146,13 @@ fn build_response(response: ServerlessResponse, guard: Option<tokio_util::sync::
 		builder = builder.header(name, value);
 	}
 
-	builder.body(Body::from_stream(stream)).unwrap_or_else(|error| {
-		tracing::error!(?error, "failed to build serverless response");
-		Response::builder()
-			.status(StatusCode::INTERNAL_SERVER_ERROR)
-			.body(Body::empty())
-			.expect("static error response is valid")
-	})
+	builder
+		.body(Body::from_stream(stream))
+		.unwrap_or_else(|error| {
+			tracing::error!(?error, "failed to build serverless response");
+			Response::builder()
+				.status(StatusCode::INTERNAL_SERVER_ERROR)
+				.body(Body::empty())
+				.expect("static error response is valid")
+		})
 }


### PR DESCRIPTION
- Allow repositories sharing the Rust workflow to provide an optional pre-check setup script.
- Publish the standalone Swift package only from actors main and release tags.
- Prevent synced copies of the workflow from publishing the Swift package.
- Format the Rust files currently failing the always-on formatting check.