### PR TITLE
fix(frontend): scope onboarding step suspense to the step content

### DIFF
--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -27,7 +27,6 @@ import {
 	CodeGroupSyncProvider,
 	CodePreview,
 	FormField,
-	Skeleton,
 } from "@/components";
 import {
 	useCloudNamespaceDataProvider,
@@ -67,6 +66,7 @@ import {
 	useStepperFormSubmit,
 } from "./forms/stepper-form";
 import { Content } from "./layout";
+import { StepContentSkeleton } from "./onboarding-skeleton";
 import { AgentSelectStep } from "@/components/onboarding/agent-os/agent-select-step";
 import { buildAgentOsSetup } from "@/components/onboarding/agent-os/build-agent-os-setup";
 import {
@@ -364,16 +364,7 @@ export function GettingStarted({
 									),
 									deploy: () => (
 										<StepContent>
-											<Suspense
-												fallback={
-													<div className="space-y-6">
-														<Skeleton className="w-full h-[180px]" />
-														<Skeleton className="w-full h-[200px]" />
-													</div>
-												}
-											>
-												<DeployScreen />
-											</Suspense>
+											<DeployScreen />
 										</StepContent>
 									),
 								}}
@@ -441,7 +432,7 @@ export function GettingStarted({
 function StepContent({ children }: { children: ReactNode }) {
 	return (
 		<div className="w-full" data-component="step-content">
-			{children}
+			<Suspense fallback={<StepContentSkeleton />}>{children}</Suspense>
 		</div>
 	);
 }

--- a/frontend/src/app/onboarding-skeleton.tsx
+++ b/frontend/src/app/onboarding-skeleton.tsx
@@ -76,3 +76,52 @@ export function OnboardingSkeleton({ header }: { header?: ReactNode }) {
 		</div>
 	);
 }
+
+function PromptBannerSkeleton() {
+	return (
+		<div className="relative w-full flex flex-col items-stretch justify-between gap-4 rounded-lg border border-border px-4 py-4 sm:flex-row sm:items-center">
+			<Skeleton className="absolute -top-2.5 left-4 h-5 w-28 rounded-full" />
+			<div className="min-w-0 flex-1 space-y-2">
+				<Skeleton className="h-4 w-40" />
+				<Skeleton className="h-3 w-full" />
+				<Skeleton className="h-3 w-2/3" />
+			</div>
+			<Skeleton className="h-9 w-full shrink-0 sm:w-32" />
+		</div>
+	);
+}
+
+function DividerSkeleton() {
+	return (
+		<div className="flex items-center gap-3">
+			<div className="h-px flex-1 bg-border" />
+			<Skeleton className="h-3 w-24" />
+			<div className="h-px flex-1 bg-border" />
+		</div>
+	);
+}
+
+function ActionRowSkeleton() {
+	return (
+		<div className="w-full flex flex-col items-stretch justify-between gap-4 rounded-lg border border-border px-4 py-4 sm:flex-row sm:items-center">
+			<div className="min-w-0 flex-1 space-y-2">
+				<Skeleton className="h-4 w-48" />
+				<Skeleton className="h-3 w-3/4" />
+			</div>
+			<Skeleton className="h-9 w-full shrink-0 sm:w-36" />
+		</div>
+	);
+}
+
+// Mirrors the shape shared by the wizard's fetching steps: a recommended prompt
+// banner, an "or" divider, then a secondary action row. Keeping the borders and
+// divider real leaves only the text and buttons as skeletons.
+export function StepContentSkeleton() {
+	return (
+		<div className="flex flex-col gap-6">
+			<PromptBannerSkeleton />
+			<DividerSkeleton />
+			<ActionRowSkeleton />
+		</div>
+	);
+}


### PR DESCRIPTION
- Give every onboarding wizard step its own Suspense boundary instead of only the deploy step, so a step that fetches falls back inside the card.
- Add a `StepContentSkeleton` that mirrors the shape the fetching steps actually render: a recommended prompt banner, an "or" divider, then a secondary action row. Borders and the divider stay real, so only text and buttons are skeletons.

Picking a product on the first step advances to "Run locally", which mints a deploy token before it can render. That fetch had no Suspense boundary below the wizard, so it escaped to the router's match boundary and replaced the whole card. The progress bar stayed on "Step 1 of 3" and the user was shown a skeleton of the step they had just left, for as long as the token took.

With the boundary inside `StepContent`, the wizard advances immediately: the progress bar moves to step 2, the step title and footer buttons render, and only the content area is a skeleton.

## Before vs after

https://github.com/user-attachments/assets/696a9a25-e903-4feb-b6bb-bedc0c14c823

The same moment in each build, with the token endpoint held open for 6s:

| Before | After |
| --- | --- |
| ![Wizard card replaced by a skeleton, progress bar still on step 1 of 3](https://github.com/user-attachments/assets/187e941c-c967-4a76-bf71-ea46a84ea6bf) | ![Progress bar on step 2 of 3 with the Run locally title, skeleton shaped like the banner, divider and action row](https://github.com/user-attachments/assets/eb93fd48-2677-4738-b9df-68736f6acfb2) |

Verified on the cloud flavor against a local cluster, driving the real product-select flow with `POST */tokens/api` delayed 6s. Before: the wizard is gone for the whole 6s. After: step 2 renders at once and fills in when the token lands.
