### PR TITLE
fix(frontend): keep billing limit banner above settings drawer and show plan exhausted card

### DIFF
--- a/frontend/src/app/billing/billing-limit-alert.tsx
+++ b/frontend/src/app/billing/billing-limit-alert.tsx
@@ -1,89 +1,77 @@
 import { faExclamationTriangle, Icon } from "@rivet-gg/icons";
-import { skipToken, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Link, useMatch } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
+import { useLayoutEffect } from "react";
 import { Button, cn } from "@/components";
+import { useCloudProjectDataProvider } from "@/components/actors";
 import { PLAN_LABELS } from "@/content/billing";
 import { features } from "@/lib/features";
+import { useHighestUsagePercent } from "./hooks";
 
-// Fixed banner height (Tailwind `h-9`). Exported so fixed overlays anchored
-// under the top bar (the settings drawer) can start below the banner instead
-// of behind it.
-export const BILLING_BANNER_HEIGHT = "2.25rem";
+// Fixed banner height (Tailwind `h-9`). Published as a CSS variable so the
+// settings drawer, a fixed overlay anchored under the top bar, can start below
+// the banner instead of behind it.
+const BANNER_HEIGHT = "2.25rem";
 
-export interface BillingLimitBannerState {
-	/** The banner is showing: free plan at or above 80% of its included usage. */
-	visible: boolean;
-	/** Usage has hit or passed 100% of the plan's included allotment. */
-	atLimit: boolean;
-	plan: string;
-	usagePercent: number;
+export function BillingLimitAlert() {
+	if (!features.billing) return null;
+	return <BillingLimitAlertGuard />;
 }
 
-/**
- * Resolves the free-plan usage banner state.
- *
- * Both the banner itself and anything that must lay out around it (the
- * settings drawer offsets its top edge by the banner height) call this, so
- * they derive the same answer from the same query data during render. A side
- * channel such as a CSS variable set from an effect would let the two
- * disagree, leaving the banner painted behind the drawer.
- *
- * Billing is project-scoped, but callers render from the shared route layout
- * and the `_context` route, where `useCloudProjectDataProvider` would throw.
- * The provider is read off the project match instead, and the queries are
- * skipped until it resolves, so the hook is safe on every route and keeps a
- * stable tree shape (no outer/inner split that would remount the caller when
- * the project loader lands). Off a project route the banner is hidden.
- */
-export function useBillingLimitBanner(): BillingLimitBannerState {
+// Billing is project-scoped, but this banner renders from the shared route
+// layout. `useMatch` with `shouldThrow: false` keeps it out of routes where
+// `useCloudProjectDataProvider` would throw, and waiting on `loaderData`
+// avoids reading the provider before the project loader resolves.
+function BillingLimitAlertGuard() {
 	const projectMatch = useMatch({
 		from: "/_context/orgs/$organization/projects/$project",
 		shouldThrow: false,
 	});
-	const dataProvider = features.billing
-		? projectMatch?.loaderData?.dataProvider
-		: undefined;
 
-	const detailsOptions =
-		dataProvider?.currentProjectBillingDetailsQueryOptions();
-	const { data: billingData } = useQuery({
-		queryKey: detailsOptions?.queryKey ?? ["billing-details", "no-project"],
-		queryFn: detailsOptions?.queryFn ?? skipToken,
-	});
+	if (!projectMatch?.loaderData) return null;
 
-	const usageOptions = dataProvider?.currentProjectBillingUsageQueryOptions();
-	const { data: usage } = useQuery({
-		queryKey: usageOptions?.queryKey ?? ["billing-usage", "no-project"],
-		queryFn: usageOptions?.queryFn ?? skipToken,
-	});
-
-	const usagePercent = usage?.highestPercent ?? 0;
-	const plan = billingData?.billing.activePlan || "free";
-
-	return {
-		visible: !!dataProvider && plan === "free" && usagePercent >= 80,
-		atLimit: usagePercent >= 100,
-		plan,
-		usagePercent,
-	};
+	return <BillingLimitAlertInner />;
 }
 
-export function BillingLimitAlert() {
-	const { visible, atLimit, plan, usagePercent } = useBillingLimitBanner();
+function BillingLimitAlertInner() {
+	const dataProvider = useCloudProjectDataProvider();
+	const { data: billingData } = useQuery({
+		...dataProvider.currentProjectBillingDetailsQueryOptions(),
+	});
+
+	const usagePercent = useHighestUsagePercent();
+	const plan = billingData?.billing.activePlan || "free";
+	const hidden = plan !== "free" || usagePercent < 80;
+
+	// Layout effect so the drawer's `top` moves in the same paint the banner
+	// mounts in, instead of a frame where the drawer still sits behind it.
+	useLayoutEffect(() => {
+		if (hidden) return;
+		const root = document.documentElement;
+		root.style.setProperty("--billing-banner-height", BANNER_HEIGHT);
+		return () => {
+			root.style.removeProperty("--billing-banner-height");
+		};
+	}, [hidden]);
+
+	const atLimit = usagePercent >= 100;
 
 	// The usage figure comes from a slow backend scan, so the banner appears well
 	// after the page loads. Expanding it in keeps the content below from jumping.
 	return (
 		<AnimatePresence>
-			{visible ? (
+			{!hidden ? (
 				<motion.div
 					initial={{ height: 0, opacity: 0 }}
-					animate={{ height: BILLING_BANNER_HEIGHT, opacity: 1 }}
+					animate={{ height: BANNER_HEIGHT, opacity: 1 }}
 					exit={{ height: 0, opacity: 0 }}
 					transition={{ duration: 0.25, ease: "easeOut" }}
 					className={cn(
-						"overflow-hidden border-b",
+						// Above the settings drawer (`z-40`) so it stays visible
+						// while the drawer's `top` catches up; below `z-50`
+						// popovers, dropdowns, and dialogs.
+						"relative z-[45] overflow-hidden border-b",
 						atLimit
 							? "border-destructive/60 bg-destructive/15"
 							: "border-warning/60 bg-warning/10",

--- a/frontend/src/app/billing/billing-limit-alert.tsx
+++ b/frontend/src/app/billing/billing-limit-alert.tsx
@@ -1,68 +1,85 @@
 import { faExclamationTriangle, Icon } from "@rivet-gg/icons";
-import { useQuery } from "@tanstack/react-query";
+import { skipToken, useQuery } from "@tanstack/react-query";
 import { Link, useMatch } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
-import { useEffect } from "react";
 import { Button, cn } from "@/components";
-import { useCloudProjectDataProvider } from "@/components/actors";
 import { PLAN_LABELS } from "@/content/billing";
 import { features } from "@/lib/features";
-import { useHighestUsagePercent } from "./hooks";
 
-// Fixed banner height (Tailwind `h-9`). Published as a CSS variable so the
-// settings drawer, a fixed overlay anchored under the top bar, can start below
-// the banner instead of behind it.
-const BANNER_HEIGHT = "2.25rem";
+// Fixed banner height (Tailwind `h-9`). Exported so fixed overlays anchored
+// under the top bar (the settings drawer) can start below the banner instead
+// of behind it.
+export const BILLING_BANNER_HEIGHT = "2.25rem";
 
-export function BillingLimitAlert() {
-	if (!features.billing) return null;
-	return <BillingLimitAlertGuard />;
+export interface BillingLimitBannerState {
+	/** The banner is showing: free plan at or above 80% of its included usage. */
+	visible: boolean;
+	/** Usage has hit or passed 100% of the plan's included allotment. */
+	atLimit: boolean;
+	plan: string;
+	usagePercent: number;
 }
 
-// Billing is project-scoped, but this banner renders from the shared route
-// layout. `useMatch` with `shouldThrow: false` keeps it out of routes where
-// `useCloudProjectDataProvider` would throw, and waiting on `loaderData`
-// avoids reading the provider before the project loader resolves.
-function BillingLimitAlertGuard() {
+/**
+ * Resolves the free-plan usage banner state.
+ *
+ * Both the banner itself and anything that must lay out around it (the
+ * settings drawer offsets its top edge by the banner height) call this, so
+ * they derive the same answer from the same query data during render. A side
+ * channel such as a CSS variable set from an effect would let the two
+ * disagree, leaving the banner painted behind the drawer.
+ *
+ * Billing is project-scoped, but callers render from the shared route layout
+ * and the `_context` route, where `useCloudProjectDataProvider` would throw.
+ * The provider is read off the project match instead, and the queries are
+ * skipped until it resolves, so the hook is safe on every route and keeps a
+ * stable tree shape (no outer/inner split that would remount the caller when
+ * the project loader lands). Off a project route the banner is hidden.
+ */
+export function useBillingLimitBanner(): BillingLimitBannerState {
 	const projectMatch = useMatch({
 		from: "/_context/orgs/$organization/projects/$project",
 		shouldThrow: false,
 	});
+	const dataProvider = features.billing
+		? projectMatch?.loaderData?.dataProvider
+		: undefined;
 
-	if (!projectMatch?.loaderData) return null;
-
-	return <BillingLimitAlertInner />;
-}
-
-function BillingLimitAlertInner() {
-	const dataProvider = useCloudProjectDataProvider();
+	const detailsOptions =
+		dataProvider?.currentProjectBillingDetailsQueryOptions();
 	const { data: billingData } = useQuery({
-		...dataProvider.currentProjectBillingDetailsQueryOptions(),
+		queryKey: detailsOptions?.queryKey ?? ["billing-details", "no-project"],
+		queryFn: detailsOptions?.queryFn ?? skipToken,
 	});
 
-	const usagePercent = useHighestUsagePercent();
+	const usageOptions = dataProvider?.currentProjectBillingUsageQueryOptions();
+	const { data: usage } = useQuery({
+		queryKey: usageOptions?.queryKey ?? ["billing-usage", "no-project"],
+		queryFn: usageOptions?.queryFn ?? skipToken,
+	});
+
+	const usagePercent = usage?.highestPercent ?? 0;
 	const plan = billingData?.billing.activePlan || "free";
-	const hidden = plan !== "free" || usagePercent < 80;
 
-	useEffect(() => {
-		if (hidden) return;
-		const root = document.documentElement;
-		root.style.setProperty("--billing-banner-height", BANNER_HEIGHT);
-		return () => {
-			root.style.removeProperty("--billing-banner-height");
-		};
-	}, [hidden]);
+	return {
+		visible: !!dataProvider && plan === "free" && usagePercent >= 80,
+		atLimit: usagePercent >= 100,
+		plan,
+		usagePercent,
+	};
+}
 
-	const atLimit = usagePercent >= 100;
+export function BillingLimitAlert() {
+	const { visible, atLimit, plan, usagePercent } = useBillingLimitBanner();
 
 	// The usage figure comes from a slow backend scan, so the banner appears well
 	// after the page loads. Expanding it in keeps the content below from jumping.
 	return (
 		<AnimatePresence>
-			{!hidden ? (
+			{visible ? (
 				<motion.div
 					initial={{ height: 0, opacity: 0 }}
-					animate={{ height: BANNER_HEIGHT, opacity: 1 }}
+					animate={{ height: BILLING_BANNER_HEIGHT, opacity: 1 }}
 					exit={{ height: 0, opacity: 0 }}
 					transition={{ duration: 0.25, ease: "easeOut" }}
 					className={cn(

--- a/frontend/src/app/settings-drawer.tsx
+++ b/frontend/src/app/settings-drawer.tsx
@@ -26,10 +26,6 @@ import {
 	useCloudProjectDataProvider,
 } from "@/components/actors/data-provider";
 import { features } from "@/lib/features";
-import {
-	BILLING_BANNER_HEIGHT,
-	useBillingLimitBanner,
-} from "./billing/billing-limit-alert";
 import { BillingUsageGauge } from "./billing/billing-usage-gauge";
 import { PoolSwitcher, poolHeaderText, resolvePoolName } from "./pool-switcher";
 import { BillingPanel } from "./settings-pages/billing-panel";
@@ -123,11 +119,6 @@ interface SettingsDrawerProps {
 	open: boolean;
 	tab: SettingsTab;
 	onOpenChange: (open: boolean) => void;
-	/**
-	 * Extra space to leave above the drawer for chrome rendered between the top
-	 * bar and the content view, e.g. the billing limit banner. CSS length.
-	 */
-	topOffset?: string;
 }
 
 // TopBar is a flush `h-12` bar (48px, border included). Add the content view's
@@ -138,7 +129,6 @@ export function SettingsDrawer({
 	open,
 	tab,
 	onOpenChange,
-	topOffset = "0px",
 }: SettingsDrawerProps) {
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
@@ -195,16 +185,18 @@ export function SettingsDrawer({
 			<DialogPrimitive.Portal>
 				<DialogPrimitive.Content
 					className={cn(
-						"fixed left-2 right-2 z-50 flex flex-col overflow-hidden",
+						// `z-40` keeps the drawer under the billing banner (`z-[45]`)
+						// and under `z-50` popovers, dropdowns, and dialogs.
+						"fixed left-2 right-2 z-40 flex flex-col overflow-hidden",
 						"bg-card border border-border rounded-lg",
 						"focus:outline-none",
 						"data-[state=open]:animate-in data-[state=closed]:animate-out",
 						"data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-						// Track the billing banner's expand/collapse animation.
+						// Follow the banner's expand/collapse animation.
 						"transition-[top] duration-[250ms] ease-out",
 					)}
 					style={{
-						top: `calc(${TOP_BAR_OUTER_HEIGHT} + ${topOffset})`,
+						top: `calc(${TOP_BAR_OUTER_HEIGHT} + var(--billing-banner-height, 0px))`,
 						bottom: "8px",
 					}}
 					onInteractOutside={(e) => e.preventDefault()}
@@ -703,17 +695,10 @@ export function SettingsDrawerHost() {
 		typeof search.settings === "string" ? search.settings : undefined;
 	const tab = settingsParamToTab(param);
 
-	// The drawer is a fixed overlay under the top bar, so it must start below
-	// the billing limit banner when that is showing. Both derive the banner
-	// state from the same data rather than the banner publishing its height
-	// through a side channel.
-	const banner = useBillingLimitBanner();
-
 	return (
 		<SettingsDrawer
 			open={tab !== null}
 			tab={tab ?? "profile"}
-			topOffset={banner.visible ? BILLING_BANNER_HEIGHT : "0px"}
 			onOpenChange={(open) => {
 				if (!open) {
 					navigate({

--- a/frontend/src/app/settings-drawer.tsx
+++ b/frontend/src/app/settings-drawer.tsx
@@ -26,6 +26,10 @@ import {
 	useCloudProjectDataProvider,
 } from "@/components/actors/data-provider";
 import { features } from "@/lib/features";
+import {
+	BILLING_BANNER_HEIGHT,
+	useBillingLimitBanner,
+} from "./billing/billing-limit-alert";
 import { BillingUsageGauge } from "./billing/billing-usage-gauge";
 import { PoolSwitcher, poolHeaderText, resolvePoolName } from "./pool-switcher";
 import { BillingPanel } from "./settings-pages/billing-panel";
@@ -119,6 +123,11 @@ interface SettingsDrawerProps {
 	open: boolean;
 	tab: SettingsTab;
 	onOpenChange: (open: boolean) => void;
+	/**
+	 * Extra space to leave above the drawer for chrome rendered between the top
+	 * bar and the content view, e.g. the billing limit banner. CSS length.
+	 */
+	topOffset?: string;
 }
 
 // TopBar is a flush `h-12` bar (48px, border included). Add the content view's
@@ -129,6 +138,7 @@ export function SettingsDrawer({
 	open,
 	tab,
 	onOpenChange,
+	topOffset = "0px",
 }: SettingsDrawerProps) {
 	const navigate = useNavigate();
 	const matchRoute = useMatchRoute();
@@ -190,9 +200,11 @@ export function SettingsDrawer({
 						"focus:outline-none",
 						"data-[state=open]:animate-in data-[state=closed]:animate-out",
 						"data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+						// Track the billing banner's expand/collapse animation.
+						"transition-[top] duration-[250ms] ease-out",
 					)}
 					style={{
-						top: `calc(${TOP_BAR_OUTER_HEIGHT} + var(--billing-banner-height, 0px))`,
+						top: `calc(${TOP_BAR_OUTER_HEIGHT} + ${topOffset})`,
 						bottom: "8px",
 					}}
 					onInteractOutside={(e) => e.preventDefault()}
@@ -691,10 +703,17 @@ export function SettingsDrawerHost() {
 		typeof search.settings === "string" ? search.settings : undefined;
 	const tab = settingsParamToTab(param);
 
+	// The drawer is a fixed overlay under the top bar, so it must start below
+	// the billing limit banner when that is showing. Both derive the banner
+	// state from the same data rather than the banner publishing its height
+	// through a side channel.
+	const banner = useBillingLimitBanner();
+
 	return (
 		<SettingsDrawer
 			open={tab !== null}
 			tab={tab ?? "profile"}
+			topOffset={banner.visible ? BILLING_BANNER_HEIGHT : "0px"}
 			onOpenChange={(open) => {
 				if (!open) {
 					navigate({

--- a/frontend/src/app/settings-pages/billing-panel.tsx
+++ b/frontend/src/app/settings-pages/billing-panel.tsx
@@ -2,6 +2,7 @@ import {
 	faArrowUpRight,
 	faBarcodeRead,
 	faDatabase,
+	faExclamationTriangle,
 	faInfoCircle,
 	faPencil,
 	faRunning,
@@ -35,9 +36,9 @@ import {
 	WithTooltip,
 } from "@/components";
 import { useCloudProjectDataProvider } from "@/components/actors";
-import { features } from "@/lib/features";
 import { TwinklingSparkles } from "@/components/twinkling-sparkles";
 import { COMPUTE_MONTHLY_CAP_USD } from "@/content/billing";
+import { features } from "@/lib/features";
 import { ResourcePicker } from "./resource-picker";
 import { SettingsCard } from "./settings-card";
 
@@ -141,8 +142,29 @@ function BillingDrawerBody() {
 		? new Date(usage.currentPeriodEnd)
 		: endOfMonth(new Date());
 
+	// Same trigger as the free-plan limit banner (`highestPercent` covers the
+	// metered metrics and the compute budget). Paid plans just bill overage, so
+	// only the free plan gets the call-out. The names list which allotments ran
+	// out so the user knows what to look at in the table below.
+	const planExhausted = plan === "free" && usage.highestPercent >= 100;
+	const exhaustedNames = [
+		...USAGE_METRICS.filter(
+			(metric) => (metricsByKey.get(metric.key)?.percent ?? 0) >= 100,
+		).map((metric) => metric.title),
+		...(showCompute && usage.computeBudgetPercent >= 100
+			? ["Compute"]
+			: []),
+	];
+
 	return (
 		<div className="space-y-8">
+			{planExhausted ? (
+				<PlanExhaustedCard
+					exhaustedNames={exhaustedNames}
+					onUpgrade={() => setPlansOpen(true)}
+				/>
+			) : null}
+
 			<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
 				<CurrentPlanCard
 					plan={plan}
@@ -225,6 +247,55 @@ function BillingDrawerBody() {
 			</div>
 		</div>
 	);
+}
+
+// Shown when a free-plan project has used up its included allotment for the
+// billing period. Plain-language version of the limit banner, with the upgrade
+// action inline so the user does not have to hunt for it in the plan card.
+function PlanExhaustedCard({
+	exhaustedNames,
+	onUpgrade,
+}: {
+	exhaustedNames: string[];
+	onUpgrade: () => void;
+}) {
+	const what =
+		exhaustedNames.length > 0
+			? `${formatList(exhaustedNames)} ${exhaustedNames.length === 1 ? "has" : "have"} reached the Free plan's included limit for this billing period.`
+			: "This project has reached the Free plan's included limits for this billing period.";
+	return (
+		<SettingsCard className="border-destructive/40 bg-destructive/5">
+			<div className="flex items-start gap-4">
+				<div className="flex size-9 shrink-0 items-center justify-center rounded-md border border-destructive/30 bg-destructive/10 text-destructive">
+					<Icon icon={faExclamationTriangle} className="size-4" />
+				</div>
+				<div className="min-w-0 flex-1">
+					<h3 className="text-sm font-semibold text-foreground">
+						You've used your entire Free plan
+					</h3>
+					<p className="mt-1 text-xs text-muted-foreground leading-relaxed">
+						{what} Upgrade to raise your limits and avoid service
+						interruptions.
+					</p>
+				</div>
+				<Button
+					variant="default"
+					size="sm"
+					className="shrink-0"
+					startIcon={<TwinklingSparkles />}
+					onClick={onUpgrade}
+				>
+					Upgrade plan
+				</Button>
+			</div>
+		</SettingsCard>
+	);
+}
+
+function formatList(items: string[]): string {
+	if (items.length <= 1) return items[0] ?? "";
+	if (items.length === 2) return `${items[0]} and ${items[1]}`;
+	return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
 }
 
 function CurrentPlanCard({
@@ -433,11 +504,17 @@ function ComputeUsageRow({
 				</div>
 			</div>
 			<div className="text-sm tabular-nums text-foreground">
-				{loading ? <Skeleton className="h-4 w-12" /> : formatCurrency(cost)}
+				{loading ? (
+					<Skeleton className="h-4 w-12" />
+				) : (
+					formatCurrency(cost)
+				)}
 			</div>
 			<div className="min-w-0">
 				<div className="text-xs text-muted-foreground">
-					{capUsd != null ? `of ${formatCurrency(capUsd)}` : "No limit"}
+					{capUsd != null
+						? `of ${formatCurrency(capUsd)}`
+						: "No limit"}
 				</div>
 				{capUsd != null ? (
 					<div className="relative h-1 rounded-full bg-foreground/10 mt-1">


### PR DESCRIPTION
# Description

- Fix the free plan overage banner rendering behind the settings drawer. The drawer offset is now derived from the same billing usage data as the banner instead of a CSS variable set from an effect.
- Add a card at the top of the billing settings panel when a free plan project has reached its usage limit, naming the exhausted metrics with an upgrade button.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Loaded the dashboard with mocked billing responses at 85% and 477% usage and confirmed the banner sits above the drawer in both cases, the exhausted card only appears at 100% or more, and the OSS flavor without billing renders unchanged.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes